### PR TITLE
Add-webrtc streaming mode into main

### DIFF
--- a/.github/workflows/create-codex-resolve-pr-comment.yml
+++ b/.github/workflows/create-codex-resolve-pr-comment.yml
@@ -182,18 +182,27 @@ jobs:
 
               if [[ "$USE_GISTS" -eq 1 ]]; then
                 # Create a private gist with the exact file content
-                GIST_PAYLOAD=$(jq -nc --arg name "$f" --arg content "$SNIPPET_CONTENT" \
+                GIST_NAME=${f//\//_}
+                GIST_PAYLOAD=$(jq -nc --arg name "$GIST_NAME" --arg content "$SNIPPET_CONTENT" \
                   '{public:false, files:{($name):{content:$content}}}')
 
+                RESPONSE_FILE=$(mktemp)
                 set +e
-                GIST_RESPONSE=$(curl -s -X POST \
+                CURL_HTTP_STATUS=$(curl -sS -w '%{http_code}' -o "$RESPONSE_FILE" \
                   -H "Authorization: token $REPO_PAT" \
                   -H "Content-Type: application/json" \
                   -d "$GIST_PAYLOAD" https://api.github.com/gists)
-                CURL_STATUS=$?
+                CURL_EXIT=$?
                 set -e
 
-                if [[ $CURL_STATUS -eq 0 && -n "$GIST_RESPONSE" ]]; then
+                CURL_HTTP_STATUS=$(printf '%s' "$CURL_HTTP_STATUS" | tr -dc '0-9')
+                GIST_RESPONSE=""
+                if [[ -f "$RESPONSE_FILE" ]]; then
+                  GIST_RESPONSE=$(cat "$RESPONSE_FILE")
+                fi
+                rm -f "$RESPONSE_FILE"
+
+                if [[ $CURL_EXIT -eq 0 && "$CURL_HTTP_STATUS" =~ ^2 ]]; then
                   set +e
                   GIST_URL=$(printf '%s' "$GIST_RESPONSE" | jq -r '.html_url // empty')
                   JQ_STATUS=$?
@@ -202,12 +211,33 @@ jobs:
                     GIST_LINES+="- **$f** (conflict hunks via gist): ${GIST_URL}\n"
                     continue
                   fi
-                fi
-
-                if [[ $CURL_STATUS -ne 0 ]]; then
-                  echo "Failed to create gist for $f (curl exit $CURL_STATUS); falling back to inline snippet." >&2
+                  ERROR_MESSAGE=$(printf '%s' "$GIST_RESPONSE" | jq -r '.message // empty' 2>/dev/null || true)
+                  if [[ -n "$ERROR_MESSAGE" ]]; then
+                    echo "Failed to parse gist URL for $f (message: $ERROR_MESSAGE); falling back to inline snippet." >&2
+                  else
+                    echo "Failed to parse gist URL for $f; falling back to inline snippet." >&2
+                  fi
                 else
-                  echo "Failed to create gist for $f; falling back to inline snippet." >&2
+                  if [[ -n "$GIST_RESPONSE" ]]; then
+                    GIST_ERRORS=$(printf '%s' "$GIST_RESPONSE" | jq -c '.errors // []' 2>/dev/null || printf '[]')
+                    echo "Failed to create gist for $f; falling back to inline snippet. errors=${GIST_ERRORS}" >&2
+
+                  ERROR_MESSAGE=""
+                  if [[ -n "$GIST_RESPONSE" ]]; then
+                    ERROR_MESSAGE=$(printf '%s' "$GIST_RESPONSE" | jq -r '.message // empty' 2>/dev/null || true)
+                  fi
+                  if [[ $CURL_EXIT -ne 0 ]]; then
+                    echo "Failed to create gist for $f (curl exit $CURL_EXIT); falling back to inline snippet." >&2
+                  elif [[ -n "$CURL_HTTP_STATUS" ]]; then
+                    if [[ -n "$ERROR_MESSAGE" ]]; then
+                      echo "Failed to create gist for $f (HTTP $CURL_HTTP_STATUS): $ERROR_MESSAGE; falling back to inline snippet." >&2
+                    else
+                      echo "Failed to create gist for $f (HTTP $CURL_HTTP_STATUS); falling back to inline snippet." >&2
+                    fi
+
+                  else
+                    echo "Failed to create gist for $f; falling back to inline snippet." >&2
+                  fi
                 fi
               fi
 

--- a/.github/workflows/create-codex-resolve-pr-comment.yml
+++ b/.github/workflows/create-codex-resolve-pr-comment.yml
@@ -221,6 +221,7 @@ jobs:
                   if [[ -n "$GIST_RESPONSE" ]]; then
                     GIST_ERRORS=$(printf '%s' "$GIST_RESPONSE" | jq -c '.errors // []' 2>/dev/null || printf '[]')
                     echo "Failed to create gist for $f; falling back to inline snippet. errors=${GIST_ERRORS}" >&2
+                  fi
 
                   ERROR_MESSAGE=""
                   if [[ -n "$GIST_RESPONSE" ]]; then

--- a/config.yaml
+++ b/config.yaml
@@ -156,6 +156,16 @@ logging:
   # When true, emits per-second debug lines from the segmenter.
   dev_mode: true
 
+streaming:
+  # Live streaming mode exposed in the dashboard. Valid values:
+  #   "hls"   – HTTP Live Streaming (higher latency, broad compatibility).
+  #   "webrtc" – WebRTC audio stream (lower latency, modern browsers only).
+  mode: "hls"
+  # When streaming.mode is "webrtc", audio frames are stored in a shared ring
+  # buffer before they are forwarded to WebRTC peers. Increase this to tolerate
+  # short stalls at the cost of RAM usage (seconds of audio history).
+  webrtc_history_seconds: 8.0
+
 dashboard:
   # Override the base URL used by the dashboard when making API and HLS requests.
   # Useful when the static dashboard is hosted separately from the recorder.
@@ -172,7 +182,7 @@ dashboard:
       description: "Segments microphone input into individual events."
     - unit: "web-streamer.service"
       label: "Web UI"
-      description: "Serves the dashboard and HLS live stream."
+      description: "Serves the dashboard and live stream."
 
   # Unit that should be restarted automatically when stopped or reloaded through
   # the dashboard to keep the management interface reachable.

--- a/lib/live_stream_daemon.py
+++ b/lib/live_stream_daemon.py
@@ -9,6 +9,7 @@ from lib.config import get_cfg
 from lib.fault_handler import reset_usb
 from lib.hls_mux import HLSTee
 from lib.hls_controller import controller  # NEW
+from lib.webrtc_buffer import WebRTCBufferWriter
 
 cfg = get_cfg()
 SAMPLE_RATE = int(cfg["audio"]["sample_rate"])
@@ -16,6 +17,10 @@ FRAME_MS = int(cfg["audio"]["frame_ms"])
 FRAME_BYTES = int(SAMPLE_RATE * 2 * FRAME_MS / 1000)
 CHUNK_BYTES = 4096
 STATE_POLL_INTERVAL = 1.0
+STREAM_MODE = str(cfg.get("streaming", {}).get("mode", "hls")).strip().lower() or "hls"
+if STREAM_MODE not in {"hls", "webrtc"}:
+    STREAM_MODE = "hls"
+WEBRTC_HISTORY_SECONDS = float(cfg.get("streaming", {}).get("webrtc_history_seconds", 8.0))
 
 AUDIO_DEV = os.environ.get("AUDIO_DEV", cfg["audio"]["device"])
 
@@ -63,23 +68,46 @@ def main():
     global p, stop_requested
     stop_requested = False
     print(f"[live] starting with device={AUDIO_DEV}", flush=True)
+    print(f"[live] streaming mode={STREAM_MODE}", flush=True)
 
-    # Construct HLS encoder but do NOT start it; the web server starts/stops on demand.
-    hls_dir = os.path.join(cfg["paths"]["tmp_dir"], "hls")
-    os.makedirs(hls_dir, exist_ok=True)
-    hls = HLSTee(
-        out_dir=hls_dir,
-        sample_rate=SAMPLE_RATE,
-        channels=1,
-        bits_per_sample=16,
-        segment_time=2.0,
-        history_seconds=60,
-        bitrate="64k",
-    )
-    state_path = os.path.join(hls_dir, "controller_state.json")
-    controller.set_state_path(state_path, persist=True)
-    controller.attach(hls)
-    controller.refresh_from_state()
+    publish_frame = None
+    hls = None
+    webrtc_writer = None
+
+    if STREAM_MODE == "hls":
+        # Construct HLS encoder but do NOT start it; the web server starts/stops on demand.
+        hls_dir = os.path.join(cfg["paths"]["tmp_dir"], "hls")
+        os.makedirs(hls_dir, exist_ok=True)
+        hls = HLSTee(
+            out_dir=hls_dir,
+            sample_rate=SAMPLE_RATE,
+            channels=1,
+            bits_per_sample=16,
+            segment_time=2.0,
+            history_seconds=60,
+            bitrate="64k",
+        )
+        state_path = os.path.join(hls_dir, "controller_state.json")
+        controller.set_state_path(state_path, persist=True)
+        controller.attach(hls)
+        controller.refresh_from_state()
+
+        def publish_frame(frame: bytes) -> None:
+            hls.feed(frame)
+
+    else:
+        webrtc_dir = os.path.join(cfg["paths"]["tmp_dir"], "webrtc")
+        os.makedirs(webrtc_dir, exist_ok=True)
+        webrtc_writer = WebRTCBufferWriter(
+            webrtc_dir,
+            sample_rate=SAMPLE_RATE,
+            frame_ms=FRAME_MS,
+            frame_bytes=FRAME_BYTES,
+            history_seconds=WEBRTC_HISTORY_SECONDS,
+        )
+
+        def publish_frame(frame: bytes) -> None:
+            webrtc_writer.feed(frame)
 
     while not stop_requested:
         p = None
@@ -108,7 +136,7 @@ def main():
 
             while not stop_requested:
                 now = time.monotonic()
-                if now >= next_state_poll:
+                if STREAM_MODE == "hls" and now >= next_state_poll:
                     controller.refresh_from_state()
                     next_state_poll = now + STATE_POLL_INTERVAL
                 chunk = p.stdout.read(CHUNK_BYTES)
@@ -118,8 +146,8 @@ def main():
 
                 while len(buf) >= FRAME_BYTES:
                     frame = bytes(buf[:FRAME_BYTES])
-                    # Always feed frames; HLSTee drops if not started.
-                    hls.feed(frame)
+                    # Always feed frames; sink drops if not started.
+                    publish_frame(frame)
                     rec.ingest(frame, frame_idx)
                     del buf[:FRAME_BYTES]
                     frame_idx += 1
@@ -145,10 +173,12 @@ def main():
             print(f"[live] loop error: {e!r}", flush=True)
         finally:
             try:
-                controller.refresh_from_state()
+                if STREAM_MODE == "hls":
+                    controller.refresh_from_state()
+                    if 'rec' in locals():
+                        # Ensure encoder is stopped when daemon exits/restarts.
+                        controller.stop_now()
                 if 'rec' in locals():
-                    # Ensure encoder is stopped when daemon exits/restarts.
-                    controller.stop_now()
                     rec.flush(frame_idx)
             except Exception as e:
                 print(f"[live] flush failed: {e!r}", flush=True)
@@ -174,6 +204,8 @@ def main():
                     print("[live] USB device reset successful", flush=True)
                 time.sleep(3)
 
+    if webrtc_writer is not None:
+        webrtc_writer.close()
     print("[live] clean shutdown complete", flush=True)
 
 if __name__ == "__main__":

--- a/lib/webrtc_buffer.py
+++ b/lib/webrtc_buffer.py
@@ -1,0 +1,227 @@
+"""Shared-memory style ring buffer for PCM frames consumed by WebRTC."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import threading
+import time
+from typing import Optional
+
+
+BUFFER_FILENAME = "webrtc_buffer.raw"
+STATE_FILENAME = "webrtc_state.json"
+
+
+class WebRTCBufferWriter:
+    """Persist PCM frames in a circular buffer for low-latency streaming."""
+
+    def __init__(
+        self,
+        root_dir: str,
+        *,
+        sample_rate: int,
+        frame_ms: int,
+        frame_bytes: int,
+        history_seconds: float = 8.0,
+    ) -> None:
+        self.root_dir = root_dir
+        os.makedirs(self.root_dir, exist_ok=True)
+
+        self.sample_rate = int(sample_rate)
+        self.frame_ms = int(frame_ms)
+        self.frame_bytes = int(frame_bytes)
+        self.history_seconds = max(float(history_seconds), 1.0)
+
+        if self.frame_bytes <= 0:
+            raise ValueError("frame_bytes must be > 0")
+
+        approx_frames = int(self.history_seconds * (1000.0 / self.frame_ms))
+        buffer_frames = max(approx_frames, 2)
+        self.buffer_size = buffer_frames * self.frame_bytes
+
+        self.buffer_path = os.path.join(self.root_dir, BUFFER_FILENAME)
+        self.state_path = os.path.join(self.root_dir, STATE_FILENAME)
+
+        flags = os.O_RDWR | os.O_CREAT
+        try:
+            self.fd = os.open(self.buffer_path, flags, 0o644)
+        except OSError as exc:  # pragma: no cover - unlikely on tmpfs but defensive
+            raise RuntimeError(f"failed to open WebRTC buffer: {exc}") from exc
+
+        try:
+            os.ftruncate(self.fd, self.buffer_size)
+        except OSError as exc:  # pragma: no cover - disk issues should be surfaced
+            os.close(self.fd)
+            raise RuntimeError(f"failed to size WebRTC buffer: {exc}") from exc
+
+        self._lock = threading.Lock()
+        self._write_offset = 0
+        self._sequence = 0
+        self._write_state(initial=True)
+
+    def close(self) -> None:
+        with self._lock:
+            try:
+                os.close(self.fd)
+            except OSError:
+                pass
+
+    def feed(self, frame: bytes) -> None:
+        if not frame:
+            return
+        data = memoryview(frame)
+        with self._lock:
+            if len(data) >= self.buffer_size:
+                data = data[-self.buffer_size :]
+
+            offset = self._write_offset
+            remaining = len(data)
+            view = data
+            while remaining > 0:
+                chunk = min(remaining, self.buffer_size - offset)
+                try:
+                    os.pwrite(self.fd, view[:chunk], offset)
+                except AttributeError:  # pragma: no cover - older Python
+                    os.lseek(self.fd, offset, os.SEEK_SET)
+                    os.write(self.fd, view[:chunk])
+                except OSError as exc:  # pragma: no cover - disk issues
+                    raise RuntimeError(f"failed to write WebRTC buffer: {exc}") from exc
+                offset = (offset + chunk) % self.buffer_size
+                view = view[chunk:]
+                remaining -= chunk
+
+            self._write_offset = offset
+            self._sequence += 1
+            self._write_state()
+
+    def _write_state(self, *, initial: bool = False) -> None:
+        payload = {
+            "sample_rate": self.sample_rate,
+            "frame_ms": self.frame_ms,
+            "frame_bytes": self.frame_bytes,
+            "buffer_size": self.buffer_size,
+            "write_offset": self._write_offset,
+            "sequence": self._sequence,
+            "updated_at": time.time(),
+        }
+        tmp_path = f"{self.state_path}.tmp"
+        with open(tmp_path, "w", encoding="utf-8") as handle:
+            json.dump(payload, handle, separators=(",", ":"))
+        os.replace(tmp_path, self.state_path)
+
+
+class WebRTCBufferConsumer:
+    """Read PCM frames from the circular buffer written by WebRTCBufferWriter."""
+
+    def __init__(
+        self,
+        root_dir: str,
+        *,
+        frame_bytes: int,
+        buffer_size: int,
+    ) -> None:
+        self.root_dir = root_dir
+        self.frame_bytes = frame_bytes
+        self.buffer_size = buffer_size
+        self.buffer_path = os.path.join(self.root_dir, BUFFER_FILENAME)
+        self.state_path = os.path.join(self.root_dir, STATE_FILENAME)
+
+        if not os.path.exists(self.buffer_path):
+            raise FileNotFoundError(self.buffer_path)
+
+        try:
+            self.fd = os.open(self.buffer_path, os.O_RDONLY)
+        except OSError as exc:  # pragma: no cover - defensive
+            raise RuntimeError(f"failed to open WebRTC buffer for read: {exc}") from exc
+
+        self._capacity_frames = max(self.buffer_size // self.frame_bytes, 1)
+        self._last_sequence = 0
+
+    def close(self) -> None:
+        try:
+            os.close(self.fd)
+        except OSError:
+            pass
+
+    def _read_state(self) -> Optional[dict[str, int]]:
+        try:
+            with open(self.state_path, "r", encoding="utf-8") as handle:
+                data = json.load(handle)
+        except FileNotFoundError:
+            return None
+        except json.JSONDecodeError:
+            return None
+
+        try:
+            sequence = int(data.get("sequence", 0))
+            write_offset = int(data.get("write_offset", 0))
+        except (TypeError, ValueError):
+            return None
+
+        return {"sequence": max(sequence, 0), "write_offset": write_offset % self.buffer_size}
+
+    def _read_bytes(self, offset: int) -> bytes:
+        buf = bytearray(self.frame_bytes)
+        chunk = min(self.frame_bytes, self.buffer_size - offset)
+        view = memoryview(buf)
+        try:
+            read = os.pread(self.fd, chunk, offset)
+        except AttributeError:  # pragma: no cover
+            os.lseek(self.fd, offset, os.SEEK_SET)
+            read = os.read(self.fd, chunk)
+        view[: len(read)] = read
+        if chunk < self.frame_bytes:
+            try:
+                tail = os.pread(self.fd, self.frame_bytes - chunk, 0)
+            except AttributeError:  # pragma: no cover
+                os.lseek(self.fd, 0, os.SEEK_SET)
+                tail = os.read(self.fd, self.frame_bytes - chunk)
+            view[chunk : chunk + len(tail)] = tail
+        return bytes(buf)
+
+    async def next_frame(self, loop, *, poll_interval: float = 0.02, timeout: float = 1.0) -> Optional[bytes]:
+        deadline = loop.time() + timeout
+        while True:
+            state = self._read_state()
+            if state is None:
+                if loop.time() >= deadline:
+                    return None
+                await asyncio_sleep(poll_interval)
+                continue
+
+            sequence = state["sequence"]
+            if sequence <= 0:
+                if loop.time() >= deadline:
+                    return None
+                await asyncio_sleep(poll_interval)
+                continue
+
+            if self._last_sequence == 0:
+                self._last_sequence = sequence
+                if loop.time() >= deadline:
+                    return None
+                await asyncio_sleep(poll_interval)
+                continue
+
+            frames_available = sequence - self._last_sequence
+            if frames_available <= 0:
+                if loop.time() >= deadline:
+                    return None
+                await asyncio_sleep(poll_interval)
+                continue
+
+            if frames_available > self._capacity_frames:
+                self._last_sequence = sequence - self._capacity_frames
+                frames_available = self._capacity_frames
+
+            offset = (state["write_offset"] - frames_available * self.frame_bytes) % self.buffer_size
+            frame = self._read_bytes(offset)
+            self._last_sequence += 1
+            return frame
+
+
+async def asyncio_sleep(delay: float) -> None:
+    await asyncio.sleep(delay)
+

--- a/lib/webrtc_stream.py
+++ b/lib/webrtc_stream.py
@@ -1,0 +1,254 @@
+"""WebRTC session management for low-latency audio streaming."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+from typing import Dict, Optional, TYPE_CHECKING
+
+try:
+    from aiortc import RTCPeerConnection as _RTCPeerConnection, RTCSessionDescription as _RTCSessionDescription
+    from aiortc.mediastreams import MediaStreamTrack as _MediaStreamTrack
+    import av as _av
+except ModuleNotFoundError as exc:  # pragma: no cover - exercised in environments without aiortc
+    _AIORTC_IMPORT_ERROR: Exception | None = exc
+    _RTCPeerConnection = None
+    _RTCSessionDescription = None
+    _MediaStreamTrack = None
+    _av = None
+else:  # pragma: no cover - import paths tested in integration environments
+    _AIORTC_IMPORT_ERROR = None
+
+from .webrtc_buffer import WebRTCBufferConsumer
+
+if TYPE_CHECKING:  # pragma: no cover - type checking only
+    from aiortc import RTCPeerConnection, RTCSessionDescription
+else:
+    RTCPeerConnection = _RTCPeerConnection  # type: ignore[assignment]
+    RTCSessionDescription = _RTCSessionDescription  # type: ignore[assignment]
+
+
+class _UnavailableSessionDescription:
+    def __init__(self, *, sdp: str, type: str) -> None:
+        self.sdp = sdp
+        self.type = type
+
+
+if RTCSessionDescription is None:  # pragma: no cover - dependency missing path
+    RTCSessionDescription = _UnavailableSessionDescription  # type: ignore[assignment]
+
+
+if _AIORTC_IMPORT_ERROR is None:
+    MediaStreamTrack = _MediaStreamTrack  # type: ignore[assignment]
+    av = _av  # type: ignore[assignment]
+
+    class PCMStreamTrack(MediaStreamTrack):
+        kind = "audio"
+
+        def __init__(
+            self,
+            consumer: WebRTCBufferConsumer,
+            *,
+            sample_rate: int,
+            frame_bytes: int,
+        ) -> None:
+            super().__init__()
+            self._consumer = consumer
+            self._sample_rate = int(sample_rate)
+            self._frame_bytes = int(frame_bytes)
+            self._silence = bytes(self._frame_bytes)
+
+        async def recv(self) -> av.AudioFrame:
+            loop = asyncio.get_running_loop()
+            frame_bytes = await self._consumer.next_frame(loop, timeout=1.0)
+            if frame_bytes is None:
+                frame_bytes = self._silence
+
+            samples = max(len(frame_bytes) // 2, 1)
+            frame = av.AudioFrame(format="s16", layout="mono", samples=samples)
+            frame.planes[0].update(frame_bytes)
+            frame.sample_rate = self._sample_rate
+            pts, time_base = await super().next_timestamp()
+            frame.pts = pts
+            frame.time_base = time_base
+            return frame
+
+        def stop(self) -> None:
+            try:
+                self._consumer.close()
+            except Exception:
+                pass
+            super().stop()
+
+
+    class WebRTCSession:
+        def __init__(self, pc: RTCPeerConnection, track: PCMStreamTrack) -> None:
+            self.pc = pc
+            self.track = track
+
+        async def close(self) -> None:
+            try:
+                await self.pc.close()
+            except Exception:
+                pass
+            self.track.stop()
+
+
+    class WebRTCManager:
+        def __init__(
+            self,
+            *,
+            buffer_dir: str,
+            sample_rate: int,
+            frame_ms: int,
+            frame_bytes: int,
+            history_seconds: float,
+        ) -> None:
+            self._buffer_dir = buffer_dir
+            self._sample_rate = int(sample_rate)
+            self._frame_ms = int(frame_ms)
+            self._frame_bytes = int(frame_bytes)
+            self._buffer_size = max(int(history_seconds * (1000.0 / self._frame_ms)), 2) * self._frame_bytes
+            self._sessions: Dict[str, WebRTCSession] = {}
+            self._lock = asyncio.Lock()
+            self._log = logging.getLogger("webrtc_manager")
+
+        def mark_started(self, session_id: Optional[str]) -> None:
+            _ = session_id
+
+        async def stop(self, session_id: Optional[str]) -> None:
+            if not session_id:
+                return
+            async with self._lock:
+                session = self._sessions.pop(session_id, None)
+            if session:
+                await session.close()
+
+        def stats(self) -> dict[str, object]:
+            active = len(self._sessions)
+            return {
+                "active_clients": active,
+                "encoder_running": active > 0,
+            }
+
+        async def shutdown(self) -> None:
+            async with self._lock:
+                sessions = list(self._sessions.values())
+                self._sessions.clear()
+            for session in sessions:
+                await session.close()
+
+        def _buffer_ready(self) -> bool:
+            buffer_path = os.path.join(self._buffer_dir, "webrtc_buffer.raw")
+            state_path = os.path.join(self._buffer_dir, "webrtc_state.json")
+            return os.path.exists(buffer_path) and os.path.exists(state_path)
+
+        async def create_answer(
+            self,
+            session_id: str,
+            offer: RTCSessionDescription,
+        ) -> Optional[RTCSessionDescription]:
+            if not self._buffer_ready():
+                return None
+
+            try:
+                consumer = WebRTCBufferConsumer(
+                    self._buffer_dir,
+                    frame_bytes=self._frame_bytes,
+                    buffer_size=self._buffer_size,
+                )
+            except FileNotFoundError:
+                return None
+
+            track = PCMStreamTrack(
+                consumer,
+                sample_rate=self._sample_rate,
+                frame_bytes=self._frame_bytes,
+            )
+
+            pc = RTCPeerConnection()
+            pc.addTrack(track)
+
+            done = asyncio.get_running_loop().create_future()
+
+            @pc.on("connectionstatechange")
+            async def _on_state_change():
+                state = pc.connectionState
+                if state in {"closed", "failed", "disconnected"} and not done.done():
+                    done.set_result(None)
+                    await self.stop(session_id)
+
+            @pc.on("icegatheringstatechange")
+            def _on_ice():
+                if pc.iceGatheringState == "complete" and not done.done():
+                    done.set_result(None)
+
+            try:
+                await pc.setRemoteDescription(offer)
+                answer = await pc.createAnswer()
+                await pc.setLocalDescription(answer)
+            except Exception:
+                consumer.close()
+                await pc.close()
+                return None
+
+            if not done.done():
+                try:
+                    await asyncio.wait_for(done, timeout=2.0)
+                except asyncio.TimeoutError:
+                    pass
+
+            async with self._lock:
+                existing = self._sessions.pop(session_id, None)
+                if existing:
+                    await existing.close()
+                self._sessions[session_id] = WebRTCSession(pc, track)
+
+            return pc.localDescription
+
+else:
+    class WebRTCManager:
+        def __init__(
+            self,
+            *,
+            buffer_dir: str,
+            sample_rate: int,
+            frame_ms: int,
+            frame_bytes: int,
+            history_seconds: float,
+        ) -> None:
+            self._buffer_dir = buffer_dir
+            self._sample_rate = int(sample_rate)
+            self._frame_ms = int(frame_ms)
+            self._frame_bytes = int(frame_bytes)
+            self._buffer_size = max(int(history_seconds * (1000.0 / self._frame_ms)), 2) * self._frame_bytes
+            self._log = logging.getLogger("webrtc_manager")
+            self._error_text = str(_AIORTC_IMPORT_ERROR or "aiortc not installed")
+            self._log.warning("WebRTC support unavailable: %s", self._error_text)
+
+        def mark_started(self, session_id: Optional[str]) -> None:
+            _ = session_id
+
+        async def stop(self, session_id: Optional[str]) -> None:
+            _ = session_id
+
+        def stats(self) -> dict[str, object]:
+            return {
+                "active_clients": 0,
+                "encoder_running": False,
+                "dependencies_ready": False,
+                "reason": self._error_text,
+            }
+
+        async def shutdown(self) -> None:
+            return None
+
+        async def create_answer(
+            self,
+            session_id: str,
+            offer: RTCSessionDescription,
+        ) -> Optional[RTCSessionDescription]:
+            _ = (session_id, offer)
+            return None
+

--- a/lib/webui/static/js/dashboard.js
+++ b/lib/webui/static/js/dashboard.js
@@ -51,10 +51,19 @@ const MAX_LIMIT = 1000;
 const FILTER_STORAGE_KEY = "tricorder.dashboard.filters";
 const CLIPPER_STORAGE_KEY = "tricorder.dashboard.clipper";
 
-const HLS_URL = apiPath("/hls/live.m3u8");
-const START_ENDPOINT = apiPath("/hls/start");
-const STOP_ENDPOINT = apiPath("/hls/stop");
-const STATS_ENDPOINT = apiPath("/hls/stats");
+const STREAM_MODE = (() => {
+  if (typeof document === "undefined" || !document.body || !document.body.dataset) {
+    return "hls";
+  }
+  const mode = (document.body.dataset.tricorderStreamMode || "").trim().toLowerCase();
+  return mode === "webrtc" ? "webrtc" : "hls";
+})();
+const STREAM_BASE = STREAM_MODE === "webrtc" ? "/webrtc" : "/hls";
+const HLS_URL = STREAM_MODE === "hls" ? apiPath("/hls/live.m3u8") : "";
+const START_ENDPOINT = apiPath(`${STREAM_BASE}/start`);
+const STOP_ENDPOINT = apiPath(`${STREAM_BASE}/stop`);
+const STATS_ENDPOINT = apiPath(`${STREAM_BASE}/stats`);
+const OFFER_ENDPOINT = STREAM_MODE === "webrtc" ? apiPath("/webrtc/offer") : "";
 const SERVICES_ENDPOINT = apiPath("/api/services");
 const HEALTH_ENDPOINT = apiPath("/api/system-health");
 const ARCHIVAL_ENDPOINT = apiPath("/api/config/archival");
@@ -475,6 +484,8 @@ const liveState = {
   hls: null,
   scriptPromise: null,
   sessionId: null,
+  pc: null,
+  stream: null,
 };
 
 const playbackState = {
@@ -5831,6 +5842,13 @@ function attachLiveStreamSource() {
   }
   detachLiveStream();
   dom.liveAudio.autoplay = true;
+  if (STREAM_MODE === "webrtc") {
+    startWebRtcStream().catch((error) => {
+      console.error("WebRTC setup failed", error);
+      setLiveStatus("Error");
+    });
+    return;
+  }
   if (nativeHlsSupported(dom.liveAudio)) {
     dom.liveAudio.src = HLS_URL;
     dom.liveAudio.play().catch(() => undefined);
@@ -5857,6 +5875,97 @@ function attachLiveStreamSource() {
     });
 }
 
+function waitForIceGatheringComplete(pc) {
+  if (!pc) {
+    return Promise.resolve();
+  }
+  if (pc.iceGatheringState === "complete") {
+    return Promise.resolve();
+  }
+  return new Promise((resolve) => {
+    const checkState = () => {
+      if (pc.iceGatheringState === "complete") {
+        pc.removeEventListener("icegatheringstatechange", checkState);
+        resolve();
+      }
+    };
+    pc.addEventListener("icegatheringstatechange", checkState);
+  });
+}
+
+async function startWebRtcStream() {
+  if (!dom.liveAudio) {
+    return;
+  }
+  const pc = new RTCPeerConnection();
+  liveState.pc = pc;
+  const mediaStream = new MediaStream();
+  liveState.stream = mediaStream;
+  dom.liveAudio.srcObject = mediaStream;
+  dom.liveAudio.setAttribute("playsinline", "true");
+
+  pc.addTransceiver("audio", { direction: "recvonly" });
+
+  pc.addEventListener("track", (event) => {
+    const [trackStream] = event.streams;
+    if (trackStream) {
+      trackStream.getTracks().forEach((track) => {
+        mediaStream.addTrack(track);
+      });
+    } else if (event.track) {
+      mediaStream.addTrack(event.track);
+    }
+    dom.liveAudio.play().catch(() => undefined);
+    setLiveStatus("Live");
+  });
+
+  pc.addEventListener("connectionstatechange", () => {
+    if (!liveState.active) {
+      return;
+    }
+    if (pc.connectionState === "failed") {
+      setLiveStatus("Connection failed");
+    } else if (pc.connectionState === "connected") {
+      setLiveStatus("Live");
+    }
+  });
+
+  const offer = await pc.createOffer();
+  await pc.setLocalDescription(offer);
+  await waitForIceGatheringComplete(pc);
+
+  if (!pc.localDescription) {
+    throw new Error("Missing local description");
+  }
+
+  if (!OFFER_ENDPOINT) {
+    throw new Error("Offer endpoint unavailable");
+  }
+
+  const response = await fetch(withSession(OFFER_ENDPOINT), {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      sdp: pc.localDescription.sdp,
+      type: pc.localDescription.type,
+    }),
+  });
+
+  if (!response.ok) {
+    throw new Error(`offer failed with status ${response.status}`);
+  }
+
+  const answer = await response.json();
+  if (!answer || typeof answer.sdp !== "string" || typeof answer.type !== "string") {
+    throw new Error("invalid answer");
+  }
+
+  const rtcAnswer = new RTCSessionDescription({ sdp: answer.sdp, type: answer.type });
+  await pc.setRemoteDescription(rtcAnswer);
+
+  dom.liveAudio.play().catch(() => undefined);
+}
+
 function detachLiveStream() {
   if (liveState.hls) {
     try {
@@ -5866,9 +5975,29 @@ function detachLiveStream() {
     }
     liveState.hls = null;
   }
+  if (liveState.pc) {
+    try {
+      liveState.pc.close();
+    } catch (error) {
+      console.warn("Failed to close WebRTC connection", error);
+    }
+    liveState.pc = null;
+  }
+  if (liveState.stream) {
+    try {
+      const tracks = liveState.stream.getTracks();
+      for (const track of tracks) {
+        track.stop();
+      }
+    } catch (error) {
+      console.warn("Failed to stop WebRTC tracks", error);
+    }
+    liveState.stream = null;
+  }
   if (dom.liveAudio) {
     dom.liveAudio.pause();
     dom.liveAudio.removeAttribute("src");
+    dom.liveAudio.srcObject = null;
     dom.liveAudio.load();
     playbackState.pausedViaSpacebar.delete(dom.liveAudio);
   }

--- a/lib/webui/templates/dashboard.html
+++ b/lib/webui/templates/dashboard.html
@@ -10,7 +10,10 @@
     </script>
     <script type="module" src="{{ static_url('js/dashboard.js') }}" defer></script>
   </head>
-  <body data-tricorder-api-base="{{ api_base | default('', true) }}">
+  <body
+    data-tricorder-api-base="{{ api_base | default('', true) }}"
+    data-tricorder-stream-mode="{{ stream_mode | default('hls', true) }}"
+  >
     <div class="app-shell">
       <div
         id="system-banner"

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,5 @@ noisereduce==3.0.3
 numpy==1.26.4
 aiohttp==3.12.15
 jinja2==3.1.4
+av==14.0.1
+aiortc==1.13.0

--- a/tests/test_25_web_streamer.py
+++ b/tests/test_25_web_streamer.py
@@ -4,6 +4,8 @@ import asyncio
 
 import pytest
 
+import copy
+
 import lib.web_streamer as web_streamer
 
 pytest_plugins = ("aiohttp.pytest_plugin",)
@@ -21,6 +23,7 @@ async def test_dashboard_page_structure(aiohttp_client):
     assert 'id="config-viewer"' in body
     assert 'href="/static/css/dashboard.css"' in body
     assert 'src="/static/js/dashboard.js"' in body
+    assert 'data-tricorder-stream-mode="hls"' in body
 
 
 @pytest.mark.asyncio
@@ -55,6 +58,12 @@ async def test_web_streamer_static_assets_available(aiohttp_client):
     assert "const SESSION_STORAGE_KEY" in js_body
     assert "withSession" in js_body
 
+    dashboard_js = await client.get("/static/js/dashboard.js")
+    assert dashboard_js.status == 200
+    dashboard_body = await dashboard_js.text()
+    assert "const STREAM_MODE" in dashboard_body
+    assert "const OFFER_ENDPOINT" in dashboard_body
+
 
 @pytest.mark.asyncio
 async def test_hls_playlist_waits_for_segments(monkeypatch, tmp_path, aiohttp_client):
@@ -84,6 +93,40 @@ async def test_hls_playlist_waits_for_segments(monkeypatch, tmp_path, aiohttp_cl
     assert response.headers.get("Cache-Control") == "no-store"
 
     await writer
+
+
+@pytest.mark.asyncio
+async def test_webrtc_mode_registers_webrtc_routes(monkeypatch, tmp_path, aiohttp_client):
+    monkeypatch.setenv("TRICORDER_TMP", str(tmp_path))
+    from lib import config as config_module
+
+    monkeypatch.setattr(config_module, "_cfg_cache", None, raising=False)
+    base_cfg = copy.deepcopy(config_module.get_cfg())
+    base_cfg["streaming"] = {"mode": "webrtc", "webrtc_history_seconds": 2.0}
+    monkeypatch.setattr(config_module, "_cfg_cache", base_cfg, raising=False)
+
+    client = await aiohttp_client(web_streamer.build_app())
+
+    start_response = await client.get("/webrtc/start")
+    assert start_response.status == 200
+
+    stats_response = await client.get("/webrtc/stats")
+    assert stats_response.status == 200
+    stats_payload = await stats_response.json()
+    assert "active_clients" in stats_payload
+    assert "encoder_running" in stats_payload
+
+    offer_response = await client.post(
+        "/webrtc/offer",
+        json={"sdp": "v=0", "type": "offer"},
+    )
+    assert offer_response.status == 503
+
+    stop_response = await client.get("/webrtc/stop")
+    assert stop_response.status == 200
+
+    legacy_response = await client.get("/hls")
+    assert legacy_response.status == 404
 
 
 def test_parse_show_output_handles_blank_fields():


### PR DESCRIPTION
## Summary
- merge the WebRTC streaming implementation into main, wiring the new buffer/manager and dashboard controls
- document the new streaming.mode configuration along with dependency additions
- retain upstream improvements to the Codex resolve workflow while adopting the new streaming mode tests

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d7f8c6387c8327a4f7bd35d7951de4