### PR TITLE
Handle gist creation failures in conflict workflow

### DIFF
--- a/.github/workflows/create-codex-resolve-pr-comment.yml
+++ b/.github/workflows/create-codex-resolve-pr-comment.yml
@@ -167,18 +167,30 @@ jobs:
                 GIST_PAYLOAD=$(jq -nc --arg name "$f" --arg content "$FILE_CONTENT" \
                   '{public:false, files:{($name):{content:$content}}}')
 
+                set +e
                 GIST_RESPONSE=$(curl -s -X POST \
                   -H "Authorization: token $REPO_PAT" \
                   -H "Content-Type: application/json" \
                   -d "$GIST_PAYLOAD" https://api.github.com/gists)
+                CURL_STATUS=$?
+                set -e
 
-                GIST_URL=$(echo "$GIST_RESPONSE" | jq -r '.html_url // empty')
-                if [[ -n "$GIST_URL" ]]; then
-                  GIST_LINES+="- **$f**: ${GIST_URL}\n"
-                  continue
+                if [[ $CURL_STATUS -eq 0 && -n "$GIST_RESPONSE" ]]; then
+                  set +e
+                  GIST_URL=$(printf '%s' "$GIST_RESPONSE" | jq -r '.html_url // empty')
+                  JQ_STATUS=$?
+                  set -e
+                  if [[ $JQ_STATUS -eq 0 && -n "$GIST_URL" ]]; then
+                    GIST_LINES+="- **$f**: ${GIST_URL}\n"
+                    continue
+                  fi
                 fi
 
-                echo "Failed to create gist for $f; falling back to inline snippet." >&2
+                if [[ $CURL_STATUS -ne 0 ]]; then
+                  echo "Failed to create gist for $f (curl exit $CURL_STATUS); falling back to inline snippet." >&2
+                else
+                  echo "Failed to create gist for $f; falling back to inline snippet." >&2
+                fi
               fi
 
               GIST_LINES+="$(emit_inline_reference "$f" "$MAX_INLINE")"


### PR DESCRIPTION
## Summary
- prevent the conflict comment workflow from failing when gist creation requests return errors
- fall back to inline snippets after logging failures so the workflow can still post merge conflict details

## Testing
- Not run (workflow change)


------
https://chatgpt.com/codex/tasks/task_e_68d6665eeb648327b289e15957d29f94