### PR TITLE
Sanitize gist filenames in conflict workflow

### DIFF
--- a/.github/workflows/create-codex-resolve-pr-comment.yml
+++ b/.github/workflows/create-codex-resolve-pr-comment.yml
@@ -182,7 +182,8 @@ jobs:
 
               if [[ "$USE_GISTS" -eq 1 ]]; then
                 # Create a private gist with the exact file content
-                GIST_PAYLOAD=$(jq -nc --arg name "$f" --arg content "$SNIPPET_CONTENT" \
+                GIST_NAME=${f//\//_}
+                GIST_PAYLOAD=$(jq -nc --arg name "$GIST_NAME" --arg content "$SNIPPET_CONTENT" \
                   '{public:false, files:{($name):{content:$content}}}')
 
                 set +e


### PR DESCRIPTION
## Summary
- derive a sanitized gist filename from each conflicted path before building the payload
- send the sanitized name to the gist creation request while keeping the original path for logging and labels

## Testing
- not run (not required)

------
https://chatgpt.com/codex/tasks/task_e_68d7f6e4e0cc83279422d19bda636ec9