### PR TITLE
Log gist API errors when gist creation fails

### DIFF
--- a/.github/workflows/create-codex-resolve-pr-comment.yml
+++ b/.github/workflows/create-codex-resolve-pr-comment.yml
@@ -207,7 +207,12 @@ jobs:
                 if [[ $CURL_STATUS -ne 0 ]]; then
                   echo "Failed to create gist for $f (curl exit $CURL_STATUS); falling back to inline snippet." >&2
                 else
-                  echo "Failed to create gist for $f; falling back to inline snippet." >&2
+                  if [[ -n "$GIST_RESPONSE" ]]; then
+                    GIST_ERRORS=$(printf '%s' "$GIST_RESPONSE" | jq -c '.errors // []' 2>/dev/null || printf '[]')
+                    echo "Failed to create gist for $f; falling back to inline snippet. errors=${GIST_ERRORS}" >&2
+                  else
+                    echo "Failed to create gist for $f; falling back to inline snippet." >&2
+                  fi
                 fi
               fi
 


### PR DESCRIPTION
## Summary
- parse the errors array from the gist API response when gist creation fails
- include the parsed errors in the stderr fallback log to improve diagnostics

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d7f6e73d7c832789da53f64d3aface