### PR TITLE
Add optional event notifications support

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,6 +268,8 @@ Key configuration sections (see `config.yaml` for defaults and documentation):
 - `adaptive_rms` – background noise follower for automatically raising/lowering thresholds.
 - `ingest` – file stability checks, extension filters, ignore suffixes.
 - `logging` – developer-mode verbosity toggle.
+- `notifications` – optional webhook/email alerts when events finish recording.
+- `streaming` – live stream transport configuration (HLS/WebRTC).
 
 ---
 
@@ -309,6 +311,21 @@ Units listed in `dashboard.web_service` are automatically restarted when a stop 
 Entries are separated by semicolons; optional `|label|description` segments override the UI text for each unit.
 
 Services that are triggered by timers or path units now surface their related units directly in the dashboard. For example, `dropbox.service` shows the state of `dropbox.path`, and the auto-updater exposes its scheduling timer so "Waiting" reflects an active watcher instead of a dead service.
+
+
+### Event notifications
+
+Set `notifications.enabled` to `true` to emit callbacks after each recorded event. Two delivery methods are supported:
+
+- **Webhooks** – configure `notifications.webhook.url` (and optional headers/method) to receive a JSON payload containing the event metadata (`etype`, `trigger_rms`, duration, etc.). Leaving the URL blank skips webhook delivery entirely so email-only installs do not raise errors.
+- **Email** – supply SMTP credentials under `notifications.email`. A templated subject/body is rendered with the event fields, enabling simple alert emails for high-priority clips.
+
+Common tunables include:
+
+- `notifications.allowed_event_types` – restrict alerts to specific event classifications (e.g., `["Human", "Both"]`).
+- `notifications.min_trigger_rms` – only notify on clips that exceed the configured RMS threshold.
+- `notifications.webhook.headers` / `method` / `timeout_sec` – customize webhook POST requests for downstream services.
+- `notifications.email.subject_template` / `body_template` – adjust the rendered message content for email delivery.
 
 ### Dashboard clip editor
 

--- a/config.yaml
+++ b/config.yaml
@@ -156,6 +156,43 @@ logging:
   # When true, emits per-second debug lines from the segmenter.
   dev_mode: true
 
+notifications:
+  # Optional notifications when events finish recording. Leave disabled to avoid network calls.
+  enabled: false
+
+  # Filter notifications to specific event types ("Human", "Other", "Both"). Empty list notifies for all.
+  allowed_event_types: ["Human", "Both"]
+
+  # Minimum trigger RMS required to notify. Set to 0 to allow all events or increase to catch only loud clips.
+  min_trigger_rms: 400
+
+  webhook:
+    # HTTP endpoint to receive JSON payloads with event metadata. Leave blank to disable webhook delivery.
+    url: ""
+    method: "POST"
+    headers: {}
+    timeout_sec: 5.0
+
+  email:
+    # SMTP settings for email notifications. Leave smtp_host blank to disable email delivery.
+    smtp_host: ""
+    smtp_port: 587
+    use_tls: true
+    use_ssl: false
+    username: ""
+    password: ""
+    from: "tricorder@example.com"
+    to: ["alerts@example.com"]
+    subject_template: "Tricorder event: {etype} (RMS {trigger_rms})"
+    body_template: |
+      Event {base_name} completed on {host}.
+      Type: {etype}
+      Trigger RMS: {trigger_rms}
+      Average RMS: {avg_rms}
+      Duration: {duration_seconds}s
+      Start: {started_at}
+      Reason: {end_reason}
+
 streaming:
   # Live streaming mode exposed in the dashboard. Valid values:
   #   "hls"   – HTTP Live Streaming (higher latency, broad compatibility).

--- a/lib/config.py
+++ b/lib/config.py
@@ -92,6 +92,13 @@ _DEFAULTS: Dict[str, Any] = {
         ],
         "web_service": "web-streamer.service",
     },
+    "notifications": {
+        "enabled": False,
+        "allowed_event_types": [],
+        "min_trigger_rms": None,
+        "webhook": {},
+        "email": {},
+    },
 }
 
 _cfg_cache: Dict[str, Any] | None = None

--- a/lib/notifications.py
+++ b/lib/notifications.py
@@ -1,0 +1,227 @@
+#!/usr/bin/env python3
+"""Utility helpers for optional event notifications."""
+
+import json
+import smtplib
+import socket
+import ssl
+import time
+from dataclasses import dataclass
+from email.message import EmailMessage
+from typing import Any
+from urllib.error import URLError
+from urllib.request import Request, urlopen
+
+
+def _as_int(value: Any, default: int | None = None) -> int | None:
+    try:
+        return int(value)
+    except Exception:
+        return default
+
+
+def _as_list(value: Any) -> list[str]:
+    if isinstance(value, (list, tuple, set)):
+        return [str(v) for v in value if str(v).strip()]
+    if isinstance(value, str):
+        return [item.strip() for item in value.split(",") if item.strip()]
+    return []
+
+
+@dataclass
+class NotificationFilters:
+    min_trigger_rms: int | None = None
+    allowed_types: tuple[str, ...] = ()
+
+    @classmethod
+    def from_cfg(cls, cfg: dict[str, Any] | None) -> "NotificationFilters":
+        cfg = cfg or {}
+        min_trigger = _as_int(cfg.get("min_trigger_rms"))
+        allowed = tuple(
+            event_type for event_type in _as_list(cfg.get("allowed_event_types"))
+        )
+        return cls(min_trigger_rms=min_trigger, allowed_types=allowed)
+
+    def matches(self, event: dict[str, Any]) -> bool:
+        trigger = _as_int(event.get("trigger_rms"))
+        if self.min_trigger_rms is not None and (
+            trigger is None or trigger < self.min_trigger_rms
+        ):
+            return False
+
+        if self.allowed_types:
+            etype = str(event.get("etype", ""))
+            if etype not in self.allowed_types:
+                return False
+
+        return True
+
+
+class NotificationDispatcher:
+    """Send notifications when an event completes."""
+
+    def __init__(
+        self,
+        *,
+        filters: NotificationFilters,
+        webhook_cfg: dict[str, Any] | None,
+        email_cfg: dict[str, Any] | None,
+    ) -> None:
+        self.filters = filters
+        self.webhook_cfg = webhook_cfg or {}
+        self.email_cfg = email_cfg or {}
+        self.hostname = socket.gethostname()
+
+        self.webhook_url = str(self.webhook_cfg.get("url") or "").strip()
+        self.webhook_method = (
+            str(self.webhook_cfg.get("method", "POST")) or "POST"
+        ).upper()
+        self.webhook_headers = self._normalise_headers(self.webhook_cfg.get("headers"))
+        self.webhook_timeout = float(self.webhook_cfg.get("timeout_sec", 5.0) or 5.0)
+
+        self.email_recipients = _as_list(self.email_cfg.get("to"))
+        self.email_sender = str(self.email_cfg.get("from") or "").strip()
+
+    @staticmethod
+    def _normalise_headers(headers: Any) -> dict[str, str]:
+        if isinstance(headers, dict):
+            return {
+                str(key): str(value)
+                for key, value in headers.items()
+                if str(key).strip()
+            }
+        return {}
+
+    def handle_event(self, event: dict[str, Any]) -> None:
+        if not self.filters.matches(event):
+            return
+
+        payload = {
+            "event": event,
+            "host": self.hostname,
+            "generated_at": time.time(),
+        }
+
+        self._send_webhook(payload)
+        self._send_email(payload)
+
+    # --- webhook ---
+    def _send_webhook(self, payload: dict[str, Any]) -> None:
+        if not self.webhook_url:
+            return
+
+        body = json.dumps(payload, separators=(",", ":")).encode("utf-8")
+        request = Request(
+            self.webhook_url,
+            data=body,
+            method=self.webhook_method,
+            headers={"Content-Type": "application/json", **self.webhook_headers},
+        )
+
+        try:
+            with urlopen(request, timeout=self.webhook_timeout) as response:
+                response.read()
+        except URLError as exc:
+            print(
+                f"[notifications] WARN: webhook delivery failed: {exc}",
+                flush=True,
+            )
+
+    # --- email ---
+    def _send_email(self, payload: dict[str, Any]) -> None:
+        if not (self.email_sender and self.email_recipients):
+            return
+
+        smtp_host = str(self.email_cfg.get("smtp_host") or "").strip()
+        if not smtp_host:
+            return
+
+        smtp_port = _as_int(self.email_cfg.get("smtp_port"), 587) or 587
+        use_ssl = bool(self.email_cfg.get("use_ssl", False))
+        use_tls = bool(self.email_cfg.get("use_tls", True))
+        username = str(self.email_cfg.get("username") or "").strip()
+        password = self.email_cfg.get("password")
+        timeout = float(self.email_cfg.get("timeout_sec", 10.0) or 10.0)
+
+        event = payload.get("event", {})
+        subject_template = (
+            self.email_cfg.get("subject_template")
+            or "Tricorder event: {etype} (RMS {trigger_rms})"
+        )
+        body_template = (
+            self.email_cfg.get("body_template")
+            or (
+                "Event {base_name} completed.\n"
+                "Type: {etype}\n"
+                "Trigger RMS: {trigger_rms}\n"
+                "Average RMS: {avg_rms}\n"
+                "Duration: {duration_seconds}s\n"
+                "Start: {started_at}\n"
+                "Reason: {end_reason}\n"
+            )
+        )
+
+        subject = subject_template.format_map(_SafeDict(event))
+        body = body_template.format_map(_SafeDict(event))
+
+        message = EmailMessage()
+        message["From"] = self.email_sender
+        message["To"] = ", ".join(self.email_recipients)
+        message["Subject"] = subject
+        message.set_content(body)
+
+        try:
+            if use_ssl:
+                context = ssl.create_default_context()
+                with smtplib.SMTP_SSL(
+                    smtp_host, smtp_port, timeout=timeout, context=context
+                ) as smtp:
+                    self._smtp_login_and_send(smtp, username, password, message)
+            else:
+                with smtplib.SMTP(smtp_host, smtp_port, timeout=timeout) as smtp:
+                    if use_tls:
+                        context = ssl.create_default_context()
+                        smtp.starttls(context=context)
+                    self._smtp_login_and_send(smtp, username, password, message)
+        except Exception as exc:
+            print(
+                f"[notifications] WARN: email delivery failed: {exc}",
+                flush=True,
+            )
+
+    @staticmethod
+    def _smtp_login_and_send(
+        smtp: smtplib.SMTP, username: str, password: Any, message: EmailMessage
+    ) -> None:
+        if username and password:
+            smtp.login(username, password)
+        smtp.send_message(message)
+
+
+class _SafeDict(dict):
+    """Gracefully handle missing keys when formatting templates."""
+
+    def __missing__(self, key: str) -> str:
+        return f"{{{key}}}"
+
+
+def build_dispatcher(cfg: dict[str, Any] | None) -> NotificationDispatcher | None:
+    if not isinstance(cfg, dict):
+        return None
+
+    if not bool(cfg.get("enabled")):
+        return None
+
+    filters = NotificationFilters.from_cfg(cfg)
+    webhook_cfg = cfg.get("webhook")
+    email_cfg = cfg.get("email")
+
+    if not any((webhook_cfg, email_cfg)):
+        return None
+
+    return NotificationDispatcher(
+        filters=filters,
+        webhook_cfg=webhook_cfg,
+        email_cfg=email_cfg,
+    )
+

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -1,0 +1,60 @@
+from lib.notifications import (
+    NotificationDispatcher,
+    NotificationFilters,
+    build_dispatcher,
+)
+
+
+def test_filters_require_threshold_and_type():
+    filters = NotificationFilters.from_cfg(
+        {"min_trigger_rms": 500, "allowed_event_types": ["Human"]}
+    )
+
+    assert not filters.matches({"trigger_rms": 400, "etype": "Human"})
+    assert not filters.matches({"trigger_rms": 600, "etype": "Other"})
+    assert filters.matches({"trigger_rms": 600, "etype": "Human"})
+
+
+def test_build_dispatcher_short_circuits():
+    assert build_dispatcher(None) is None
+    assert (
+        build_dispatcher({"enabled": False, "webhook": {"url": "http://example"}})
+        is None
+    )
+    assert build_dispatcher({"enabled": True}) is None
+
+    dispatcher = build_dispatcher(
+        {
+            "enabled": True,
+            "webhook": {"url": "http://example"},
+        }
+    )
+    assert isinstance(dispatcher, NotificationDispatcher)
+
+
+def test_dispatcher_matches(monkeypatch):
+    class Dummy(NotificationDispatcher):
+        def __init__(self):
+            super().__init__(
+                filters=NotificationFilters.from_cfg(
+                    {"min_trigger_rms": 300, "allowed_event_types": ["Both"]}
+                ),
+                webhook_cfg={"url": ""},
+                email_cfg={},
+            )
+            self.webhook_payloads = []
+            self.email_payloads = []
+
+        def _send_webhook(self, payload):
+            self.webhook_payloads.append(payload)
+
+        def _send_email(self, payload):
+            self.email_payloads.append(payload)
+
+    dummy = Dummy()
+    dummy.handle_event({"trigger_rms": 200, "etype": "Both"})
+    assert not dummy.webhook_payloads
+    assert not dummy.email_payloads
+
+    dummy.handle_event({"trigger_rms": 400, "etype": "Both"})
+    assert dummy.webhook_payloads and dummy.email_payloads

--- a/tests/test_notifications.py
+++ b/tests/test_notifications.py
@@ -41,6 +41,7 @@ def test_dispatcher_matches(monkeypatch):
                 ),
                 webhook_cfg={"url": ""},
                 email_cfg={},
+                run_async=False,
             )
             self.webhook_payloads = []
             self.email_payloads = []


### PR DESCRIPTION
## Summary
- add configuration defaults, documentation, and sample settings for optional event notifications
- implement a notification dispatcher with webhook/email delivery and integrate it into the segmenter
- add unit coverage for notification filters/dispatch logic and ensure event completion reasons are surfaced

## Testing
- pytest tests/test_notifications.py -q
- pytest tests/test_10_segmenter.py -q

------
https://chatgpt.com/codex/tasks/task_e_68d810ebd7188327b78d8e14cfb9e123