### PR TITLE
Handle SD card monitor persistence errors on read-only media

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -16,7 +16,7 @@ SYSTEMD_DIR="/etc/systemd/system"
 PY_VER=$(python3 -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")')
 SITE=$VENV/lib/python$PY_VER/site-packages
 
-UNITS=(voice-recorder.service web-streamer.service dropbox.service dropbox.path tmpfs-guard.service tmpfs-guard.timer tricorder-auto-update.service tricorder-auto-update.timer tricorder.target)
+UNITS=(voice-recorder.service web-streamer.service sd-card-monitor.service dropbox.service dropbox.path tmpfs-guard.service tmpfs-guard.timer tricorder-auto-update.service tricorder-auto-update.timer tricorder.target)
 
 say(){ echo "[Tricorder] $*"; }
 
@@ -174,7 +174,7 @@ fi
 if [[ "${DEV:-0}" != "1" ]]; then
   say "Enable, reload, and restart Systemd units"
   sudo systemctl daemon-reload
-  for unit in voice-recorder.service web-streamer.service dropbox.service tmpfs-guard.service tricorder-auto-update.service; do
+  for unit in voice-recorder.service web-streamer.service sd-card-monitor.service dropbox.service tmpfs-guard.service tricorder-auto-update.service; do
       sudo systemctl enable "$unit" || true
   done
   for timer in tmpfs-guard.timer tricorder-auto-update.timer; do

--- a/lib/__init__.py
+++ b/lib/__init__.py
@@ -1,6 +1,8 @@
 __all__ = [
-    'fault_handler',
-    'live_stream_daemon',
-    'process_dropped_file',
-    'segmenter',
+    "fault_handler",
+    "live_stream_daemon",
+    "process_dropped_file",
+    "segmenter",
+    "sd_card_health",
+    "sd_card_monitor",
 ]

--- a/lib/sd_card_health.py
+++ b/lib/sd_card_health.py
@@ -1,0 +1,287 @@
+#!/usr/bin/env python3
+"""Persistent SD card health state helpers.
+
+This module centralises state management for the SD card warning feature. It is
+used by the long-running monitor daemon and the web UI to read and persist the
+"SD card failure" flag. The state is intentionally stored in a small JSON file
+under ``/apps/tricorder/state`` so it survives reboots and service restarts.
+
+The helpers here avoid any concurrency primitives; writers atomically replace
+the state file to keep updates crash-safe. Callers should rely on
+``sync_cid`` to capture the current CID baseline and ``register_failure`` to
+record new fault events.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+import json
+import os
+from pathlib import Path
+from typing import Any, Dict, Tuple
+
+__all__ = [
+    "CID_PATH",
+    "STATE_PATH",
+    "VOLATILE_STATE_PATH",
+    "load_state",
+    "register_failure",
+    "reset_state",
+    "state_summary",
+    "sync_cid",
+    "write_state",
+]
+
+
+BASE_DIR = Path("/apps/tricorder")
+STATE_DIR = BASE_DIR / "state"
+STATE_PATH = STATE_DIR / "sd_card_health.json"
+VOLATILE_STATE_DIR = Path("/run/tricorder")
+VOLATILE_STATE_PATH = VOLATILE_STATE_DIR / "sd_card_health.json"
+CID_PATH = Path("/sys/block/mmcblk0/device/cid")
+
+_DEFAULT_STATE: Dict[str, Any] = {
+    "cid": "",
+    "warning_active": False,
+    "first_detected_at": None,
+    "first_detected_ts": None,
+    "last_event": None,
+    "updated_at": None,
+}
+
+_MAX_MESSAGE_LENGTH = 512
+
+
+@dataclass
+class SyncResult:
+    """Return structure for :func:`sync_cid` operations."""
+
+    state: Dict[str, Any]
+    status: str
+
+
+def _ensure_directory(path: Path) -> None:
+    directory = path.parent
+    directory.mkdir(parents=True, exist_ok=True)
+
+
+def _isoformat(ts: float | None = None) -> str:
+    value = ts if ts is not None else datetime.now(timezone.utc).timestamp()
+    return datetime.fromtimestamp(value, tz=timezone.utc).isoformat(timespec="seconds")
+
+
+def _truncate_message(message: str) -> str:
+    cleaned = message.strip()
+    if len(cleaned) <= _MAX_MESSAGE_LENGTH:
+        return cleaned
+    return cleaned[: _MAX_MESSAGE_LENGTH - 1].rstrip() + "…"
+
+
+def _normalise_state(raw: Dict[str, Any] | None) -> Dict[str, Any]:
+    state: Dict[str, Any] = dict(_DEFAULT_STATE)
+    if isinstance(raw, dict):
+        for key, value in raw.items():
+            if key in state:
+                state[key] = value
+
+    if not isinstance(state.get("cid"), str):
+        state["cid"] = ""
+    state["warning_active"] = bool(state.get("warning_active"))
+
+    first_detected = state.get("first_detected_at")
+    if isinstance(first_detected, str) and first_detected:
+        state["first_detected_at"] = first_detected
+    else:
+        state["first_detected_at"] = None
+
+    first_detected_ts = state.get("first_detected_ts")
+    if isinstance(first_detected_ts, (int, float)):
+        state["first_detected_ts"] = float(first_detected_ts)
+    else:
+        state["first_detected_ts"] = None
+
+    last_event = state.get("last_event")
+    if isinstance(last_event, dict):
+        event: Dict[str, Any] = {}
+        timestamp = last_event.get("timestamp")
+        if isinstance(timestamp, str) and timestamp:
+            event["timestamp"] = timestamp
+        message = last_event.get("message")
+        if isinstance(message, str) and message:
+            event["message"] = _truncate_message(message)
+        pattern = last_event.get("pattern")
+        if isinstance(pattern, str) and pattern:
+            event["pattern"] = pattern
+        state["last_event"] = event if event else None
+    else:
+        state["last_event"] = None
+
+    updated_at = state.get("updated_at")
+    if isinstance(updated_at, str) and updated_at:
+        state["updated_at"] = updated_at
+    else:
+        state["updated_at"] = None
+
+    return state
+
+
+def load_state(
+    state_path: Path | None = None,
+    *,
+    fallback_path: Path | None = None,
+) -> Dict[str, Any]:
+    """Load the persisted SD card health state.
+
+    When the main state file cannot be read (for example, the SD card flips to
+    read-only), the loader falls back to the volatile state file living on the
+    RAM-backed ``/run`` filesystem. Callers can override the fallback via
+    ``fallback_path`` when working with temporary directories in tests.
+    """
+
+    primary = Path(state_path) if state_path else STATE_PATH
+    fallback = Path(fallback_path) if fallback_path else VOLATILE_STATE_PATH
+    candidates = [primary]
+    if fallback and fallback != primary:
+        candidates.append(fallback)
+
+    for target in candidates:
+        try:
+            with target.open("r", encoding="utf-8") as handle:
+                data = json.load(handle)
+        except FileNotFoundError:
+            continue
+        except json.JSONDecodeError:
+            continue
+        except OSError:
+            continue
+        return _normalise_state(data)
+
+    return dict(_DEFAULT_STATE)
+
+
+def _store_state(state: Dict[str, Any], state_path: Path | None = None) -> None:
+    target = Path(state_path) if state_path else STATE_PATH
+    _ensure_directory(target)
+    tmp_path = target.with_suffix(".tmp")
+    with tmp_path.open("w", encoding="utf-8") as handle:
+        json.dump(state, handle, indent=2, sort_keys=True)
+        handle.write("\n")
+    os.replace(tmp_path, target)
+
+
+def reset_state(new_cid: str, state_path: Path | None = None) -> Dict[str, Any]:
+    """Return a cleared state for a freshly detected SD card."""
+
+    now = datetime.now(timezone.utc).timestamp()
+    state = dict(_DEFAULT_STATE)
+    state["cid"] = new_cid
+    state["updated_at"] = _isoformat(now)
+    _store_state(state, state_path)
+    return state
+
+
+def sync_cid(current_cid: str | None, state_path: Path | None = None) -> SyncResult:
+    """Ensure the persisted state matches the current CID.
+
+    Returns ``SyncResult`` where ``status`` is one of:
+
+    - ``"missing"`` – CID unreadable (no state change).
+    - ``"initialised"`` – baseline persisted for the first time.
+    - ``"replaced"`` – CID changed, warning cleared.
+    - ``"unchanged"`` – CID matches the persisted baseline.
+    """
+
+    state = load_state(state_path)
+    cid = (current_cid or "").strip()
+    if not cid:
+        return SyncResult(state=state, status="missing")
+
+    stored_cid = state.get("cid") or ""
+    if not stored_cid:
+        state["cid"] = cid
+        now = datetime.now(timezone.utc).timestamp()
+        state["updated_at"] = _isoformat(now)
+        _store_state(state, state_path)
+        return SyncResult(state=state, status="initialised")
+
+    if stored_cid != cid:
+        state = reset_state(cid, state_path)
+        return SyncResult(state=state, status="replaced")
+
+    return SyncResult(state=state, status="unchanged")
+
+
+def register_failure(
+    message: str,
+    pattern: str,
+    state_path: Path | None = None,
+) -> Tuple[Dict[str, Any], bool]:
+    """Record a failure event and set the persistent warning flag.
+
+    Returns a tuple ``(state, changed)`` where ``changed`` signals whether the
+    on-disk representation was updated.
+    """
+
+    state = load_state(state_path)
+    now_ts = datetime.now(timezone.utc).timestamp()
+    now_iso = _isoformat(now_ts)
+    truncated = _truncate_message(message)
+
+    changed = False
+    if not state.get("warning_active"):
+        state["warning_active"] = True
+        state["first_detected_at"] = now_iso
+        state["first_detected_ts"] = now_ts
+        changed = True
+    elif not state.get("first_detected_at"):
+        state["first_detected_at"] = now_iso
+        state["first_detected_ts"] = now_ts
+        changed = True
+
+    new_event = {
+        "timestamp": now_iso,
+        "message": truncated,
+        "pattern": pattern,
+    }
+
+    if state.get("last_event") != new_event:
+        changed = True
+    state["last_event"] = new_event
+    state["updated_at"] = now_iso
+
+    _store_state(state, state_path)
+    return state, changed
+
+
+def state_summary(state: Dict[str, Any] | None = None) -> Dict[str, Any]:
+    """Prepare a state payload safe for JSON responses."""
+
+    normalised = _normalise_state(state)
+    summary: Dict[str, Any] = {
+        "cid": normalised.get("cid", ""),
+        "warning_active": bool(normalised.get("warning_active")),
+        "first_detected_at": normalised.get("first_detected_at"),
+        "first_detected_ts": normalised.get("first_detected_ts"),
+        "updated_at": normalised.get("updated_at"),
+        "has_baseline": bool(normalised.get("cid")),
+    }
+
+    last_event = normalised.get("last_event")
+    if isinstance(last_event, dict) and last_event:
+        summary["last_event"] = {
+            "timestamp": last_event.get("timestamp"),
+            "message": last_event.get("message"),
+            "pattern": last_event.get("pattern"),
+        }
+    else:
+        summary["last_event"] = None
+
+    return summary
+
+
+def write_state(state: Dict[str, Any], state_path: Path | None = None) -> None:
+    """Persist a precomputed state mapping atomically."""
+
+    normalised = _normalise_state(state)
+    _store_state(normalised, state_path)

--- a/lib/sd_card_monitor.py
+++ b/lib/sd_card_monitor.py
@@ -1,0 +1,315 @@
+#!/usr/bin/env python3
+"""SD card health monitor service.
+
+This module is intended to run under systemd. It periodically scans the system
+journal for kernel/storage errors and persists a warning flag through
+``lib.sd_card_health``. The warning remains active until the SD card's CID
+changes, indicating the card has been replaced.
+"""
+
+from __future__ import annotations
+
+import argparse
+import signal
+import subprocess
+import sys
+import threading
+import time
+import re
+from pathlib import Path
+from typing import Iterable, List
+
+from lib import sd_card_health
+
+
+class SdCardMonitor:
+    """Background monitor that inspects system logs for SD card faults."""
+
+    JOURNAL_BASE = [
+        "journalctl",
+        "--system",
+        "--no-pager",
+        "--output=cat",
+        "--quiet",
+        "--priority=3",
+    ]
+
+    PATTERNS: List[tuple[str, re.Pattern[str]]] = [
+        ("io_error", re.compile(r"\bio error\b", re.IGNORECASE)),
+        ("crc_error", re.compile(r"\bcrc\b.*\berror\b", re.IGNORECASE)),
+        (
+            "readonly_remount",
+            re.compile(r"\b(remount|mounting).*read-?only\b|\bread-?only\b.*remount", re.IGNORECASE),
+        ),
+    ]
+
+    def __init__(
+        self,
+        poll_interval: float = 30.0,
+        since_slack: float = 2.0,
+        state_path: Path | None = None,
+        cid_path: Path | None = None,
+        volatile_state_path: Path | None = None,
+    ) -> None:
+        self.poll_interval = max(5.0, float(poll_interval))
+        self.since_slack = max(0.0, float(since_slack))
+        self.state_path = Path(state_path) if state_path else sd_card_health.STATE_PATH
+        self.cid_path = Path(cid_path) if cid_path else sd_card_health.CID_PATH
+        self.volatile_state_path = (
+            Path(volatile_state_path)
+            if volatile_state_path
+            else sd_card_health.VOLATILE_STATE_PATH
+        )
+        self.stop_event = threading.Event()
+        self._last_checked: float | None = None
+        self._journal_available = True
+        self._cid_missing_logged = False
+        self._volatile_active = False
+
+    def _log(self, message: str) -> None:
+        print(f"[sd-card-monitor] {message}", flush=True)
+
+    def _read_cid(self) -> str | None:
+        try:
+            text = self.cid_path.read_text(encoding="utf-8", errors="ignore")
+        except FileNotFoundError:
+            self._log(f"CID path missing: {self.cid_path}")
+            return None
+        except OSError as exc:
+            self._log(f"Failed to read CID: {exc}")
+            return None
+        cid = text.strip()
+        return cid or None
+
+    def _clear_volatile_state(self) -> None:
+        if not self.volatile_state_path:
+            self._volatile_active = False
+            return
+        if self.volatile_state_path == self.state_path:
+            self._volatile_active = False
+            return
+        try:
+            self.volatile_state_path.unlink()
+        except FileNotFoundError:
+            self._volatile_active = False
+            return
+        except OSError as exc:
+            self._log(f"Unable to remove volatile SD card state: {exc}")
+        else:
+            self._log("Cleared volatile SD card warning cache")
+        finally:
+            self._volatile_active = False
+
+    def _migrate_volatile_state(self) -> None:
+        if not self._volatile_active:
+            return
+        if not self.volatile_state_path or self.volatile_state_path == self.state_path:
+            self._volatile_active = False
+            return
+        if not self.volatile_state_path.exists():
+            self._volatile_active = False
+            return
+
+        state = sd_card_health.load_state(
+            state_path=self.volatile_state_path,
+            fallback_path=self.volatile_state_path,
+        )
+        try:
+            sd_card_health.write_state(state, self.state_path)
+        except OSError as exc:
+            self._log(f"Failed to migrate volatile SD card state: {exc}")
+            return
+        self._clear_volatile_state()
+
+    def _sync_cid(self) -> None:
+        cid = self._read_cid()
+        try:
+            result = sd_card_health.sync_cid(cid, self.state_path)
+        except OSError as exc:
+            self._log(
+                "Failed to persist SD card CID baseline: "
+                f"{exc}; using volatile cache"
+            )
+            try:
+                result = sd_card_health.sync_cid(cid, self.volatile_state_path)
+            except OSError as fallback_exc:
+                self._log(
+                    "Unable to persist SD card CID baseline in volatile cache: "
+                    f"{fallback_exc}"
+                )
+                self._volatile_active = True
+                return
+            self._volatile_active = True
+        else:
+            if self._volatile_active:
+                self._migrate_volatile_state()
+        if result.status == "missing":
+            if not self._cid_missing_logged:
+                self._log("Unable to read SD card CID; monitoring continues")
+                self._cid_missing_logged = True
+        elif result.status == "initialised":
+            self._cid_missing_logged = False
+            self._log("Stored SD card CID baseline")
+        elif result.status == "replaced":
+            self._cid_missing_logged = False
+            self._log("Detected SD card replacement; warning state cleared")
+            if self._volatile_active:
+                self._clear_volatile_state()
+        else:
+            self._cid_missing_logged = False
+            self._log("CID baseline verified")
+
+    def _execute_journal(self, since: float | str | None) -> Iterable[str]:
+        if not self._journal_available:
+            return []
+
+        args = list(self.JOURNAL_BASE)
+        if since == "boot":
+            args.extend(["--since", "boot"])
+        elif isinstance(since, (int, float)):
+            threshold = max(0.0, since - self.since_slack)
+            args.extend(["--since", f"@{threshold:.0f}"])
+        else:
+            args.extend(["--since", "now"])
+
+        try:
+            proc = subprocess.run(
+                args,
+                capture_output=True,
+                text=True,
+                check=False,
+                timeout=25,
+            )
+        except FileNotFoundError:
+            self._journal_available = False
+            self._log("journalctl not found; SD card monitoring disabled")
+            return []
+        except subprocess.SubprocessError as exc:
+            self._log(f"journalctl invocation failed: {exc}")
+            return []
+
+        if proc.returncode not in (0, 1):
+            stderr = (proc.stderr or "").strip()
+            self._log(f"journalctl returned {proc.returncode}: {stderr}")
+            return []
+
+        return (line for line in (proc.stdout or "").splitlines() if line.strip())
+
+    def _scan_logs(self, initial: bool = False) -> None:
+        if initial or self._last_checked is None:
+            since: float | str | None = "boot"
+        else:
+            since = self._last_checked
+
+        lines = self._execute_journal(since)
+        matched = False
+        for line in lines:
+            if self._process_line(line):
+                matched = True
+
+        now = time.time()
+        self._last_checked = now
+        if matched:
+            self._log("Warning flag asserted from log scan")
+
+    def _process_line(self, line: str) -> bool:
+        for pattern_name, regex in self.PATTERNS:
+            if regex.search(line):
+                try:
+                    _, changed = sd_card_health.register_failure(
+                        message=line,
+                        pattern=pattern_name,
+                        state_path=self.state_path,
+                    )
+                except OSError as exc:
+                    self._log(
+                        "Failed to persist SD card warning: "
+                        f"{exc}; using volatile cache"
+                    )
+                    try:
+                        _, changed = sd_card_health.register_failure(
+                            message=line,
+                            pattern=pattern_name,
+                            state_path=self.volatile_state_path,
+                        )
+                    except OSError as volatile_exc:
+                        self._log(
+                            "Unable to persist SD card warning in volatile cache: "
+                            f"{volatile_exc}"
+                        )
+                        self._volatile_active = True
+                        return False
+                    self._volatile_active = True
+                    if changed:
+                        self._log(
+                            "Recorded SD card warning "
+                            f"({pattern_name}) via volatile cache"
+                        )
+                    return changed
+                else:
+                    if self._volatile_active:
+                        self._clear_volatile_state()
+                    if changed:
+                        self._log(f"Recorded SD card warning ({pattern_name})")
+                    return changed
+        return False
+
+    def _handle_signal(self, signum: int, _: object) -> None:
+        self._log(f"Received signal {signum}; shutting down")
+        self.stop_event.set()
+
+    def run(self) -> int:
+        for sig in (signal.SIGINT, signal.SIGTERM):
+            try:
+                signal.signal(sig, self._handle_signal)
+            except Exception:
+                # Signal registration can fail in non-main threads/tests.
+                pass
+
+        self._log("Starting SD card monitor")
+        self._sync_cid()
+        self._scan_logs(initial=True)
+
+        while not self.stop_event.wait(self.poll_interval):
+            self._sync_cid()
+            self._scan_logs()
+
+        self._log("Monitor exiting")
+        return 0
+
+
+def parse_args(argv: Iterable[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="SD card health monitor")
+    parser.add_argument(
+        "--poll-interval",
+        type=float,
+        default=30.0,
+        help="Polling interval in seconds (default: 30)",
+    )
+    parser.add_argument(
+        "--state-path",
+        type=Path,
+        default=sd_card_health.STATE_PATH,
+        help="Override path to sd_card_health.json",
+    )
+    parser.add_argument(
+        "--cid-path",
+        type=Path,
+        default=sd_card_health.CID_PATH,
+        help="Override CID sysfs path",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Iterable[str] | None = None) -> int:
+    args = parse_args(argv or sys.argv[1:])
+    monitor = SdCardMonitor(
+        poll_interval=args.poll_interval,
+        state_path=args.state_path,
+        cid_path=args.cid_path,
+    )
+    return monitor.run()
+
+
+if __name__ == "__main__":  # pragma: no cover - manual execution path
+    raise SystemExit(main())

--- a/lib/webui/static/css/dashboard.css
+++ b/lib/webui/static/css/dashboard.css
@@ -38,6 +38,81 @@ body {
   margin: 0 auto;
 }
 
+.system-banner {
+  display: none;
+  align-items: flex-start;
+  gap: 1rem;
+  padding: 1rem 1.25rem;
+  border-radius: 0.75rem;
+  border: 1px solid rgba(248, 113, 113, 0.35);
+  background: rgba(127, 29, 29, 0.42);
+  box-shadow: 0 18px 40px -26px rgba(248, 113, 113, 0.55);
+  backdrop-filter: blur(10px);
+  color: #fee2e2;
+  line-height: 1.35;
+}
+
+.system-banner[data-visible="true"] {
+  display: flex;
+}
+
+.system-banner .banner-icon {
+  flex-shrink: 0;
+  width: 2.5rem;
+  height: 2.5rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 999px;
+  background: rgba(248, 113, 113, 0.15);
+  border: 1px solid rgba(248, 113, 113, 0.45);
+  font-weight: 700;
+  font-size: 1.4rem;
+}
+
+.system-banner .banner-body {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+}
+
+.system-banner .banner-title {
+  margin: 0;
+  font-size: 1.05rem;
+  letter-spacing: 0.03em;
+}
+
+.system-banner .banner-message {
+  margin: 0;
+  font-size: 0.95rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.system-banner .banner-link {
+  color: #bae6fd;
+  font-weight: 600;
+  text-decoration: underline;
+  width: fit-content;
+}
+
+.system-banner .banner-link:hover {
+  color: #f8fafc;
+}
+
+.system-banner .banner-link:focus-visible {
+  outline: 2px solid rgba(191, 219, 254, 0.9);
+  outline-offset: 2px;
+  border-radius: 0.25rem;
+}
+
+.system-banner .banner-detail {
+  margin: 0;
+  font-size: 0.85rem;
+  color: rgba(254, 226, 226, 0.85);
+}
+
 .app-header {
   display: flex;
   justify-content: space-between;

--- a/lib/webui/static/docs/sd-card-recovery.html
+++ b/lib/webui/static/docs/sd-card-recovery.html
@@ -1,0 +1,149 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Clone and Replace the Recorder SD Card</title>
+    <style>
+      :root {
+        color-scheme: light dark;
+      }
+      body {
+        font-family: system-ui, -apple-system, "Segoe UI", sans-serif;
+        margin: 0 auto;
+        padding: 1.5rem clamp(1rem, 4vw, 3rem);
+        max-width: 60rem;
+        line-height: 1.6;
+        background: #0b111b;
+        color: #f8fafc;
+      }
+      h1,
+      h2,
+      h3 {
+        line-height: 1.2;
+        margin-top: 2rem;
+      }
+      h1 {
+        margin-top: 0;
+        font-size: clamp(2rem, 5vw, 2.8rem);
+      }
+      h2 {
+        font-size: clamp(1.4rem, 4vw, 1.9rem);
+      }
+      h3 {
+        font-size: clamp(1.2rem, 3vw, 1.4rem);
+      }
+      p,
+      li {
+        font-size: clamp(1rem, 3vw, 1.05rem);
+      }
+      code,
+      pre {
+        font-family: "JetBrains Mono", "Fira Code", "SFMono-Regular", monospace;
+      }
+      pre {
+        background: rgba(15, 23, 42, 0.85);
+        border-radius: 0.5rem;
+        padding: 1rem;
+        overflow-x: auto;
+      }
+      a {
+        color: #38bdf8;
+      }
+      .callout {
+        border-left: 0.35rem solid #f97316;
+        background: rgba(249, 115, 22, 0.12);
+        padding: 0.75rem 1rem;
+        border-radius: 0.5rem;
+        margin: 1.5rem 0;
+      }
+      ol {
+        padding-left: 1.25rem;
+      }
+      footer {
+        margin-top: 3rem;
+        font-size: 0.9rem;
+        color: rgba(248, 250, 252, 0.75);
+      }
+      @media (prefers-color-scheme: light) {
+        body {
+          background: #f9fafb;
+          color: #0f172a;
+        }
+        pre {
+          background: rgba(226, 232, 240, 0.7);
+        }
+        .callout {
+          background: rgba(251, 191, 36, 0.2);
+          color: #92400e;
+        }
+        footer {
+          color: rgba(15, 23, 42, 0.7);
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <h1>Clone and Replace the Recorder SD Card</h1>
+    <p>
+      This guide explains how to copy the recorder's SD card to a new card after a
+      hardware warning. The steps assume you have a Linux or macOS workstation
+      with an SD card reader. Commands use <code>sdX</code> as the source card and
+      <code>sdY</code> as the destination; substitute the actual device paths on
+      your workstation.
+    </p>
+
+    <div class="callout">
+      <strong>Important:</strong> The recorder must be shut down before you remove
+      its SD card. Removing a card from a running system can corrupt data.
+    </div>
+
+    <h2>1. Shut down and identify the failing card</h2>
+    <ol>
+      <li>Run <code>sudo shutdown -h now</code> on the recorder and wait for the LEDs to stop blinking.</li>
+      <li>Remove the card from the recorder and insert it into your workstation's reader.</li>
+      <li>Run <code>lsblk</code> (Linux) or <code>diskutil list</code> (macOS) to identify the device name for the failing card.</li>
+    </ol>
+
+    <h2>2. Insert the replacement card</h2>
+    <ol>
+      <li>Insert the new SD card into the reader. It must be equal or larger in capacity.</li>
+      <li>Use <code>lsblk</code> or <code>diskutil list</code> again to confirm the device name. Double-check the mapping; the next step will overwrite the destination card completely.</li>
+      <li>If the new card has existing partitions mounted, unmount them (for example <code>sudo umount /dev/sdY*</code> on Linux).</li>
+    </ol>
+
+    <h2>3. Clone the card block-for-block</h2>
+    <p>
+      Use <code>dd</code> with a progress monitor to stream the failing card onto the new card. The <code>conv=fsync</code> flag makes sure buffers are flushed before the command exits.
+    </p>
+    <pre><code>sudo dd if=/dev/sdX of=/dev/sdY bs=4M status=progress conv=fsync</code></pre>
+    <p>
+      When the command finishes, run <code>sync</code> to flush any outstanding writes. Some cards need a few extra seconds before it is safe to remove them from the reader.
+    </p>
+
+    <h2>4. Expand the filesystem (optional)</h2>
+    <p>
+      If the replacement card is larger than the original, expand the filesystem so the recorder can use the extra space:</p>
+    <ul>
+      <li>Linux: run <code>sudo raspi-config --expand-rootfs</code> after the new card boots, or use <code>growpart</code> and <code>resize2fs</code>.</li>
+      <li>Raspberry Pi OS (Bookworm): the GUI imager's “Expand filesystem” option performs the same task on first boot.</li>
+    </ul>
+
+    <h2>5. Boot the recorder with the new card</h2>
+    <ol>
+      <li>Eject both cards from your workstation. Reinsert the cloned card into the recorder.</li>
+      <li>Power on the recorder. The dashboard warning banner clears automatically after it detects the new card's CID.</li>
+      <li>Verify that recordings resume and that the dashboard no longer shows the SD card warning after a refresh.</li>
+    </ol>
+
+    <h2>Troubleshooting</h2>
+    <ul>
+      <li>If <code>dd</code> reports read errors, retry with <code>ddrescue</code> for a more fault-tolerant copy. Document the command you used in case you need to re-run it.</li>
+      <li>If the recorder refuses to boot, re-image the new card with a fresh OS image and restore the <code>/recordings</code> and configuration files from backup.</li>
+    </ul>
+
+    <footer>
+      Static recovery instructions live at <code>/static/docs/sd-card-recovery.html</code> on the device.
+    </footer>
+  </body>
+</html>

--- a/lib/webui/static/js/dashboard.js
+++ b/lib/webui/static/js/dashboard.js
@@ -56,8 +56,10 @@ const START_ENDPOINT = apiPath("/hls/start");
 const STOP_ENDPOINT = apiPath("/hls/stop");
 const STATS_ENDPOINT = apiPath("/hls/stats");
 const SERVICES_ENDPOINT = apiPath("/api/services");
+const HEALTH_ENDPOINT = apiPath("/api/system-health");
 const SERVICE_REFRESH_INTERVAL_MS = 5000;
 const SERVICE_RESULT_TTL_MS = 15000;
+const HEALTH_REFRESH_INTERVAL_MS = 30000;
 const SESSION_STORAGE_KEY = "tricorder.session";
 const WINDOW_NAME_PREFIX = "tricorder.session:";
 
@@ -80,7 +82,15 @@ const state = {
   storage: { recordings: 0, total: null, free: null, diskUsed: null },
 };
 
+const healthState = {
+  sdCard: null,
+  lastUpdated: null,
+};
+
 const dom = {
+  systemBanner: document.getElementById("system-banner"),
+  systemBannerMessage: document.getElementById("system-banner-message"),
+  systemBannerDetail: document.getElementById("system-banner-detail"),
   recordingCount: document.getElementById("recording-count"),
   recordingCountMobile: document.getElementById("recording-count-mobile"),
   selectedCount: document.getElementById("selected-count"),
@@ -198,6 +208,148 @@ const timeFormatter = new Intl.DateTimeFormat(userLocales, {
 });
 
 let autoRefreshId = null;
+let healthRefreshId = null;
+let healthFetchInFlight = false;
+let healthFetchQueued = false;
+
+function formatIsoDateTime(isoString) {
+  if (typeof isoString !== "string" || !isoString) {
+    return null;
+  }
+  const date = new Date(isoString);
+  if (Number.isNaN(date.getTime())) {
+    return null;
+  }
+  try {
+    return dateFormatter.format(date);
+  } catch (error) {
+    console.warn("Unable to format ISO date", error);
+  }
+  return date.toISOString();
+}
+
+function setSystemBannerVisible(visible) {
+  if (!dom.systemBanner) {
+    return;
+  }
+  if (visible) {
+    dom.systemBanner.hidden = false;
+    dom.systemBanner.dataset.visible = "true";
+  } else {
+    dom.systemBanner.dataset.visible = "false";
+    dom.systemBanner.hidden = true;
+  }
+}
+
+function renderSdCardBanner() {
+  if (!dom.systemBanner || !dom.systemBannerMessage || !dom.systemBannerDetail) {
+    return;
+  }
+  const sdCard = healthState.sdCard;
+  if (!sdCard || sdCard.warning_active !== true) {
+    setSystemBannerVisible(false);
+    dom.systemBannerDetail.textContent = "";
+    return;
+  }
+
+  setSystemBannerVisible(true);
+
+  const parts = [];
+  const event = sdCard.last_event;
+  if (event && typeof event === "object") {
+    const when = formatIsoDateTime(event.timestamp);
+    if (when) {
+      parts.push(`Last error ${when}`);
+    }
+    if (typeof event.message === "string" && event.message) {
+      parts.push(event.message);
+    }
+  } else {
+    const firstDetected = formatIsoDateTime(sdCard.first_detected_at);
+    if (firstDetected) {
+      parts.push(`Warning first detected ${firstDetected}`);
+    }
+  }
+
+  dom.systemBannerDetail.textContent = parts.join(" — ");
+}
+
+function applyHealthPayload(payload) {
+  if (!payload || typeof payload !== "object") {
+    healthState.sdCard = null;
+    healthState.lastUpdated = null;
+    renderSdCardBanner();
+    return;
+  }
+
+  if (typeof payload.generated_at === "number") {
+    healthState.lastUpdated = payload.generated_at;
+  }
+
+  const sdCard = payload.sd_card;
+  if (sdCard && typeof sdCard === "object") {
+    const normalised = {
+      warning_active: sdCard.warning_active === true,
+      first_detected_at:
+        typeof sdCard.first_detected_at === "string" ? sdCard.first_detected_at : null,
+      last_event: null,
+    };
+    if (sdCard.last_event && typeof sdCard.last_event === "object") {
+      normalised.last_event = {
+        timestamp:
+          typeof sdCard.last_event.timestamp === "string"
+            ? sdCard.last_event.timestamp
+            : null,
+        message:
+          typeof sdCard.last_event.message === "string"
+            ? sdCard.last_event.message
+            : "",
+      };
+    }
+    healthState.sdCard = normalised;
+  } else {
+    healthState.sdCard = null;
+  }
+
+  renderSdCardBanner();
+}
+
+async function fetchSystemHealth() {
+  if (healthFetchInFlight) {
+    healthFetchQueued = true;
+    return;
+  }
+  healthFetchInFlight = true;
+  try {
+    const response = await fetch(HEALTH_ENDPOINT, { cache: "no-store" });
+    if (!response.ok) {
+      throw new Error(`System health request failed with ${response.status}`);
+    }
+    const payload = await response.json();
+    applyHealthPayload(payload);
+  } catch (error) {
+    console.error("Failed to fetch system health", error);
+  } finally {
+    healthFetchInFlight = false;
+    if (healthFetchQueued) {
+      healthFetchQueued = false;
+      fetchSystemHealth();
+    }
+  }
+}
+
+function startHealthRefresh() {
+  stopHealthRefresh();
+  fetchSystemHealth();
+  healthRefreshId = window.setInterval(fetchSystemHealth, HEALTH_REFRESH_INTERVAL_MS);
+}
+
+function stopHealthRefresh() {
+  if (healthRefreshId !== null) {
+    window.clearInterval(healthRefreshId);
+    healthRefreshId = null;
+  }
+}
 let autoRefreshIntervalMs = AUTO_REFRESH_INTERVAL_MS;
 let autoRefreshSuspended = false;
 let fetchInFlight = false;
@@ -5254,6 +5406,7 @@ function attachEventListeners() {
   window.addEventListener("beforeunload", () => {
     stopAutoRefresh();
     stopServicesRefresh();
+    stopHealthRefresh();
     if (liveState.open || liveState.active) {
       stopLiveStream({ sendSignal: true, useBeacon: true });
     }
@@ -5262,6 +5415,7 @@ function attachEventListeners() {
   window.addEventListener("pagehide", () => {
     stopAutoRefresh();
     stopServicesRefresh();
+    stopHealthRefresh();
     if (liveState.open || liveState.active) {
       stopLiveStream({ sendSignal: true, useBeacon: true });
     }
@@ -5271,6 +5425,7 @@ function attachEventListeners() {
     if (document.visibilityState === "hidden") {
       stopAutoRefresh();
       stopServicesRefresh();
+      stopHealthRefresh();
       if (liveState.open) {
         cancelLiveStats();
         sendStop(false);
@@ -5281,6 +5436,7 @@ function attachEventListeners() {
     } else {
       startAutoRefresh();
       startServicesRefresh();
+      startHealthRefresh();
       if (liveState.open && liveState.active) {
         scheduleLiveStats();
         sendStart();
@@ -5322,6 +5478,7 @@ function initialize() {
   attachEventListeners();
   fetchRecordings({ silent: false });
   fetchConfig();
+  startHealthRefresh();
   startAutoRefresh();
 }
 

--- a/lib/webui/templates/dashboard.html
+++ b/lib/webui/templates/dashboard.html
@@ -12,6 +12,34 @@
   </head>
   <body data-tricorder-api-base="{{ api_base | default('', true) }}">
     <div class="app-shell">
+      <div
+        id="system-banner"
+        class="system-banner"
+        role="alert"
+        aria-live="assertive"
+        hidden
+        data-visible="false"
+      >
+        <div class="banner-icon" aria-hidden="true">!</div>
+        <div class="banner-body">
+          <h2 class="banner-title">SD card warning</h2>
+          <p id="system-banner-message" class="banner-message">
+            <span>
+              Persistent SD card faults detected. Replace the card as soon as possible.
+            </span>
+            <a
+              id="system-banner-help"
+              class="banner-link"
+              href="{{ static_url('docs/sd-card-recovery.html') }}"
+              target="_blank"
+              rel="noopener"
+            >
+              How to clone and replace the SD card
+            </a>
+          </p>
+          <p id="system-banner-detail" class="banner-detail"></p>
+        </div>
+      </div>
       <header class="app-header">
         <div class="titles">
           <h1>Dashboard</h1>

--- a/systemd/sd-card-monitor.service
+++ b/systemd/sd-card-monitor.service
@@ -1,0 +1,19 @@
+[Unit]
+Description=Tricorder SD card health monitor
+After=network-online.target
+Wants=network-online.target
+PartOf=tricorder.target
+
+[Service]
+Type=simple
+Environment=PYTHONUNBUFFERED=1
+WorkingDirectory=/apps/tricorder
+ExecStart=/apps/tricorder/venv/bin/python -m lib.sd_card_monitor
+Restart=always
+RestartSec=5
+StandardOutput=journal
+StandardError=journal
+NoNewPrivileges=true
+
+[Install]
+WantedBy=multi-user.target

--- a/systemd/tricorder.target
+++ b/systemd/tricorder.target
@@ -1,6 +1,6 @@
 [Unit]
 Description=Tricorder Service Group
-Requires=voice-recorder.service web-streamer.service
+Requires=voice-recorder.service web-streamer.service sd-card-monitor.service
 Wants=tricorder-auto-update.timer tmpfs-guard.timer dropbox.path
 
 [Install]

--- a/tests/test_37_web_dashboard.py
+++ b/tests/test_37_web_dashboard.py
@@ -493,3 +493,20 @@ def test_service_action_auto_restart(monkeypatch, dashboard_env):
             await server.close()
 
     asyncio.run(runner())
+
+
+def test_sd_card_recovery_static_doc_served(dashboard_env):
+    async def runner():
+        app = web_streamer.build_app()
+        client, server = await _start_client(app)
+
+        try:
+            resp = await client.get("/static/docs/sd-card-recovery.html")
+            assert resp.status == 200
+            payload = await resp.text()
+            assert "Clone and Replace the Recorder SD Card" in payload
+        finally:
+            await client.close()
+            await server.close()
+
+    asyncio.run(runner())

--- a/tests/test_sd_card_health.py
+++ b/tests/test_sd_card_health.py
@@ -1,0 +1,91 @@
+from pathlib import Path
+
+from lib import sd_card_health
+
+
+def test_load_state_defaults(tmp_path):
+    state_path = tmp_path / "sd_state.json"
+    state = sd_card_health.load_state(state_path)
+    assert state["cid"] == ""
+    assert state["warning_active"] is False
+    assert state["last_event"] is None
+
+
+def test_register_failure_sets_warning(tmp_path):
+    state_path = tmp_path / "sd_state.json"
+    state, changed = sd_card_health.register_failure(
+        "mmcblk0: I/O error",
+        pattern="io_error",
+        state_path=state_path,
+    )
+    assert changed is True
+    assert state["warning_active"] is True
+    assert state["last_event"]["pattern"] == "io_error"
+    assert isinstance(state["first_detected_at"], str)
+
+    state_again, changed_again = sd_card_health.register_failure(
+        "mmcblk0: I/O error",
+        pattern="io_error",
+        state_path=state_path,
+    )
+    assert state_again["warning_active"] is True
+    assert state_again["last_event"]["timestamp"]
+
+
+def test_sync_cid_transitions(tmp_path):
+    state_path = tmp_path / "sd_state.json"
+
+    result_missing = sd_card_health.sync_cid(None, state_path)
+    assert result_missing.status == "missing"
+
+    result_init = sd_card_health.sync_cid("abcd", state_path)
+    assert result_init.status == "initialised"
+    assert result_init.state["cid"] == "abcd"
+
+    result_same = sd_card_health.sync_cid("abcd", state_path)
+    assert result_same.status == "unchanged"
+
+    state_after_warning, _ = sd_card_health.register_failure(
+        "crc error",
+        pattern="crc_error",
+        state_path=state_path,
+    )
+    assert state_after_warning["warning_active"] is True
+
+    result_replaced = sd_card_health.sync_cid("efgh", state_path)
+    assert result_replaced.status == "replaced"
+    assert result_replaced.state["cid"] == "efgh"
+    assert result_replaced.state["warning_active"] is False
+
+
+def test_state_summary_structure(tmp_path):
+    state_path = tmp_path / "sd_state.json"
+    sd_card_health.register_failure(
+        "read-only filesystem remount",
+        pattern="readonly_remount",
+        state_path=state_path,
+    )
+    summary = sd_card_health.state_summary(sd_card_health.load_state(state_path))
+    assert summary["warning_active"] is True
+    assert summary["last_event"]["pattern"] == "readonly_remount"
+    assert summary["has_baseline"] is False
+
+
+def test_load_state_uses_volatile_fallback(tmp_path, monkeypatch):
+    primary = tmp_path / "persist.json"
+    volatile_dir = tmp_path / "volatile"
+    volatile_dir.mkdir()
+    volatile = volatile_dir / "sd_card_health.json"
+
+    monkeypatch.setattr(sd_card_health, "VOLATILE_STATE_DIR", volatile_dir)
+    monkeypatch.setattr(sd_card_health, "VOLATILE_STATE_PATH", volatile)
+
+    sd_card_health.register_failure(
+        "mmcblk0: io error",
+        pattern="io_error",
+        state_path=volatile,
+    )
+
+    state = sd_card_health.load_state(state_path=primary)
+    assert state["warning_active"] is True
+    assert state["last_event"]["pattern"] == "io_error"

--- a/tests/test_sd_card_monitor.py
+++ b/tests/test_sd_card_monitor.py
@@ -1,0 +1,104 @@
+from pathlib import Path
+
+from lib import sd_card_health
+from lib.sd_card_monitor import SdCardMonitor
+
+
+def test_monitor_falls_back_to_volatile_on_persist_error(tmp_path, monkeypatch):
+    primary = tmp_path / "persist.json"
+    volatile = tmp_path / "volatile.json"
+    cid_path = tmp_path / "cid"
+    cid_path.write_text("abcd\n", encoding="utf-8")
+
+    monkeypatch.setattr(sd_card_health, "VOLATILE_STATE_DIR", volatile.parent)
+    monkeypatch.setattr(sd_card_health, "VOLATILE_STATE_PATH", volatile)
+
+    monitor = SdCardMonitor(
+        poll_interval=5,
+        state_path=primary,
+        cid_path=cid_path,
+        volatile_state_path=volatile,
+    )
+
+    original_store = sd_card_health._store_state
+
+    def flaky_store(state, state_path=None):
+        target = Path(state_path) if state_path else sd_card_health.STATE_PATH
+        if target == primary:
+            raise OSError("read-only")
+        return original_store(state, state_path)
+
+    monkeypatch.setattr(sd_card_health, "_store_state", flaky_store)
+
+    line = "kernel: mmcblk0: io error"
+    changed = monitor._process_line(line)
+    assert changed is True
+    assert volatile.exists()
+
+    fallback_state = sd_card_health.load_state(
+        state_path=primary,
+        fallback_path=volatile,
+    )
+    assert fallback_state["warning_active"] is True
+    assert fallback_state["last_event"]["pattern"] == "io_error"
+
+    monkeypatch.setattr(sd_card_health, "_store_state", original_store)
+
+    second_line = "kernel: mmcblk0: io error recovered"
+    changed_second = monitor._process_line(second_line)
+    assert changed_second is True
+    assert not volatile.exists()
+
+    persisted_state = sd_card_health.load_state(
+        state_path=primary,
+        fallback_path=volatile,
+    )
+    assert persisted_state["warning_active"] is True
+    assert persisted_state["last_event"]["message"].endswith("recovered")
+
+
+def test_sync_cid_uses_volatile_on_persist_error(tmp_path, monkeypatch):
+    primary = tmp_path / "persist.json"
+    volatile = tmp_path / "volatile.json"
+    cid_path = tmp_path / "cid"
+    cid_path.write_text("abcd\n", encoding="utf-8")
+
+    monkeypatch.setattr(sd_card_health, "VOLATILE_STATE_DIR", volatile.parent)
+    monkeypatch.setattr(sd_card_health, "VOLATILE_STATE_PATH", volatile)
+
+    monitor = SdCardMonitor(
+        poll_interval=5,
+        state_path=primary,
+        cid_path=cid_path,
+        volatile_state_path=volatile,
+    )
+
+    original_store = sd_card_health._store_state
+
+    def flaky_store(state, state_path=None):
+        target = Path(state_path) if state_path else sd_card_health.STATE_PATH
+        if target == primary:
+            raise OSError("read-only")
+        return original_store(state, state_path)
+
+    monkeypatch.setattr(sd_card_health, "_store_state", flaky_store)
+
+    monitor._sync_cid()
+    assert volatile.exists()
+
+    cached_state = sd_card_health.load_state(
+        state_path=primary,
+        fallback_path=volatile,
+    )
+    assert cached_state["cid"] == "abcd"
+
+    monkeypatch.setattr(sd_card_health, "_store_state", original_store)
+
+    monitor._sync_cid()
+    assert not volatile.exists()
+
+    persisted_state = sd_card_health.load_state(
+        state_path=primary,
+        fallback_path=volatile,
+    )
+    assert persisted_state["cid"] == "abcd"


### PR DESCRIPTION
## Summary
- add a volatile `/run/tricorder` fallback for sd card health state loading
- make the monitor catch write errors, persist warnings in the volatile cache, and migrate back once the card is writable again
- cover the new behaviour with targeted sd card health and monitor tests

## Testing
- pytest tests/test_sd_card_health.py tests/test_sd_card_monitor.py
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d61ae22cc48327ba7f542855c955b3