### PR TITLE
Add light/dark theme toggle to dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ Waveform sidecars are produced via `lib.waveform_cache` during the encode step s
 - Recording browser with search, day filtering, pagination, and bulk deletion.
 - Audio preview player with waveform visualization, trigger/release markers, and timeline scrubbing.
 - Config viewer that renders the merged runtime configuration (post-environment overrides).
+- Light/dark theme toggle that follows the OS preference until a user selection is stored locally.
 - JSON APIs (`/api/recordings`, `/api/config`, `/api/recordings/delete`, `/hls/stats`, etc.) consumed by the dashboard and available for automation.
 - Legacy HLS status page at `/hls` retained for compatibility with earlier deployments.
 

--- a/lib/webui/static/css/dashboard.css
+++ b/lib/webui/static/css/dashboard.css
@@ -594,6 +594,21 @@ button.small {
   margin: 0;
 }
 
+@media (max-width: 900px) {
+  .filters-grid {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .filters-grid .input-group {
+    width: 100%;
+  }
+
+  #filter-limit {
+    max-width: none;
+    justify-self: stretch;
+  }
+}
+
 .player-card[hidden] {
   display: none !important;
 }

--- a/lib/webui/static/css/dashboard.css
+++ b/lib/webui/static/css/dashboard.css
@@ -11,7 +11,108 @@
   --text-muted: rgba(226, 232, 240, 0.65);
   --table-border: rgba(148, 163, 184, 0.18);
   --code-bg: rgba(15, 23, 42, 0.55);
+  --surface-muted: rgba(15, 23, 42, 0.55);
+  --surface-strong: rgba(15, 23, 42, 0.65);
+  --surface-soft: rgba(15, 23, 42, 0.45);
+  --surface-soft-alt: rgba(15, 23, 42, 0.35);
+  --surface-faint: rgba(15, 23, 42, 0.25);
+  --surface-table: rgba(15, 23, 42, 0.5);
+  --surface-table-header: rgba(15, 23, 42, 0.8);
+  --overlay-backdrop: rgba(15, 23, 42, 0.72);
+  --overlay-panel: rgba(15, 23, 42, 0.65);
+  --dialog-surface: rgba(15, 23, 42, 0.82);
+  --divider: rgba(148, 163, 184, 0.12);
+  --storage-track: rgba(148, 163, 184, 0.2);
+  --ghost-border: rgba(148, 163, 184, 0.35);
+  --ghost-border-hover: rgba(148, 163, 184, 0.6);
+  --ghost-border-muted: rgba(148, 163, 184, 0.25);
+  --danger-bg: rgba(248, 113, 113, 0.15);
+  --danger-border: rgba(248, 113, 113, 0.35);
+  --danger-bg-hover: rgba(248, 113, 113, 0.25);
+  --input-focus-border: rgba(56, 189, 248, 0.7);
+  --input-focus-ring: rgba(56, 189, 248, 0.25);
+  --waveform-bg: linear-gradient(180deg, rgba(15, 23, 42, 0.75), rgba(15, 23, 42, 0.55));
+  --waveform-chip-bg: rgba(15, 23, 42, 0.82);
+  --waveform-chip-shadow: 0 12px 28px rgba(15, 23, 42, 0.45);
+  --waveform-border: rgba(148, 163, 184, 0.18);
+  --marker-label-shadow: 0 6px 18px rgba(15, 23, 42, 0.45);
+  --table-footer-bg: rgba(15, 23, 42, 0.5);
+  --table-row-border: rgba(148, 163, 184, 0.22);
+  --table-row-hover-bg: rgba(56, 189, 248, 0.14);
+  --table-row-active-border: rgba(56, 189, 248, 0.45);
+  --table-row-active-ring: rgba(56, 189, 248, 0.35);
+  --action-chip-bg: rgba(15, 23, 42, 0.55);
+  --action-chip-border: rgba(148, 163, 184, 0.35);
+  --modal-shadow: 0 28px 60px -30px rgba(15, 23, 42, 0.85);
+  --mobile-row-shadow: 0 18px 42px -28px rgba(15, 23, 42, 0.9);
+  --service-status-inactive: rgba(148, 163, 184, 0.85);
+  --service-related-heading: rgba(226, 232, 240, 0.55);
+  --service-related-text: rgba(226, 232, 240, 0.8);
+  --service-related-status: rgba(148, 163, 184, 0.9);
+  --service-details-text: rgba(226, 232, 240, 0.5);
+  --service-message-text: rgba(226, 232, 240, 0.92);
+  --service-message-pending-text: rgba(226, 232, 240, 0.85);
   --font-family: "Inter", "Segoe UI", system-ui, -apple-system, BlinkMacSystemFont, "Roboto", "Ubuntu", sans-serif;
+}
+
+body[data-theme="light"] {
+  color-scheme: light;
+  --bg-gradient: linear-gradient(135deg, #f8fafc 0%, #e2e8f0 45%, #dbeafe 100%);
+  --card-bg: rgba(255, 255, 255, 0.9);
+  --card-border: rgba(148, 163, 184, 0.3);
+  --card-shadow: 0 20px 40px -24px rgba(15, 23, 42, 0.25);
+  --primary: #0ea5e9;
+  --primary-text: #f8fafc;
+  --danger: #dc2626;
+  --text: #0f172a;
+  --text-muted: rgba(30, 41, 59, 0.65);
+  --table-border: rgba(148, 163, 184, 0.35);
+  --code-bg: rgba(15, 23, 42, 0.05);
+  --surface-muted: rgba(248, 250, 252, 0.9);
+  --surface-strong: rgba(226, 232, 240, 0.82);
+  --surface-soft: rgba(226, 232, 240, 0.7);
+  --surface-soft-alt: rgba(226, 232, 240, 0.6);
+  --surface-faint: rgba(226, 232, 240, 0.5);
+  --surface-table: rgba(226, 232, 240, 0.8);
+  --surface-table-header: rgba(226, 232, 240, 0.9);
+  --overlay-backdrop: rgba(15, 23, 42, 0.25);
+  --overlay-panel: rgba(148, 163, 184, 0.3);
+  --dialog-surface: rgba(255, 255, 255, 0.95);
+  --divider: rgba(148, 163, 184, 0.25);
+  --storage-track: rgba(203, 213, 225, 0.65);
+  --ghost-border: rgba(148, 163, 184, 0.5);
+  --ghost-border-hover: rgba(100, 116, 139, 0.75);
+  --ghost-border-muted: rgba(148, 163, 184, 0.35);
+  --danger-bg: rgba(239, 68, 68, 0.1);
+  --danger-border: rgba(239, 68, 68, 0.3);
+  --danger-bg-hover: rgba(239, 68, 68, 0.16);
+  --input-focus-border: rgba(14, 165, 233, 0.7);
+  --input-focus-ring: rgba(14, 165, 233, 0.25);
+  --waveform-bg: linear-gradient(180deg, rgba(226, 232, 240, 0.75), rgba(226, 232, 240, 0.55));
+  --waveform-chip-bg: rgba(255, 255, 255, 0.85);
+  --waveform-chip-shadow: 0 12px 28px rgba(148, 163, 184, 0.35);
+  --waveform-border: rgba(148, 163, 184, 0.25);
+  --marker-label-shadow: 0 6px 18px rgba(148, 163, 184, 0.25);
+  --table-footer-bg: rgba(226, 232, 240, 0.8);
+  --table-row-border: rgba(203, 213, 225, 0.9);
+  --table-row-hover-bg: rgba(14, 165, 233, 0.16);
+  --table-row-active-border: rgba(14, 165, 233, 0.45);
+  --table-row-active-ring: rgba(14, 165, 233, 0.35);
+  --action-chip-bg: rgba(255, 255, 255, 0.85);
+  --action-chip-border: rgba(148, 163, 184, 0.4);
+  --modal-shadow: 0 28px 60px -30px rgba(15, 23, 42, 0.2);
+  --mobile-row-shadow: 0 18px 42px -28px rgba(148, 163, 184, 0.35);
+  --service-status-inactive: rgba(100, 116, 139, 0.8);
+  --service-related-heading: rgba(71, 85, 105, 0.7);
+  --service-related-text: rgba(51, 65, 85, 0.85);
+  --service-related-status: rgba(71, 85, 105, 0.85);
+  --service-details-text: rgba(71, 85, 105, 0.6);
+  --service-message-text: #0f172a;
+  --service-message-pending-text: rgba(51, 65, 85, 0.9);
+}
+
+body[data-theme="dark"] {
+  color-scheme: dark;
 }
 
 *,
@@ -78,15 +179,19 @@ body {
   min-width: 0;
 }
 
+#theme-toggle {
+  white-space: nowrap;
+}
+
 .recording-indicator {
   display: inline-flex;
   align-items: center;
   gap: 0.45rem;
   padding: 0.35rem 0.75rem;
   border-radius: 999px;
-  border: 1px solid rgba(148, 163, 184, 0.25);
-  background: rgba(15, 23, 42, 0.55);
-  box-shadow: 0 10px 24px -18px rgba(15, 23, 42, 0.65);
+  border: 1px solid var(--ghost-border-muted);
+  background: var(--surface-muted);
+  box-shadow: 0 10px 24px -18px var(--overlay-panel);
   font-size: 0.85rem;
   font-weight: 600;
   letter-spacing: 0.04em;
@@ -171,7 +276,7 @@ body {
   width: 1rem;
   height: 1rem;
   border-radius: 50%;
-  border: 2px solid rgba(148, 163, 184, 0.35);
+  border: 2px solid var(--ghost-border);
   border-top-color: var(--primary);
   animation: refresh-spin 0.8s linear infinite;
 }
@@ -231,7 +336,7 @@ body {
   width: 100%;
   height: 0.45rem;
   border-radius: 999px;
-  background: rgba(148, 163, 184, 0.2);
+  background: var(--storage-track);
   overflow: hidden;
   margin-top: 0.45rem;
 }
@@ -361,7 +466,7 @@ body {
   border-radius: 0.75rem;
   border: 1px solid var(--card-border);
   padding: 0.65rem 0.75rem;
-  background: rgba(15, 23, 42, 0.55);
+  background: var(--surface-muted);
   color: var(--text);
   outline: none;
   transition: border-color 0.2s ease, box-shadow 0.2s ease;
@@ -369,8 +474,8 @@ body {
 
 .input-group input:focus,
 .input-group select:focus {
-  border-color: rgba(56, 189, 248, 0.7);
-  box-shadow: 0 0 0 3px rgba(56, 189, 248, 0.25);
+  border-color: var(--input-focus-border);
+  box-shadow: 0 0 0 3px var(--input-focus-ring);
 }
 
 .primary-button,
@@ -404,22 +509,22 @@ body {
 .ghost-button {
   background: transparent;
   color: var(--text);
-  border: 1px solid rgba(148, 163, 184, 0.35);
+  border: 1px solid var(--ghost-border);
 }
 
 .ghost-button:hover {
   transform: translateY(-1px);
-  border-color: rgba(148, 163, 184, 0.6);
+  border-color: var(--ghost-border-hover);
 }
 
 .danger-button {
-  background: rgba(248, 113, 113, 0.15);
+  background: var(--danger-bg);
   color: var(--danger);
-  border: 1px solid rgba(248, 113, 113, 0.35);
+  border: 1px solid var(--danger-border);
 }
 
 .danger-button:hover {
-  background: rgba(248, 113, 113, 0.25);
+  background: var(--danger-bg-hover);
   transform: translateY(-1px);
 }
 
@@ -429,9 +534,9 @@ button.small {
 }
 
 .filters-panel {
-  border-top: 1px solid rgba(148, 163, 184, 0.12);
-  border-bottom: 1px solid rgba(148, 163, 184, 0.12);
-  background: rgba(15, 23, 42, 0.45);
+  border-top: 1px solid var(--divider);
+  border-bottom: 1px solid var(--divider);
+  background: var(--surface-soft);
   padding: 1.25rem 1.5rem 1.35rem;
   display: flex;
   flex-direction: column;
@@ -478,7 +583,7 @@ button.small {
 .player-card audio {
   width: 100%;
   border-radius: 0.75rem;
-  background: rgba(15, 23, 42, 0.65);
+  background: var(--surface-strong);
   margin-top: 0.75rem;
 }
 
@@ -512,7 +617,7 @@ button.small {
   overflow: hidden;
   border-radius: 1rem;
   border: 1px solid transparent;
-  background: rgba(15, 23, 42, 0.6);
+  background: var(--overlay-panel);
   margin-bottom: 0;
 }
 
@@ -560,7 +665,7 @@ button.small {
 .live-stream-panel audio {
   width: 100%;
   border-radius: 0.75rem;
-  background: rgba(15, 23, 42, 0.65);
+  background: var(--surface-strong);
 }
 
 .live-stream-hint {
@@ -600,8 +705,8 @@ button.small {
   width: 100%;
   height: 160px;
   border-radius: 1rem;
-  background: linear-gradient(180deg, rgba(15, 23, 42, 0.75), rgba(15, 23, 42, 0.55));
-  box-shadow: inset 0 0 0 1px rgba(148, 163, 184, 0.18);
+  background: var(--waveform-bg);
+  box-shadow: inset 0 0 0 1px var(--waveform-border);
   overflow: hidden;
   cursor: pointer;
 }
@@ -619,7 +724,7 @@ button.small {
   transform: translateX(-50%);
   padding: 0.35rem 0.75rem;
   border-radius: 0.65rem;
-  background: rgba(15, 23, 42, 0.82);
+  background: var(--waveform-chip-bg);
   color: var(--text);
   font-family: "SFMono-Regular", "Consolas", "Liberation Mono", "Menlo", "Courier New", monospace;
   font-size: 0.95rem;
@@ -627,7 +732,7 @@ button.small {
   font-variant-numeric: tabular-nums;
   letter-spacing: 0.08em;
   pointer-events: none;
-  box-shadow: 0 12px 28px rgba(15, 23, 42, 0.45);
+  box-shadow: var(--waveform-chip-shadow);
   opacity: 0;
   transition: opacity 0.2s ease;
   z-index: 1;
@@ -669,7 +774,7 @@ button.small {
   top: 0.75rem;
   left: 50%;
   transform: translate(-50%, -40%);
-  background: rgba(15, 23, 42, 0.82);
+  background: var(--waveform-chip-bg);
   color: var(--text);
   font-size: 0.65rem;
   font-weight: 600;
@@ -677,7 +782,7 @@ button.small {
   text-transform: uppercase;
   padding: 0.2rem 0.45rem;
   border-radius: 0.4rem;
-  box-shadow: 0 6px 18px rgba(15, 23, 42, 0.45);
+  box-shadow: var(--marker-label-shadow);
   opacity: 0;
   transition: opacity 0.2s ease;
   white-space: nowrap;
@@ -710,9 +815,9 @@ button.small {
   color: var(--text-muted);
   font-size: 0.9rem;
   border-radius: 1rem;
-  border: 1px dashed rgba(148, 163, 184, 0.35);
+  border: 1px dashed var(--action-chip-border);
   padding: 1.5rem 1rem;
-  background: rgba(15, 23, 42, 0.25);
+  background: var(--surface-faint);
 }
 
 .table-card {
@@ -724,14 +829,14 @@ button.small {
 
 .table-card .card-header {
   padding: 1.25rem 1.5rem 1rem;
-  border-bottom: 1px solid rgba(148, 163, 184, 0.12);
+  border-bottom: 1px solid var(--divider);
   margin-bottom: 0;
 }
 
 .table-card .filters-panel {
   border-top: none;
-  border-bottom: 1px solid rgba(148, 163, 184, 0.12);
-  background: rgba(15, 23, 42, 0.35);
+  border-bottom: 1px solid var(--divider);
+  background: var(--surface-soft-alt);
   padding: 1.25rem 1.5rem 1.5rem;
 }
 
@@ -742,7 +847,7 @@ button.small {
   align-items: center;
   justify-content: center;
   padding: clamp(1.5rem, 4vw, 3rem);
-  background: rgba(15, 23, 42, 0.72);
+  background: var(--overlay-backdrop);
   backdrop-filter: blur(12px);
   z-index: 1000;
   opacity: 0;
@@ -803,7 +908,7 @@ button.small {
 }
 
 .services-status[data-state="info"] {
-  color: rgba(148, 163, 184, 0.85);
+  color: var(--service-status-inactive);
 }
 
 .services-list {
@@ -817,16 +922,16 @@ button.small {
   color: var(--text-muted);
   font-size: 0.9rem;
   border-radius: 1rem;
-  border: 1px dashed rgba(148, 163, 184, 0.35);
+  border: 1px dashed var(--action-chip-border);
   padding: 1.25rem;
-  background: rgba(15, 23, 42, 0.25);
+  background: var(--surface-faint);
 }
 
 .service-row {
-  border: 1px solid rgba(148, 163, 184, 0.18);
+  border: 1px solid var(--table-row-border);
   border-radius: 1rem;
   padding: 1rem 1.25rem;
-  background: rgba(15, 23, 42, 0.45);
+  background: var(--surface-soft);
   display: flex;
   flex-direction: column;
   gap: 0.75rem;
@@ -879,7 +984,7 @@ button.small {
 }
 
 .service-status[data-state="inactive"] {
-  color: rgba(148, 163, 184, 0.85);
+  color: var(--service-status-inactive);
 }
 
 .service-status[data-state="error"] {
@@ -915,7 +1020,7 @@ button.small {
   font-size: 0.65rem;
   text-transform: uppercase;
   letter-spacing: 0.12em;
-  color: rgba(226, 232, 240, 0.55);
+  color: var(--service-related-heading);
 }
 
 .service-related-list {
@@ -933,7 +1038,7 @@ button.small {
   align-items: baseline;
   gap: 0.75rem;
   font-size: 0.85rem;
-  color: rgba(226, 232, 240, 0.8);
+  color: var(--service-related-text);
 }
 
 .service-related-item[data-state="error"] {
@@ -954,14 +1059,14 @@ button.small {
 
 .service-related-status {
   font-variant-numeric: tabular-nums;
-  color: rgba(148, 163, 184, 0.9);
+  color: var(--service-related-status);
 }
 
 .service-details {
   font-size: 0.75rem;
   letter-spacing: 0.1em;
   text-transform: uppercase;
-  color: rgba(226, 232, 240, 0.5);
+  color: var(--service-details-text);
 }
 
 .service-message {
@@ -970,7 +1075,7 @@ button.small {
   padding: 0.6rem 0.75rem;
   border-radius: 0.75rem;
   background: rgba(56, 189, 248, 0.15);
-  color: rgba(226, 232, 240, 0.92);
+  color: var(--service-message-text);
 }
 
 .service-message[data-visible="true"] {
@@ -989,7 +1094,7 @@ button.small {
 
 .service-message[data-state="pending"] {
   background: rgba(148, 163, 184, 0.18);
-  color: rgba(226, 232, 240, 0.85);
+  color: var(--service-message-pending-text);
 }
 
 .table-responsive {
@@ -1003,8 +1108,8 @@ button.small {
   align-items: center;
   gap: 1rem;
   padding: 1rem 1.5rem 1.25rem;
-  border-top: 1px solid rgba(148, 163, 184, 0.12);
-  background: rgba(15, 23, 42, 0.5);
+  border-top: 1px solid var(--divider);
+  background: var(--surface-table);
   flex-wrap: wrap;
 }
 
@@ -1054,7 +1159,7 @@ button.small {
 }
 
 #recordings-table thead {
-  background: rgba(15, 23, 42, 0.8);
+  background: var(--surface-table-header);
 }
 
 #recordings-table th,
@@ -1172,10 +1277,10 @@ button.small {
 .action-buttons button,
 .action-buttons a {
   border-radius: 999px;
-  border: 1px solid rgba(148, 163, 184, 0.35);
+  border: 1px solid var(--action-chip-border);
   padding: 0.35rem 0.75rem;
   font-size: 0.8rem;
-  background: rgba(15, 23, 42, 0.55);
+  background: var(--action-chip-bg);
   color: var(--text);
   text-decoration: none;
   display: inline-flex;
@@ -1272,7 +1377,7 @@ button.small {
   align-items: center;
   justify-content: center;
   padding: 1.5rem;
-  background: rgba(15, 23, 42, 0.72);
+  background: var(--overlay-backdrop);
   backdrop-filter: blur(6px);
   z-index: 1000;
   opacity: 0;
@@ -1292,7 +1397,7 @@ button.small {
   border-radius: 1rem;
   background: var(--card-bg);
   border: 1px solid var(--card-border);
-  box-shadow: 0 28px 60px -30px rgba(15, 23, 42, 0.85);
+  box-shadow: var(--modal-shadow);
   padding: 1.75rem;
   display: flex;
   flex-direction: column;
@@ -1395,10 +1500,10 @@ button.small {
     grid-template-columns: auto 1fr;
     gap: 0.5rem 0.75rem;
     padding: 1rem 1.1rem;
-    border: 1px solid rgba(148, 163, 184, 0.22);
+    border: 1px solid var(--table-row-border);
     border-radius: 1rem;
-    background: rgba(15, 23, 42, 0.45);
-    box-shadow: 0 18px 42px -28px rgba(15, 23, 42, 0.9);
+    background: var(--surface-soft);
+    box-shadow: var(--mobile-row-shadow);
   }
 
   #recordings-table tbody tr .mobile-player-cell {
@@ -1462,12 +1567,12 @@ button.small {
   }
 
   #recordings-table tbody tr:hover {
-    background: rgba(56, 189, 248, 0.14);
+    background: var(--table-row-hover-bg);
   }
 
   #recordings-table tbody tr.active-row {
-    border-color: rgba(56, 189, 248, 0.45);
-    box-shadow: 0 0 0 1px rgba(56, 189, 248, 0.35);
+    border-color: var(--table-row-active-border);
+    box-shadow: 0 0 0 1px var(--table-row-active-ring);
   }
 }
 

--- a/lib/webui/static/css/dashboard.css
+++ b/lib/webui/static/css/dashboard.css
@@ -568,12 +568,30 @@ button.small {
 
 .filters-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  grid-template-columns: minmax(220px, 2fr) minmax(180px, 1fr) minmax(120px, auto);
   gap: 1rem;
+  align-items: end;
 }
 
 .filters-grid .input-group {
   margin-bottom: 0;
+}
+
+.filters-grid .input-group input,
+.filters-grid .input-group select {
+  width: 100%;
+}
+
+#filter-limit {
+  max-width: 140px;
+  justify-self: end;
+  -moz-appearance: textfield;
+}
+
+#filter-limit::-webkit-outer-spin-button,
+#filter-limit::-webkit-inner-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
 }
 
 .player-card[hidden] {

--- a/lib/webui/static/js/dashboard.js
+++ b/lib/webui/static/js/dashboard.js
@@ -4172,9 +4172,24 @@ function attachEventListeners() {
       });
     };
 
+    const handleFiltersPointerEnd = () => {
+      window.requestAnimationFrame(() => {
+        const active =
+          document.activeElement instanceof HTMLElement
+            ? document.activeElement
+            : null;
+        if (!active || !dom.filtersPanel.contains(active)) {
+          resumeAutoRefresh();
+        }
+      });
+    };
+
     dom.filtersPanel.addEventListener("focusin", suspendAutoRefresh);
     dom.filtersPanel.addEventListener("pointerdown", suspendAutoRefresh);
     dom.filtersPanel.addEventListener("focusout", handleFiltersFocusOut);
+    dom.filtersPanel.addEventListener("pointerup", handleFiltersPointerEnd);
+    dom.filtersPanel.addEventListener("pointercancel", handleFiltersPointerEnd);
+    dom.filtersPanel.addEventListener("pointerleave", handleFiltersPointerEnd);
   }
 
   dom.applyFilters.addEventListener("click", () => {

--- a/lib/webui/static/js/dashboard.js
+++ b/lib/webui/static/js/dashboard.js
@@ -48,6 +48,7 @@ const KEYBOARD_JOG_RATE_SECONDS_PER_SECOND = 4;
 const DEFAULT_LIMIT = 200;
 const MAX_LIMIT = 1000;
 const FILTER_STORAGE_KEY = "tricorder.dashboard.filters";
+const THEME_STORAGE_KEY = "tricorder.dashboard.theme";
 
 const HLS_URL = apiPath("/hls/live.m3u8");
 const START_ENDPOINT = apiPath("/hls/start");
@@ -92,6 +93,7 @@ const dom = {
   deleteSelected: document.getElementById("delete-selected"),
   refreshButton: document.getElementById("refresh-button"),
   refreshIndicator: document.getElementById("refresh-indicator"),
+  themeToggle: document.getElementById("theme-toggle"),
   connectionStatus: document.getElementById("connection-status"),
   recordingIndicator: document.getElementById("recording-indicator"),
   recordingIndicatorText: document.getElementById("recording-indicator-text"),
@@ -148,6 +150,15 @@ const sortHeaderMap = new Map(
   dom.sortButtons.map((button) => [button.dataset.sortKey ?? "", button.closest("th")])
 );
 
+const VALID_THEMES = new Set(["dark", "light"]);
+
+const themeState = {
+  current: "dark",
+  manual: false,
+  mediaQuery: null,
+  mediaListener: null,
+};
+
 const userLocales = (() => {
   if (typeof navigator !== "undefined") {
     if (Array.isArray(navigator.languages) && navigator.languages.length > 0) {
@@ -174,6 +185,106 @@ const timeFormatter = new Intl.DateTimeFormat(userLocales, {
   hour12: false,
   hourCycle: "h23",
 });
+
+function readStoredTheme() {
+  if (typeof window === "undefined" || typeof window.localStorage === "undefined") {
+    return null;
+  }
+  try {
+    const raw = window.localStorage.getItem(THEME_STORAGE_KEY);
+    if (typeof raw === "string") {
+      const normalized = raw.trim().toLowerCase();
+      if (VALID_THEMES.has(normalized)) {
+        return normalized;
+      }
+    }
+  } catch (error) {
+    return null;
+  }
+  return null;
+}
+
+function writeStoredTheme(theme) {
+  if (typeof window === "undefined" || typeof window.localStorage === "undefined") {
+    return;
+  }
+  try {
+    window.localStorage.setItem(THEME_STORAGE_KEY, theme);
+  } catch (error) {
+    /* ignore storage errors */
+  }
+}
+
+function updateThemeToggle(theme) {
+  if (!dom.themeToggle) {
+    return;
+  }
+  const nextTheme = theme === "dark" ? "light" : "dark";
+  const label = nextTheme === "light" ? "Switch to light theme" : "Switch to dark theme";
+  dom.themeToggle.textContent = label;
+  dom.themeToggle.setAttribute("aria-label", label);
+  dom.themeToggle.setAttribute("title", label);
+  dom.themeToggle.setAttribute("aria-pressed", theme === "dark" ? "true" : "false");
+  dom.themeToggle.dataset.currentTheme = theme;
+}
+
+function applyTheme(theme) {
+  const nextTheme = VALID_THEMES.has(theme) ? theme : "dark";
+  themeState.current = nextTheme;
+  if (document.body) {
+    document.body.setAttribute("data-theme", nextTheme);
+  }
+  updateThemeToggle(nextTheme);
+}
+
+function handleSystemThemeChange(event) {
+  if (themeState.manual) {
+    return;
+  }
+  applyTheme(event.matches ? "dark" : "light");
+}
+
+function ensureSystemThemeSubscription() {
+  if (typeof window === "undefined" || typeof window.matchMedia !== "function") {
+    themeState.mediaQuery = null;
+    themeState.mediaListener = null;
+    return "dark";
+  }
+  if (themeState.mediaQuery && themeState.mediaListener) {
+    return themeState.mediaQuery.matches ? "dark" : "light";
+  }
+  const query = window.matchMedia("(prefers-color-scheme: dark)");
+  const listener = (event) => {
+    handleSystemThemeChange(event);
+  };
+  if (typeof query.addEventListener === "function") {
+    query.addEventListener("change", listener);
+  } else if (typeof query.addListener === "function") {
+    query.addListener(listener);
+  }
+  themeState.mediaQuery = query;
+  themeState.mediaListener = listener;
+  return query.matches ? "dark" : "light";
+}
+
+function initializeTheme() {
+  const storedTheme = readStoredTheme();
+  if (storedTheme) {
+    themeState.manual = true;
+    applyTheme(storedTheme);
+    return;
+  }
+  themeState.manual = false;
+  const systemTheme = ensureSystemThemeSubscription();
+  applyTheme(systemTheme);
+}
+
+function toggleTheme() {
+  const nextTheme = themeState.current === "dark" ? "light" : "dark";
+  themeState.manual = true;
+  applyTheme(nextTheme);
+  writeStoredTheme(nextTheme);
+}
 
 let autoRefreshId = null;
 let autoRefreshIntervalMs = AUTO_REFRESH_INTERVAL_MS;
@@ -4040,6 +4151,12 @@ function attachEventListeners() {
     updateSelectionUI();
   });
 
+  if (dom.themeToggle) {
+    dom.themeToggle.addEventListener("click", () => {
+      toggleTheme();
+    });
+  }
+
   if (dom.refreshButton) {
     dom.refreshButton.addEventListener("click", () => {
       fetchRecordings({ silent: false });
@@ -4338,6 +4455,7 @@ function attachEventListeners() {
 }
 
 function initialize() {
+  initializeTheme();
   restoreFiltersFromStorage();
   populateFilters();
   updateSelectionUI();

--- a/lib/webui/static/js/dashboard.js
+++ b/lib/webui/static/js/dashboard.js
@@ -107,6 +107,7 @@ const dom = {
   paginationStatus: document.getElementById("pagination-status"),
   pagePrev: document.getElementById("page-prev"),
   pageNext: document.getElementById("page-next"),
+  filtersPanel: document.querySelector(".filters-panel"),
   playerCard: document.getElementById("player-card"),
   player: document.getElementById("preview-player"),
   playerMeta: document.getElementById("player-meta"),
@@ -288,6 +289,7 @@ function toggleTheme() {
 
 let autoRefreshId = null;
 let autoRefreshIntervalMs = AUTO_REFRESH_INTERVAL_MS;
+let autoRefreshSuspended = false;
 let fetchInFlight = false;
 let fetchQueued = false;
 let refreshIndicatorTimer = null;
@@ -500,7 +502,7 @@ function restoreFiltersFromStorage() {
 }
 
 function startAutoRefresh() {
-  if (autoRefreshId) {
+  if (autoRefreshSuspended || autoRefreshId) {
     return;
   }
   autoRefreshId = window.setInterval(() => {
@@ -516,6 +518,9 @@ function stopAutoRefresh() {
 }
 
 function restartAutoRefresh() {
+  if (autoRefreshSuspended) {
+    return;
+  }
   if (!autoRefreshId) {
     return;
   }
@@ -530,6 +535,25 @@ function setAutoRefreshInterval(intervalMs) {
   }
   autoRefreshIntervalMs = clamped;
   restartAutoRefresh();
+}
+
+function suspendAutoRefresh() {
+  if (autoRefreshSuspended) {
+    return;
+  }
+  autoRefreshSuspended = true;
+  stopAutoRefresh();
+}
+
+function resumeAutoRefresh() {
+  if (!autoRefreshSuspended) {
+    if (!autoRefreshId) {
+      startAutoRefresh();
+    }
+    return;
+  }
+  autoRefreshSuspended = false;
+  startAutoRefresh();
 }
 
 function setConnectionStatus(message) {
@@ -4130,11 +4154,35 @@ function handleServiceListClick(event) {
 }
 
 function attachEventListeners() {
+  if (dom.filtersPanel) {
+    const handleFiltersFocusOut = (event) => {
+      const next =
+        event.relatedTarget instanceof HTMLElement ? event.relatedTarget : null;
+      if (next && dom.filtersPanel.contains(next)) {
+        return;
+      }
+      window.requestAnimationFrame(() => {
+        const active =
+          document.activeElement instanceof HTMLElement
+            ? document.activeElement
+            : null;
+        if (!active || !dom.filtersPanel.contains(active)) {
+          resumeAutoRefresh();
+        }
+      });
+    };
+
+    dom.filtersPanel.addEventListener("focusin", suspendAutoRefresh);
+    dom.filtersPanel.addEventListener("pointerdown", suspendAutoRefresh);
+    dom.filtersPanel.addEventListener("focusout", handleFiltersFocusOut);
+  }
+
   dom.applyFilters.addEventListener("click", () => {
     applyFiltersFromInputs();
     state.selections.clear();
     fetchRecordings({ silent: false });
     updateSelectionUI();
+    resumeAutoRefresh();
   });
 
   dom.filterSearch.addEventListener("keydown", (event) => {
@@ -4149,6 +4197,7 @@ function attachEventListeners() {
     state.selections.clear();
     fetchRecordings({ silent: false });
     updateSelectionUI();
+    resumeAutoRefresh();
   });
 
   if (dom.themeToggle) {

--- a/lib/webui/templates/dashboard.html
+++ b/lib/webui/templates/dashboard.html
@@ -47,6 +47,15 @@
               data-visible="false"
             ></div>
           </div>
+          <button
+            id="theme-toggle"
+            class="ghost-button"
+            type="button"
+            aria-pressed="false"
+            aria-label="Toggle light and dark theme"
+          >
+            Toggle theme
+          </button>
           <button id="refresh-button" class="ghost-button" type="button">Refresh</button>
           <div
             id="refresh-indicator"


### PR DESCRIPTION
## Summary
- add a light/dark theme toggle to the dashboard header and persist the user selection
- rework dashboard styling to rely on theme variables so the UI adapts cleanly across both themes
- document the new theme toggle in the README

## Testing
- pytest tests/test_37_web_dashboard.py
- pytest tests/test_25_web_streamer.py
- pytest -q *(fails: tests/test_35_hls.py::test_hls_controller_state_persistence, reran individually and it passed)*

------
https://chatgpt.com/codex/tasks/task_e_68d537f668d483278836d8e8f567f4e3