### PR TITLE
Disable live stream toggle when recorder is down

### DIFF
--- a/lib/webui/static/js/dashboard.js
+++ b/lib/webui/static/js/dashboard.js
@@ -58,6 +58,8 @@ const STATS_ENDPOINT = apiPath("/hls/stats");
 const SERVICES_ENDPOINT = apiPath("/api/services");
 const SERVICE_REFRESH_INTERVAL_MS = 5000;
 const SERVICE_RESULT_TTL_MS = 15000;
+const VOICE_RECORDER_SERVICE_UNIT = "voice-recorder.service";
+const RECORDER_SERVICE_REFRESH_INTERVAL_MS = 10000;
 const SESSION_STORAGE_KEY = "tricorder.session";
 const WINDOW_NAME_PREFIX = "tricorder.session:";
 
@@ -350,6 +352,10 @@ const servicesDialogState = {
   open: false,
   previouslyFocused: null,
   keydownHandler: null,
+};
+
+const recorderServiceMonitor = {
+  timerId: null,
 };
 
 const connectionState = {
@@ -3908,6 +3914,7 @@ function renderServices() {
 
   dom.servicesList.innerHTML = "";
   if (!hasItems) {
+    updateLiveToggleAvailabilityFromServices();
     return;
   }
 
@@ -4105,6 +4112,7 @@ function renderServices() {
   }
 
   dom.servicesList.append(fragment);
+  updateLiveToggleAvailabilityFromServices();
 }
 
 function servicesModalFocusableElements() {
@@ -4753,6 +4761,107 @@ function setLiveButtonState(active) {
   dom.liveToggle.textContent = active ? "Stop Stream" : "Live Stream";
 }
 
+function setLiveToggleDisabled(disabled, reason = "") {
+  if (!dom.liveToggle) {
+    return;
+  }
+  const nextDisabled = Boolean(disabled);
+  if (dom.liveToggle.disabled !== nextDisabled) {
+    dom.liveToggle.disabled = nextDisabled;
+  }
+  if (nextDisabled) {
+    if (reason) {
+      dom.liveToggle.title = reason;
+    } else {
+      dom.liveToggle.removeAttribute("title");
+    }
+    dom.liveToggle.setAttribute("aria-disabled", "true");
+  } else {
+    dom.liveToggle.removeAttribute("title");
+    dom.liveToggle.removeAttribute("aria-disabled");
+  }
+}
+
+function updateLiveToggleAvailabilityFromServices() {
+  if (!dom.liveToggle) {
+    return;
+  }
+
+  const service = servicesState.items.find(
+    (entry) => entry && entry.unit === VOICE_RECORDER_SERVICE_UNIT,
+  );
+  if (!service) {
+    if (servicesState.items.length > 0) {
+      setLiveToggleDisabled(true, "Recorder service unavailable.");
+      if (liveState.open) {
+        closeLiveStreamPanel();
+      }
+    }
+    return;
+  }
+
+  const pending = servicesState.pending.has(service.unit);
+  const available = service.available !== false;
+  const active = service.is_active === true;
+
+  let disabled = false;
+  let reason = "";
+
+  if (pending) {
+    disabled = true;
+    reason = "Recorder service changing state.";
+  } else if (!available) {
+    disabled = true;
+    reason = service.error || "Recorder service unavailable.";
+  } else if (!active) {
+    disabled = true;
+    reason = "Recorder service is stopped.";
+  }
+
+  setLiveToggleDisabled(disabled, reason);
+  if (disabled && liveState.open) {
+    closeLiveStreamPanel();
+  }
+}
+
+function refreshRecorderServiceStatus() {
+  if (!dom.liveToggle) {
+    return;
+  }
+  if (document.visibilityState === "hidden") {
+    return;
+  }
+  if (servicesDialogState.open) {
+    return;
+  }
+  if (servicesState.fetchInFlight) {
+    return;
+  }
+  fetchServices({ silent: true });
+}
+
+function startRecorderServiceMonitor() {
+  if (!dom.liveToggle) {
+    return;
+  }
+  if (recorderServiceMonitor.timerId) {
+    return;
+  }
+  refreshRecorderServiceStatus();
+  recorderServiceMonitor.timerId = window.setInterval(
+    refreshRecorderServiceStatus,
+    RECORDER_SERVICE_REFRESH_INTERVAL_MS,
+  );
+}
+
+function stopRecorderServiceMonitor() {
+  if (!recorderServiceMonitor.timerId) {
+    return;
+  }
+  window.clearInterval(recorderServiceMonitor.timerId);
+  recorderServiceMonitor.timerId = null;
+}
+
 function attachLiveStreamSource() {
   if (!dom.liveAudio) {
     return;
@@ -5254,6 +5363,7 @@ function attachEventListeners() {
   window.addEventListener("beforeunload", () => {
     stopAutoRefresh();
     stopServicesRefresh();
+    stopRecorderServiceMonitor();
     if (liveState.open || liveState.active) {
       stopLiveStream({ sendSignal: true, useBeacon: true });
     }
@@ -5262,6 +5372,7 @@ function attachEventListeners() {
   window.addEventListener("pagehide", () => {
     stopAutoRefresh();
     stopServicesRefresh();
+    stopRecorderServiceMonitor();
     if (liveState.open || liveState.active) {
       stopLiveStream({ sendSignal: true, useBeacon: true });
     }
@@ -5271,6 +5382,7 @@ function attachEventListeners() {
     if (document.visibilityState === "hidden") {
       stopAutoRefresh();
       stopServicesRefresh();
+      stopRecorderServiceMonitor();
       if (liveState.open) {
         cancelLiveStats();
         sendStop(false);
@@ -5281,6 +5393,7 @@ function attachEventListeners() {
     } else {
       startAutoRefresh();
       startServicesRefresh();
+      startRecorderServiceMonitor();
       if (liveState.open && liveState.active) {
         scheduleLiveStats();
         sendStart();
@@ -5323,6 +5436,7 @@ function initialize() {
   fetchRecordings({ silent: false });
   fetchConfig();
   startAutoRefresh();
+  startRecorderServiceMonitor();
 }
 
 if (document.readyState === "loading") {

--- a/lib/webui/static/js/dashboard.js
+++ b/lib/webui/static/js/dashboard.js
@@ -59,7 +59,6 @@ const SERVICES_ENDPOINT = apiPath("/api/services");
 const SERVICE_REFRESH_INTERVAL_MS = 5000;
 const SERVICE_RESULT_TTL_MS = 15000;
 const VOICE_RECORDER_SERVICE_UNIT = "voice-recorder.service";
-const RECORDER_SERVICE_REFRESH_INTERVAL_MS = 10000;
 const SESSION_STORAGE_KEY = "tricorder.session";
 const WINDOW_NAME_PREFIX = "tricorder.session:";
 
@@ -354,9 +353,6 @@ const servicesDialogState = {
   keydownHandler: null,
 };
 
-const recorderServiceMonitor = {
-  timerId: null,
-};
 
 const connectionState = {
   offline: false,
@@ -4791,11 +4787,17 @@ function updateLiveToggleAvailabilityFromServices() {
     (entry) => entry && entry.unit === VOICE_RECORDER_SERVICE_UNIT,
   );
   if (!service) {
+    let reason = "Recorder service status unavailable.";
     if (servicesState.items.length > 0) {
-      setLiveToggleDisabled(true, "Recorder service unavailable.");
-      if (liveState.open) {
-        closeLiveStreamPanel();
-      }
+      reason = "Recorder service unavailable.";
+    } else if (servicesState.error) {
+      reason = servicesState.error;
+    } else if (servicesState.fetchInFlight) {
+      reason = "Checking recorder service status…";
+    }
+    setLiveToggleDisabled(true, reason);
+    if (liveState.open) {
+      closeLiveStreamPanel();
     }
     return;
   }
@@ -4822,44 +4824,6 @@ function updateLiveToggleAvailabilityFromServices() {
   if (disabled && liveState.open) {
     closeLiveStreamPanel();
   }
-}
-
-function refreshRecorderServiceStatus() {
-  if (!dom.liveToggle) {
-    return;
-  }
-  if (document.visibilityState === "hidden") {
-    return;
-  }
-  if (servicesDialogState.open) {
-    return;
-  }
-  if (servicesState.fetchInFlight) {
-    return;
-  }
-  fetchServices({ silent: true });
-}
-
-function startRecorderServiceMonitor() {
-  if (!dom.liveToggle) {
-    return;
-  }
-  if (recorderServiceMonitor.timerId) {
-    return;
-  }
-  refreshRecorderServiceStatus();
-  recorderServiceMonitor.timerId = window.setInterval(
-    refreshRecorderServiceStatus,
-    RECORDER_SERVICE_REFRESH_INTERVAL_MS,
-  );
-}
-
-function stopRecorderServiceMonitor() {
-  if (!recorderServiceMonitor.timerId) {
-    return;
-  }
-  window.clearInterval(recorderServiceMonitor.timerId);
-  recorderServiceMonitor.timerId = null;
 }
 
 function attachLiveStreamSource() {
@@ -5363,7 +5327,6 @@ function attachEventListeners() {
   window.addEventListener("beforeunload", () => {
     stopAutoRefresh();
     stopServicesRefresh();
-    stopRecorderServiceMonitor();
     if (liveState.open || liveState.active) {
       stopLiveStream({ sendSignal: true, useBeacon: true });
     }
@@ -5372,7 +5335,6 @@ function attachEventListeners() {
   window.addEventListener("pagehide", () => {
     stopAutoRefresh();
     stopServicesRefresh();
-    stopRecorderServiceMonitor();
     if (liveState.open || liveState.active) {
       stopLiveStream({ sendSignal: true, useBeacon: true });
     }
@@ -5382,7 +5344,6 @@ function attachEventListeners() {
     if (document.visibilityState === "hidden") {
       stopAutoRefresh();
       stopServicesRefresh();
-      stopRecorderServiceMonitor();
       if (liveState.open) {
         cancelLiveStats();
         sendStop(false);
@@ -5393,7 +5354,7 @@ function attachEventListeners() {
     } else {
       startAutoRefresh();
       startServicesRefresh();
-      startRecorderServiceMonitor();
+      fetchServices({ silent: true });
       if (liveState.open && liveState.active) {
         scheduleLiveStats();
         sendStart();
@@ -5431,12 +5392,13 @@ function initialize() {
   setRefreshIndicatorVisible(false);
   setLiveButtonState(false);
   setLiveStatus("Idle");
+  setLiveToggleDisabled(true, "Checking recorder service status…");
   setServicesModalVisible(false);
   attachEventListeners();
   fetchRecordings({ silent: false });
   fetchConfig();
+  fetchServices({ silent: true });
   startAutoRefresh();
-  startRecorderServiceMonitor();
 }
 
 if (document.readyState === "loading") {


### PR DESCRIPTION
## Summary
- poll the services endpoint in the dashboard to detect the voice-recorder unit state
- disable the Live Stream button and close the panel when the recorder service is stopped or unavailable

## Testing
- pytest tests/test_37_web_dashboard.py

------
https://chatgpt.com/codex/tasks/task_e_68d6174e59d883278d86b47cbbd2efa2