### PR TITLE
Add offline transcription sidecars and transcript-aware search

### DIFF
--- a/bin/encode_and_store.sh
+++ b/bin/encode_and_store.sh
@@ -56,6 +56,11 @@ if ! "$VENV/bin/python" -m lib.waveform_cache "$in_wav" "$waveform_file"; then
   exit 1
 fi
 
+transcript_file="${outfile}.transcript.json"
+if ! "$VENV/bin/python" -m lib.transcription "$in_wav" "$transcript_file" "$base"; then
+  echo "[encode] transcription failed for $base" | systemd-cat -t tricorder
+fi
+
 echo "[encode] Wrote waveform $waveform_file"
 
 rm -f "$in_wav"

--- a/config.yaml
+++ b/config.yaml
@@ -121,6 +121,28 @@ ingest:
   # Common suffixes indicating partial/incomplete downloads or temp files to ignore.
   ignore_suffixes: [".part", ".partial", ".tmp", ".incomplete", ".opdownload", ".crdownload"]
 
+transcription:
+  # Enable offline speech-to-text using the configured engine. When disabled no transcript files are written.
+  enabled: false
+
+  # Supported engines: "vosk" (default). Vosk runs entirely offline using a Kaldi acoustic model.
+  engine: "vosk"
+
+  # Only events tagged with these types are transcribed. Default restricts transcripts to Human-tagged segments.
+  types: ["Human"]
+
+  # Path to the unpacked Vosk model directory (download separately, e.g. vosk-model-small-en-us-0.15).
+  vosk_model_path: "/apps/tricorder/models/vosk-small-en-us-0.15"
+
+  # Audio is resampled to this sample rate before feeding the recognizer. 16000 Hz matches Vosk small English models.
+  target_sample_rate: 16000
+
+  # Include per-word timestamps/confidence values in the transcript payload (slightly larger JSON files).
+  include_words: true
+
+  # Set >0 to request alternative transcript hypotheses when supported by the model.
+  max_alternatives: 0
+
 logging:
   # Developer-mode verbose logging (equivalent to setting DEV=1 in the environment).
   # When true, emits per-second debug lines from the segmenter.

--- a/lib/transcription.py
+++ b/lib/transcription.py
@@ -1,0 +1,331 @@
+#!/usr/bin/env python3
+"""Speech-to-text helpers for generating transcript sidecars."""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import json
+import os
+import sys
+import time
+import wave
+from array import array
+from pathlib import Path
+from typing import Any
+
+import audioop  # noqa: F401  (imported for side-effects + rate conversion)
+
+from lib.config import get_cfg
+
+
+class TranscriptionError(Exception):
+    """Raised when transcription should be treated as a failure."""
+
+
+def _bool(value: Any) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        return bool(value)
+    if isinstance(value, str):
+        return value.strip().lower() in {"1", "true", "yes", "on", "enabled"}
+    return False
+
+
+def _write_json_atomic(destination: Path, payload: dict[str, Any]) -> None:
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    tmp_path = destination.with_suffix(destination.suffix + ".tmp")
+    with tmp_path.open("w", encoding="utf-8") as handle:
+        json.dump(payload, handle, ensure_ascii=False, separators=(",", ":"))
+    os.replace(tmp_path, destination)
+
+
+def _extract_event_type(base_name: str | None) -> str:
+    if not base_name:
+        return ""
+    tokens = base_name.split("_")
+    if len(tokens) >= 2:
+        return tokens[1]
+    return ""
+
+
+def _load_vosk_model(model_path: Path):  # pragma: no cover - exercised via stub
+    from vosk import Model, SetLogLevel  # type: ignore[import-not-found]
+
+    SetLogLevel(-1)
+    return Model(str(model_path))
+
+
+def _convert_to_mono(data: bytes, channels: int, sample_width: int) -> bytes:
+    if channels <= 1:
+        return data
+    if channels == 2:
+        return audioop.tomono(data, sample_width, 0.5, 0.5)
+
+    if sample_width != 2:
+        raise TranscriptionError("Only 16-bit PCM is supported for multi-channel input")
+
+    samples = array("h")
+    samples.frombytes(data)
+    frame_count = len(samples) // channels
+    if frame_count <= 0:
+        return b""
+    mono = array("h")
+    mono.extend(0 for _ in range(frame_count))
+    for idx in range(frame_count):
+        total = 0
+        base = idx * channels
+        for ch in range(channels):
+            total += samples[base + ch]
+        mono[idx] = int(total / channels)
+    return mono.tobytes()
+
+
+def _transcribe_with_vosk(
+    source: Path,
+    *,
+    model_path: Path,
+    target_sample_rate: int,
+    include_words: bool,
+    max_alternatives: int,
+) -> tuple[str, dict[str, Any]]:
+    try:
+        model = _load_vosk_model(model_path)
+    except Exception as exc:  # pragma: no cover - depends on installed vosk
+        raise TranscriptionError(f"Failed to load Vosk model: {exc}") from exc
+
+    target_sample_rate = max(8000, int(target_sample_rate) if target_sample_rate else 16000)
+
+    from vosk import KaldiRecognizer  # type: ignore[import-not-found]
+
+    recognizer = KaldiRecognizer(model, float(target_sample_rate))
+    if include_words:
+        try:
+            recognizer.SetWords(True)
+        except Exception:
+            pass
+    if max_alternatives > 0:
+        try:
+            recognizer.SetMaxAlternatives(int(max_alternatives))
+        except Exception:
+            pass
+
+    with contextlib.closing(wave.open(str(source), "rb")) as wav_file:
+        channels = wav_file.getnchannels()
+        sample_width = wav_file.getsampwidth()
+        input_rate = wav_file.getframerate()
+        total_frames = wav_file.getnframes()
+
+        if sample_width <= 0:
+            raise TranscriptionError("Invalid WAV sample width")
+        if input_rate <= 0:
+            raise TranscriptionError("Invalid WAV sample rate")
+
+        rate_state: Any = None
+        while True:
+            chunk = wav_file.readframes(4000)
+            if not chunk:
+                break
+
+            if sample_width != 2:
+                chunk = audioop.lin2lin(chunk, sample_width, 2)
+                effective_width = 2
+            else:
+                effective_width = sample_width
+
+            if channels != 1:
+                chunk = _convert_to_mono(chunk, channels, effective_width)
+
+            if input_rate != target_sample_rate:
+                chunk, rate_state = audioop.ratecv(
+                    chunk,
+                    effective_width,
+                    1,
+                    input_rate,
+                    target_sample_rate,
+                    rate_state,
+                )
+
+            if chunk:
+                recognizer.AcceptWaveform(chunk)
+
+        if input_rate != target_sample_rate:
+            flush, _ = audioop.ratecv(
+                b"",
+                2,
+                1,
+                input_rate,
+                target_sample_rate,
+                rate_state,
+            )
+            if flush:
+                recognizer.AcceptWaveform(flush)
+
+    try:
+        result = json.loads(recognizer.FinalResult())
+    except json.JSONDecodeError as exc:
+        raise TranscriptionError("Recognizer returned invalid JSON") from exc
+
+    text = str(result.get("text", "")).strip()
+    metadata: dict[str, Any] = {}
+    if include_words:
+        words = []
+        for item in result.get("result", []):
+            if not isinstance(item, dict):
+                continue
+            word = str(item.get("word", "")).strip()
+            if not word:
+                continue
+            entry: dict[str, Any] = {
+                "word": word,
+            }
+            if isinstance(item.get("start"), (int, float)):
+                entry["start"] = float(item["start"])
+            if isinstance(item.get("end"), (int, float)):
+                entry["end"] = float(item["end"])
+            if isinstance(item.get("conf"), (int, float)):
+                entry["confidence"] = float(item["conf"])
+            words.append(entry)
+        if words:
+            metadata["words"] = words
+
+    if max_alternatives > 0:
+        alts: list[dict[str, Any]] = []
+        for alt in result.get("alternatives", []):
+            if not isinstance(alt, dict):
+                continue
+            alt_text = str(alt.get("text", "")).strip()
+            if not alt_text:
+                continue
+            alt_entry: dict[str, Any] = {"text": alt_text}
+            if isinstance(alt.get("confidence"), (int, float)):
+                alt_entry["confidence"] = float(alt["confidence"])
+            alts.append(alt_entry)
+        if alts:
+            metadata["alternatives"] = alts
+
+    duration = 0.0
+    if input_rate > 0 and total_frames > 0:
+        duration = total_frames / float(input_rate)
+
+    metadata["input_sample_rate"] = int(input_rate)
+    metadata["target_sample_rate"] = int(target_sample_rate)
+    metadata["duration_seconds"] = float(duration)
+
+    return text, metadata
+
+
+def transcribe_audio(
+    source_audio: os.PathLike[str] | str,
+    destination: os.PathLike[str] | str,
+    *,
+    base_name: str | None = None,
+    event_type: str | None = None,
+) -> bool:
+    cfg = get_cfg()
+    section = cfg.get("transcription") if isinstance(cfg, dict) else None
+    if not isinstance(section, dict):
+        return False
+
+    if not _bool(section.get("enabled")):
+        return False
+
+    allowed_types: set[str] = set()
+    raw_types = section.get("types")
+    if isinstance(raw_types, (list, tuple, set)):
+        for token in raw_types:
+            if isinstance(token, str) and token.strip():
+                allowed_types.add(token.strip().lower())
+    elif isinstance(raw_types, str) and raw_types.strip():
+        allowed_types.add(raw_types.strip().lower())
+
+    if event_type is None:
+        event_type = _extract_event_type(base_name)
+    event_type = (event_type or "").strip()
+
+    if allowed_types and event_type.lower() not in allowed_types:
+        return False
+
+    engine = str(section.get("engine", "vosk")).strip().lower()
+    if engine not in {"vosk"}:
+        raise TranscriptionError(f"Unsupported transcription engine: {engine}")
+
+    source_path = Path(source_audio)
+    dest_path = Path(destination)
+
+    if not source_path.exists():
+        raise TranscriptionError(f"Source audio not found: {source_path}")
+
+    model_key = section.get("vosk_model_path") or section.get("model_path")
+    if not isinstance(model_key, str) or not model_key.strip():
+        raise TranscriptionError("transcription.vosk_model_path is not configured")
+    model_path = Path(model_key.strip())
+    if not model_path.exists():
+        raise TranscriptionError(f"Configured Vosk model not found: {model_path}")
+
+    target_rate = section.get("target_sample_rate") or section.get("vosk_sample_rate")
+    try:
+        target_rate_int = int(target_rate) if target_rate else 16000
+    except Exception:
+        target_rate_int = 16000
+    include_words = _bool(section.get("include_words", True))
+    try:
+        max_alternatives = int(section.get("max_alternatives", 0) or 0)
+    except Exception:
+        max_alternatives = 0
+
+    text, metadata = _transcribe_with_vosk(
+        source_path,
+        model_path=model_path,
+        target_sample_rate=target_rate_int,
+        include_words=include_words,
+        max_alternatives=max_alternatives,
+    )
+
+    payload: dict[str, Any] = {
+        "version": 1,
+        "engine": "vosk",
+        "model_path": str(model_path),
+        "base_name": base_name or "",
+        "event_type": event_type,
+        "created_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        "text": text,
+    }
+    payload.update(metadata)
+
+    _write_json_atomic(dest_path, payload)
+
+    print(f"[transcription] Wrote {dest_path}", flush=True)
+    return True
+
+
+def _parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Generate a transcript sidecar for an audio file")
+    parser.add_argument("source", help="Path to the input WAV file")
+    parser.add_argument("destination", help="Path for the transcript JSON sidecar")
+    parser.add_argument("base_name", nargs="?", help="Recording base name (used to infer event type)")
+    parser.add_argument("--event-type", dest="event_type", help="Override event type instead of parsing base name")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv or sys.argv[1:])
+    try:
+        wrote = transcribe_audio(
+            args.source,
+            args.destination,
+            base_name=args.base_name,
+            event_type=args.event_type,
+        )
+    except TranscriptionError as exc:
+        print(f"[transcription] ERROR: {exc}", flush=True)
+        return 1
+
+    if not wrote:
+        return 0
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/lib/web_streamer.py
+++ b/lib/web_streamer.py
@@ -131,6 +131,7 @@ def _scan_recordings_worker(
         if allowed_ext and suffix not in allowed_ext:
             continue
         waveform_path = path.with_suffix(path.suffix + ".waveform.json")
+        transcript_path = path.with_suffix(path.suffix + ".transcript.json")
         try:
             waveform_stat = waveform_path.stat()
         except FileNotFoundError:
@@ -160,6 +161,42 @@ def _scan_recordings_worker(
                     waveform_meta = payload
         except (OSError, json.JSONDecodeError):
             continue
+
+        transcript_path_rel = ""
+        transcript_text = ""
+        transcript_event_type = ""
+        transcript_updated: float | None = None
+        transcript_updated_iso = ""
+        try:
+            transcript_stat = transcript_path.stat()
+        except FileNotFoundError:
+            transcript_stat = None
+        except OSError:
+            transcript_stat = None
+        if transcript_stat and transcript_stat.st_size > 0:
+            try:
+                transcript_path_rel = transcript_path.relative_to(recordings_root).as_posix()
+            except ValueError:
+                transcript_path_rel = ""
+            try:
+                with transcript_path.open("r", encoding="utf-8") as handle:
+                    payload = json.load(handle)
+                    if isinstance(payload, dict):
+                        raw_text = payload.get("text")
+                        if isinstance(raw_text, str):
+                            transcript_text = raw_text.strip()
+                        raw_type = payload.get("event_type")
+                        if isinstance(raw_type, str):
+                            transcript_event_type = raw_type.strip()
+            except (OSError, json.JSONDecodeError):
+                transcript_path_rel = ""
+                transcript_text = ""
+                transcript_event_type = ""
+            else:
+                transcript_updated = float(transcript_stat.st_mtime)
+                transcript_updated_iso = datetime.fromtimestamp(
+                    transcript_stat.st_mtime, tz=timezone.utc
+                ).isoformat()
 
         raw_duration = None
         if waveform_meta is not None:
@@ -210,6 +247,12 @@ def _scan_recordings_worker(
                 "waveform_path": waveform_rel.as_posix(),
                 "start_epoch": start_epoch,
                 "started_at": started_at_iso,
+                "has_transcript": bool(transcript_path_rel),
+                "transcript_path": transcript_path_rel,
+                "transcript_text": transcript_text,
+                "transcript_event_type": transcript_event_type,
+                "transcript_updated": transcript_updated,
+                "transcript_updated_iso": transcript_updated_iso,
             }
         )
 
@@ -715,6 +758,17 @@ def build_app() -> web.Application:
 
         return status
 
+    def _excerpt(text: str, limit: int = 240) -> str:
+        normalized = " ".join(text.split())
+        if not normalized:
+            return ""
+        if len(normalized) <= limit:
+            return normalized
+        truncated = normalized[:limit]
+        if " " in truncated:
+            truncated = truncated.rsplit(" ", 1)[0]
+        return truncated + "…"
+
     def _filter_recordings(entries: list[dict[str, object]], request: web.Request) -> dict[str, object]:
         query = request.rel_url.query
 
@@ -751,8 +805,16 @@ def build_app() -> web.Application:
             path = str(item.get("path", ""))
             day = str(item.get("day", ""))
             ext = str(item.get("extension", ""))
+            transcript_text = ""
+            raw_transcript_text = item.get("transcript_text")
+            if isinstance(raw_transcript_text, str):
+                transcript_text = raw_transcript_text
 
-            if search and search not in name.lower() and search not in path.lower():
+            haystacks = [name.lower(), path.lower()]
+            if transcript_text:
+                haystacks.append(transcript_text.lower())
+
+            if search and all(search not in candidate for candidate in haystacks):
                 continue
             if day_filter and day not in day_filter:
                 continue
@@ -797,6 +859,28 @@ def build_app() -> web.Application:
                     if isinstance(entry.get("started_at"), str)
                     else ""
                 ),
+                "has_transcript": bool(entry.get("has_transcript")),
+                "transcript_path": (
+                    str(entry.get("transcript_path"))
+                    if entry.get("transcript_path")
+                    else ""
+                ),
+                "transcript_event_type": (
+                    str(entry.get("transcript_event_type"))
+                    if entry.get("transcript_event_type")
+                    else ""
+                ),
+                "transcript_updated": (
+                    float(entry.get("transcript_updated", 0.0))
+                    if isinstance(entry.get("transcript_updated"), (int, float))
+                    else None
+                ),
+                "transcript_updated_iso": (
+                    str(entry.get("transcript_updated_iso"))
+                    if isinstance(entry.get("transcript_updated_iso"), str)
+                    else ""
+                ),
+                "transcript_excerpt": _excerpt(str(entry.get("transcript_text", ""))),
             }
             for entry in window
         ]
@@ -872,6 +956,13 @@ def build_app() -> web.Application:
                 waveform_sidecar = resolved.with_suffix(resolved.suffix + ".waveform.json")
                 try:
                     waveform_sidecar.unlink()
+                except FileNotFoundError:
+                    pass
+                except OSError:
+                    pass
+                transcript_sidecar = resolved.with_suffix(resolved.suffix + ".transcript.json")
+                try:
+                    transcript_sidecar.unlink()
                 except FileNotFoundError:
                     pass
                 except OSError:

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ noisereduce==3.0.3
 numpy==1.26.4
 aiohttp==3.12.15
 jinja2==3.1.4
+vosk==0.3.45

--- a/tests/test_transcription.py
+++ b/tests/test_transcription.py
@@ -1,0 +1,113 @@
+import json
+import sys
+import types
+import wave
+from pathlib import Path
+
+import pytest
+
+import lib.config as config
+
+
+def _write_silence_wav(path: Path, *, seconds: float = 0.5, sample_rate: int = 48000) -> None:
+    frame_count = int(seconds * sample_rate)
+    with wave.open(str(path), "wb") as wav_file:
+        wav_file.setnchannels(1)
+        wav_file.setsampwidth(2)
+        wav_file.setframerate(sample_rate)
+        wav_file.writeframes(b"\x00\x00" * frame_count)
+
+
+def test_transcription_disabled_returns_false(tmp_path, monkeypatch):
+    wav_path = tmp_path / "input.wav"
+    _write_silence_wav(wav_path)
+
+    monkeypatch.setenv("TRANSCRIPTION_ENABLED", "0")
+    monkeypatch.setattr(config, "_cfg_cache", None, raising=False)
+
+    from lib import transcription
+
+    output_path = tmp_path / "out.json"
+    wrote = transcription.transcribe_audio(wav_path, output_path, base_name="12-00-00_Human_1")
+    assert wrote is False
+    assert not output_path.exists()
+
+
+def test_transcription_with_stub_vosk(tmp_path, monkeypatch):
+    model_dir = tmp_path / "vosk"
+    model_dir.mkdir()
+
+    wav_path = tmp_path / "event.wav"
+    _write_silence_wav(wav_path, seconds=0.2)
+
+    class _DummyModel:
+        def __init__(self, path: str) -> None:
+            self.path = path
+
+    class _DummyRecognizer:
+        def __init__(self, model: _DummyModel, rate: float) -> None:
+            self.model = model
+            self.rate = rate
+            self.words = False
+            self.max_alt = 0
+            self._chunks: list[bytes] = []
+
+        def SetWords(self, enabled: bool) -> None:
+            self.words = enabled
+
+        def SetMaxAlternatives(self, count: int) -> None:
+            self.max_alt = count
+
+        def AcceptWaveform(self, data: bytes) -> bool:
+            self._chunks.append(bytes(data))
+            return False
+
+        def FinalResult(self) -> str:
+            payload = {
+                "text": "hello zebra",
+                "result": [
+                    {"word": "hello", "start": 0.0, "end": 0.5, "conf": 0.9},
+                    {"word": "zebra", "start": 0.5, "end": 1.0, "conf": 0.8},
+                ],
+                "alternatives": [
+                    {"text": "hello zebra", "confidence": 0.99},
+                ],
+            }
+            return json.dumps(payload)
+
+    dummy_module = types.ModuleType("vosk_stub")
+    dummy_module.Model = _DummyModel
+    dummy_module.KaldiRecognizer = _DummyRecognizer
+    dummy_module.SetLogLevel = lambda level: None
+
+    monkeypatch.setitem(sys.modules, "vosk", dummy_module)
+    monkeypatch.setenv("TRANSCRIPTION_ENABLED", "1")
+    monkeypatch.setenv("TRANSCRIPTION_TYPES", "Human")
+    monkeypatch.setenv("TRANSCRIPTION_TARGET_RATE", "16000")
+    monkeypatch.setenv("TRANSCRIPTION_INCLUDE_WORDS", "1")
+    monkeypatch.setenv("TRANSCRIPTION_MAX_ALTERNATIVES", "2")
+    monkeypatch.setenv("VOSK_MODEL_PATH", str(model_dir))
+    monkeypatch.setattr(config, "_cfg_cache", None, raising=False)
+
+    from lib import transcription
+
+    cfg = config.get_cfg()
+    assert cfg.get("transcription", {}).get("enabled") is True
+
+    output_path = tmp_path / "transcript.json"
+    wrote = transcription.transcribe_audio(
+        wav_path,
+        output_path,
+        base_name="12-34-56_Human_RMS-100_1",
+    )
+
+    assert wrote is True
+    data = json.loads(output_path.read_text(encoding="utf-8"))
+    assert data["text"] == "hello zebra"
+    assert data["engine"] == "vosk"
+    assert data["event_type"] == "Human"
+    assert data["base_name"] == "12-34-56_Human_RMS-100_1"
+    assert data.get("words") and len(data["words"]) == 2
+    assert any(entry.get("word") == "zebra" for entry in data["words"])
+    assert data.get("alternatives") and data["alternatives"][0]["text"] == "hello zebra"
+    assert Path(data["model_path"]).resolve() == model_dir.resolve()


### PR DESCRIPTION
## Summary
- integrate a Vosk-backed transcription helper that writes .transcript.json sidecars for Human-tagged recordings
- expose transcript metadata in the recordings API, search across transcript text, and remove sidecars when deleting files
- document the feature, surface configuration toggles, and add tests covering transcription and dashboard keyword search

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d53802f47483279bfa9a72c4b1190f