### PR TITLE
Finish recorder settings modal interactions

### DIFF
--- a/lib/config.py
+++ b/lib/config.py
@@ -393,13 +393,58 @@ def _dump_yaml(path: Path, payload: Dict[str, Any]) -> None:
         raise ConfigPersistenceError(f"Unable to write configuration: {exc}") from exc
 
 
-def update_archival_settings(settings: Dict[str, Any]) -> Dict[str, Any]:
+def _persist_settings_section(
+    section: str, settings: Dict[str, Any], *, merge: bool = True
+) -> Dict[str, Any]:
     if not isinstance(settings, dict):
-        raise ConfigPersistenceError("Archival settings payload must be a mapping")
+        raise ConfigPersistenceError(f"{section} settings payload must be a mapping")
 
     primary_path = primary_config_path()
     current = _load_raw_yaml(primary_path)
     updated = copy.deepcopy(current)
-    updated["archival"] = copy.deepcopy(settings)
+
+    if merge:
+        base: Dict[str, Any] = {}
+        existing = updated.get(section)
+        if isinstance(existing, dict):
+            base = copy.deepcopy(existing)
+        for key, value in settings.items():
+            base[key] = copy.deepcopy(value)
+        updated[section] = base
+    else:
+        updated[section] = copy.deepcopy(settings)
+
     _dump_yaml(primary_path, updated)
-    return reload_cfg().get("archival", {})
+    return reload_cfg().get(section, {})
+
+
+def update_archival_settings(settings: Dict[str, Any]) -> Dict[str, Any]:
+    return _persist_settings_section("archival", settings, merge=False)
+
+
+def update_audio_settings(settings: Dict[str, Any]) -> Dict[str, Any]:
+    return _persist_settings_section("audio", settings, merge=True)
+
+
+def update_segmenter_settings(settings: Dict[str, Any]) -> Dict[str, Any]:
+    return _persist_settings_section("segmenter", settings, merge=True)
+
+
+def update_adaptive_rms_settings(settings: Dict[str, Any]) -> Dict[str, Any]:
+    return _persist_settings_section("adaptive_rms", settings, merge=True)
+
+
+def update_ingest_settings(settings: Dict[str, Any]) -> Dict[str, Any]:
+    return _persist_settings_section("ingest", settings, merge=True)
+
+
+def update_logging_settings(settings: Dict[str, Any]) -> Dict[str, Any]:
+    return _persist_settings_section("logging", settings, merge=True)
+
+
+def update_streaming_settings(settings: Dict[str, Any]) -> Dict[str, Any]:
+    return _persist_settings_section("streaming", settings, merge=True)
+
+
+def update_dashboard_settings(settings: Dict[str, Any]) -> Dict[str, Any]:
+    return _persist_settings_section("dashboard", settings, merge=True)

--- a/lib/webui/static/css/dashboard.css
+++ b/lib/webui/static/css/dashboard.css
@@ -217,6 +217,37 @@ body {
   background: rgba(30, 41, 59, 0.85);
 }
 
+.app-menu .menu-section {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  padding: 0.35rem 0.25rem;
+}
+
+.app-menu .menu-section + .menu-section {
+  margin-top: 0.4rem;
+  border-top: 1px solid rgba(148, 163, 184, 0.12);
+  padding-top: 0.6rem;
+}
+
+.menu-section-title {
+  font-size: 0.68rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: rgba(148, 163, 184, 0.75);
+  padding: 0 0.45rem;
+}
+
+.recorder-menu-item {
+  justify-content: flex-start;
+}
+
+.app-menu .recorder-menu-item[data-active="true"] {
+  background: rgba(59, 130, 246, 0.22);
+  color: rgba(241, 245, 249, 0.95);
+}
+
 .sr-only {
   position: absolute;
   width: 1px;
@@ -1215,6 +1246,54 @@ button.small {
   gap: 1rem;
   flex: 1 1 auto;
   min-height: 0;
+}
+
+.settings-subform {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.settings-section-footer {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  border-top: 1px solid rgba(148, 163, 184, 0.12);
+  padding-top: 0.75rem;
+  margin-top: 0.35rem;
+}
+
+.recorder-settings-dialog {
+  width: min(860px, 96vw);
+  max-height: min(92vh, 900px);
+}
+
+.recorder-settings-body {
+  gap: 1.5rem;
+}
+
+.recorder-section {
+  border-left: 2px solid transparent;
+  padding-left: 1.35rem;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.recorder-settings-dialog[data-active-section="audio"]
+  .recorder-section[data-section-key="audio"],
+.recorder-settings-dialog[data-active-section="segmenter"]
+  .recorder-section[data-section-key="segmenter"],
+.recorder-settings-dialog[data-active-section="adaptive_rms"]
+  .recorder-section[data-section-key="adaptive_rms"],
+.recorder-settings-dialog[data-active-section="ingest"]
+  .recorder-section[data-section-key="ingest"],
+.recorder-settings-dialog[data-active-section="logging"]
+  .recorder-section[data-section-key="logging"],
+.recorder-settings-dialog[data-active-section="streaming"]
+  .recorder-section[data-section-key="streaming"],
+.recorder-settings-dialog[data-active-section="dashboard"]
+  .recorder-section[data-section-key="dashboard"] {
+  border-left-color: rgba(59, 130, 246, 0.75);
+  box-shadow: 0 0 0 1px rgba(59, 130, 246, 0.22);
 }
 
 .settings-section {

--- a/lib/webui/static/js/dashboard.js
+++ b/lib/webui/static/js/dashboard.js
@@ -209,6 +209,89 @@ const dom = {
   confirmCancel: document.getElementById("confirm-modal-cancel"),
 };
 
+const recorderDom = {
+  menuItems: document.querySelectorAll(".recorder-menu-item"),
+  modal: document.getElementById("recorder-settings-modal"),
+  dialog: document.getElementById("recorder-settings-dialog"),
+  close: document.getElementById("recorder-settings-close"),
+  configPath: document.getElementById("recorder-settings-config-path"),
+  sections: {
+    audio: {
+      form: document.getElementById("audio-form"),
+      device: document.getElementById("audio-device"),
+      sampleRate: document.getElementById("audio-sample-rate"),
+      frameMs: document.getElementById("audio-frame-ms"),
+      gain: document.getElementById("audio-gain"),
+      vad: document.getElementById("audio-vad"),
+      save: document.getElementById("audio-save"),
+      reset: document.getElementById("audio-reset"),
+      status: document.getElementById("audio-status"),
+    },
+    segmenter: {
+      form: document.getElementById("segmenter-form"),
+      prePad: document.getElementById("segmenter-pre-pad"),
+      postPad: document.getElementById("segmenter-post-pad"),
+      threshold: document.getElementById("segmenter-threshold"),
+      keepWindow: document.getElementById("segmenter-keep-window"),
+      startConsecutive: document.getElementById("segmenter-start-consecutive"),
+      keepConsecutive: document.getElementById("segmenter-keep-consecutive"),
+      flushBytes: document.getElementById("segmenter-flush-bytes"),
+      maxQueue: document.getElementById("segmenter-max-queue"),
+      useRnnoise: document.getElementById("segmenter-use-rnnoise"),
+      useNoisereduce: document.getElementById("segmenter-use-noisereduce"),
+      denoiseBeforeVad: document.getElementById("segmenter-denoise-before-vad"),
+      save: document.getElementById("segmenter-save"),
+      reset: document.getElementById("segmenter-reset"),
+      status: document.getElementById("segmenter-status"),
+    },
+    adaptive_rms: {
+      form: document.getElementById("adaptive-form"),
+      enabled: document.getElementById("adaptive-enabled"),
+      minThresh: document.getElementById("adaptive-min-thresh"),
+      margin: document.getElementById("adaptive-margin"),
+      updateInterval: document.getElementById("adaptive-update-interval"),
+      window: document.getElementById("adaptive-window"),
+      hysteresis: document.getElementById("adaptive-hysteresis"),
+      release: document.getElementById("adaptive-release"),
+      save: document.getElementById("adaptive-save"),
+      reset: document.getElementById("adaptive-reset"),
+      status: document.getElementById("adaptive-status"),
+    },
+    ingest: {
+      form: document.getElementById("ingest-form"),
+      stableChecks: document.getElementById("ingest-stable-checks"),
+      stableInterval: document.getElementById("ingest-stable-interval"),
+      allowedExt: document.getElementById("ingest-allowed-ext"),
+      ignoreSuffixes: document.getElementById("ingest-ignore-suffixes"),
+      save: document.getElementById("ingest-save"),
+      reset: document.getElementById("ingest-reset"),
+      status: document.getElementById("ingest-status"),
+    },
+    logging: {
+      form: document.getElementById("logging-form"),
+      devMode: document.getElementById("logging-dev-mode"),
+      save: document.getElementById("logging-save"),
+      reset: document.getElementById("logging-reset"),
+      status: document.getElementById("logging-status"),
+    },
+    streaming: {
+      form: document.getElementById("streaming-form"),
+      mode: document.getElementById("streaming-mode"),
+      history: document.getElementById("streaming-history"),
+      save: document.getElementById("streaming-save"),
+      reset: document.getElementById("streaming-reset"),
+      status: document.getElementById("streaming-status"),
+    },
+    dashboard: {
+      form: document.getElementById("dashboard-form"),
+      apiBase: document.getElementById("dashboard-api-base"),
+      save: document.getElementById("dashboard-save"),
+      reset: document.getElementById("dashboard-reset"),
+      status: document.getElementById("dashboard-status"),
+    },
+  },
+};
+
 const sortHeaderMap = new Map(
   dom.sortButtons.map((button) => [button.dataset.sortKey ?? "", button.closest("th")])
 );
@@ -563,6 +646,20 @@ const archivalState = {
   statusTimeoutId: null,
   fetchInFlight: false,
   fetchQueued: false,
+};
+
+const recorderState = {
+  configPath: "",
+  loaded: false,
+  loadingPromise: null,
+  sections: new Map(),
+};
+
+const recorderDialogState = {
+  open: false,
+  previouslyFocused: null,
+  keydownHandler: null,
+  activeSection: "",
 };
 
 const appMenuState = {
@@ -3991,6 +4088,1060 @@ function parseListInput(value) {
     .filter((line) => line);
 }
 
+const AUDIO_SAMPLE_RATES = [48000, 32000, 16000];
+const AUDIO_FRAME_LENGTHS = [10, 20, 30];
+const STREAMING_MODES = new Set(["hls", "webrtc"]);
+
+function audioDefaults() {
+  return {
+    device: "",
+    sample_rate: 48000,
+    frame_ms: 20,
+    gain: 2.5,
+    vad_aggressiveness: 3,
+  };
+}
+
+function canonicalAudioSettings(settings) {
+  const defaults = audioDefaults();
+  const source = settings && typeof settings === "object" ? settings : {};
+
+  if (typeof source.device === "string") {
+    defaults.device = source.device.trim();
+  }
+
+  const sampleRate = Number(source.sample_rate);
+  if (Number.isFinite(sampleRate)) {
+    const rounded = Math.round(sampleRate);
+    defaults.sample_rate = AUDIO_SAMPLE_RATES.includes(rounded)
+      ? rounded
+      : defaults.sample_rate;
+  }
+
+  const frameMs = Number(source.frame_ms);
+  if (Number.isFinite(frameMs)) {
+    const rounded = Math.round(frameMs);
+    defaults.frame_ms = AUDIO_FRAME_LENGTHS.includes(rounded)
+      ? rounded
+      : defaults.frame_ms;
+  }
+
+  const gain = Number(source.gain);
+  if (Number.isFinite(gain)) {
+    defaults.gain = Math.max(0.1, Math.min(16, gain));
+  }
+
+  const vad = Number(source.vad_aggressiveness);
+  if (Number.isFinite(vad)) {
+    const rounded = Math.round(vad);
+    defaults.vad_aggressiveness = Math.max(0, Math.min(3, rounded));
+  }
+
+  return defaults;
+}
+
+function canonicalAudioFromConfig(config) {
+  const section = config && typeof config === "object" ? config.audio : null;
+  return canonicalAudioSettings(section);
+}
+
+function segmenterDefaults() {
+  return {
+    pre_pad_ms: 2000,
+    post_pad_ms: 3000,
+    rms_threshold: 300,
+    keep_window_frames: 30,
+    start_consecutive: 25,
+    keep_consecutive: 25,
+    flush_threshold_bytes: 128 * 1024,
+    max_queue_frames: 512,
+    use_rnnoise: false,
+    use_noisereduce: false,
+    denoise_before_vad: false,
+  };
+}
+
+function canonicalSegmenterSettings(settings) {
+  const defaults = segmenterDefaults();
+  const source = settings && typeof settings === "object" ? settings : {};
+
+  function toInt(value, fallback, { min, max } = {}) {
+    const number = Number(value);
+    if (!Number.isFinite(number)) {
+      return fallback;
+    }
+    let candidate = Math.round(number);
+    if (typeof min === "number") {
+      candidate = Math.max(min, candidate);
+    }
+    if (typeof max === "number") {
+      candidate = Math.min(max, candidate);
+    }
+    return candidate;
+  }
+
+  defaults.pre_pad_ms = toInt(source.pre_pad_ms, defaults.pre_pad_ms, { min: 0, max: 60000 });
+  defaults.post_pad_ms = toInt(source.post_pad_ms, defaults.post_pad_ms, { min: 0, max: 120000 });
+  defaults.rms_threshold = toInt(source.rms_threshold, defaults.rms_threshold, { min: 0, max: 10000 });
+  defaults.keep_window_frames = toInt(
+    source.keep_window_frames,
+    defaults.keep_window_frames,
+    { min: 1, max: 2000 }
+  );
+  defaults.start_consecutive = toInt(
+    source.start_consecutive,
+    defaults.start_consecutive,
+    { min: 1, max: 2000 }
+  );
+  defaults.keep_consecutive = toInt(
+    source.keep_consecutive,
+    defaults.keep_consecutive,
+    { min: 1, max: 2000 }
+  );
+  defaults.flush_threshold_bytes = toInt(
+    source.flush_threshold_bytes,
+    defaults.flush_threshold_bytes,
+    { min: 4096, max: 4 * 1024 * 1024 }
+  );
+  defaults.max_queue_frames = toInt(
+    source.max_queue_frames,
+    defaults.max_queue_frames,
+    { min: 16, max: 4096 }
+  );
+
+  defaults.use_rnnoise = parseBoolean(source.use_rnnoise);
+  defaults.use_noisereduce = parseBoolean(source.use_noisereduce);
+  defaults.denoise_before_vad = parseBoolean(source.denoise_before_vad);
+
+  return defaults;
+}
+
+function canonicalSegmenterFromConfig(config) {
+  const section = config && typeof config === "object" ? config.segmenter : null;
+  return canonicalSegmenterSettings(section);
+}
+
+function adaptiveDefaults() {
+  return {
+    enabled: false,
+    min_thresh: 0.01,
+    margin: 1.2,
+    update_interval_sec: 5.0,
+    window_sec: 10.0,
+    hysteresis_tolerance: 0.1,
+    release_percentile: 0.5,
+  };
+}
+
+function canonicalAdaptiveSettings(settings) {
+  const defaults = adaptiveDefaults();
+  const source = settings && typeof settings === "object" ? settings : {};
+
+  defaults.enabled = parseBoolean(source.enabled);
+
+  function clampFloat(value, fallback, min, max) {
+    const number = Number(value);
+    if (!Number.isFinite(number)) {
+      return fallback;
+    }
+    return Math.min(max, Math.max(min, number));
+  }
+
+  defaults.min_thresh = clampFloat(source.min_thresh, defaults.min_thresh, 0, 1);
+  defaults.margin = clampFloat(source.margin, defaults.margin, 0.5, 10);
+  defaults.update_interval_sec = clampFloat(
+    source.update_interval_sec,
+    defaults.update_interval_sec,
+    0.5,
+    120
+  );
+  defaults.window_sec = clampFloat(source.window_sec, defaults.window_sec, 1, 300);
+  defaults.hysteresis_tolerance = clampFloat(
+    source.hysteresis_tolerance,
+    defaults.hysteresis_tolerance,
+    0,
+    1
+  );
+  defaults.release_percentile = clampFloat(
+    source.release_percentile,
+    defaults.release_percentile,
+    0.05,
+    1
+  );
+
+  return defaults;
+}
+
+function canonicalAdaptiveFromConfig(config) {
+  const section = config && typeof config === "object" ? config.adaptive_rms : null;
+  return canonicalAdaptiveSettings(section);
+}
+
+function ingestDefaults() {
+  return {
+    stable_checks: 2,
+    stable_interval_sec: 1.0,
+    allowed_ext: [".wav", ".opus", ".flac", ".mp3"],
+    ignore_suffixes: [".part", ".partial", ".tmp", ".incomplete", ".opdownload", ".crdownload"],
+  };
+}
+
+function normalizeExtensionList(values, fallback) {
+  const base = Array.isArray(fallback) ? fallback.slice() : [];
+  if (!values) {
+    return base;
+  }
+  const items = [];
+  const seen = new Set();
+  const list = Array.isArray(values) ? values : typeof values === "string" ? values.split(/\r?\n/) : [];
+  for (const entry of list) {
+    if (typeof entry !== "string") {
+      continue;
+    }
+    let candidate = entry.trim().toLowerCase();
+    if (!candidate) {
+      continue;
+    }
+    if (!candidate.startsWith(".")) {
+      candidate = `.${candidate}`;
+    }
+    if (!seen.has(candidate)) {
+      seen.add(candidate);
+      items.push(candidate);
+    }
+  }
+  return items.length > 0 ? items : base;
+}
+
+function normalizeSuffixList(values, fallback) {
+  const base = Array.isArray(fallback) ? fallback.slice() : [];
+  if (!values) {
+    return base;
+  }
+  const items = [];
+  const seen = new Set();
+  const list = Array.isArray(values) ? values : typeof values === "string" ? values.split(/\r?\n/) : [];
+  for (const entry of list) {
+    if (typeof entry !== "string") {
+      continue;
+    }
+    const candidate = entry.trim().toLowerCase();
+    if (!candidate) {
+      continue;
+    }
+    if (!seen.has(candidate)) {
+      seen.add(candidate);
+      items.push(candidate);
+    }
+  }
+  return items.length > 0 ? items : base;
+}
+
+function canonicalIngestSettings(settings) {
+  const defaults = ingestDefaults();
+  const source = settings && typeof settings === "object" ? settings : {};
+
+  const stableChecks = Number(source.stable_checks);
+  if (Number.isFinite(stableChecks)) {
+    defaults.stable_checks = Math.max(1, Math.min(20, Math.round(stableChecks)));
+  }
+
+  const stableInterval = Number(source.stable_interval_sec);
+  if (Number.isFinite(stableInterval)) {
+    defaults.stable_interval_sec = Math.max(0.1, Math.min(30, stableInterval));
+  }
+
+  defaults.allowed_ext = normalizeExtensionList(source.allowed_ext, defaults.allowed_ext);
+  defaults.ignore_suffixes = normalizeSuffixList(
+    source.ignore_suffixes,
+    defaults.ignore_suffixes
+  );
+
+  return defaults;
+}
+
+function canonicalIngestFromConfig(config) {
+  const section = config && typeof config === "object" ? config.ingest : null;
+  return canonicalIngestSettings(section);
+}
+
+function loggingDefaults() {
+  return { dev_mode: false };
+}
+
+function canonicalLoggingSettings(settings) {
+  const defaults = loggingDefaults();
+  const source = settings && typeof settings === "object" ? settings : {};
+  defaults.dev_mode = parseBoolean(source.dev_mode);
+  return defaults;
+}
+
+function canonicalLoggingFromConfig(config) {
+  const section = config && typeof config === "object" ? config.logging : null;
+  return canonicalLoggingSettings(section);
+}
+
+function streamingDefaults() {
+  return { mode: "hls", webrtc_history_seconds: 8.0 };
+}
+
+function canonicalStreamingSettings(settings) {
+  const defaults = streamingDefaults();
+  const source = settings && typeof settings === "object" ? settings : {};
+
+  if (typeof source.mode === "string") {
+    const candidate = source.mode.trim().toLowerCase();
+    if (STREAMING_MODES.has(candidate)) {
+      defaults.mode = candidate;
+    }
+  }
+
+  const history = Number(source.webrtc_history_seconds);
+  if (Number.isFinite(history)) {
+    defaults.webrtc_history_seconds = Math.max(1, Math.min(600, history));
+  }
+
+  return defaults;
+}
+
+function canonicalStreamingFromConfig(config) {
+  const section = config && typeof config === "object" ? config.streaming : null;
+  return canonicalStreamingSettings(section);
+}
+
+function dashboardDefaults() {
+  return { api_base: "" };
+}
+
+function canonicalDashboardSettings(settings) {
+  const defaults = dashboardDefaults();
+  const source = settings && typeof settings === "object" ? settings : {};
+  if (typeof source.api_base === "string") {
+    defaults.api_base = source.api_base.trim();
+  }
+  return defaults;
+}
+
+function canonicalDashboardFromConfig(config) {
+  const section = config && typeof config === "object" ? config.dashboard : null;
+  return canonicalDashboardSettings(section);
+}
+
+function getRecorderSection(key) {
+  const section = recorderState.sections.get(key);
+  if (!section) {
+    throw new Error(`Unknown recorder section: ${key}`);
+  }
+  return section;
+}
+
+function setRecorderStatus(key, text, state, options = {}) {
+  const section = getRecorderSection(key);
+  const statusElement = section.options.status;
+  if (!statusElement) {
+    return;
+  }
+  if (section.state.statusTimeoutId) {
+    window.clearTimeout(section.state.statusTimeoutId);
+    section.state.statusTimeoutId = null;
+  }
+
+  const message = typeof text === "string" ? text : "";
+  statusElement.textContent = message;
+  if (state) {
+    statusElement.dataset.state = state;
+  } else if (statusElement.dataset.state) {
+    delete statusElement.dataset.state;
+  }
+  statusElement.setAttribute("aria-hidden", message ? "false" : "true");
+
+  if (message && options.autoHide) {
+    const duration = typeof options.duration === "number" ? options.duration : 3200;
+    section.state.statusTimeoutId = window.setTimeout(() => {
+      section.state.statusTimeoutId = null;
+      statusElement.textContent = "";
+      if (statusElement.dataset.state) {
+        delete statusElement.dataset.state;
+      }
+      statusElement.setAttribute("aria-hidden", "true");
+    }, Math.max(1000, duration));
+  }
+}
+
+function updateRecorderButtons(key) {
+  const section = getRecorderSection(key);
+  const { saveButton, resetButton, form } = section.options;
+  if (saveButton) {
+    saveButton.disabled = section.state.saving || !section.state.dirty;
+  }
+  if (resetButton) {
+    const disableReset =
+      section.state.saving ||
+      (!section.state.dirty && !section.state.pendingSnapshot && !section.state.hasExternalUpdate);
+    resetButton.disabled = disableReset;
+  }
+  if (form) {
+    form.setAttribute("aria-busy", section.state.saving ? "true" : "false");
+  }
+}
+
+function applyRecorderSectionData(key, data, { markPristine = false } = {}) {
+  const section = getRecorderSection(key);
+  if (typeof section.options.apply === "function") {
+    section.options.apply(data);
+  }
+  section.state.current = data;
+  if (markPristine) {
+    section.state.lastAppliedFingerprint = JSON.stringify(data);
+    section.state.dirty = false;
+    section.state.pendingSnapshot = null;
+    section.state.hasExternalUpdate = false;
+  }
+  updateRecorderButtons(key);
+}
+
+function markRecorderSectionDirty(key) {
+  const section = getRecorderSection(key);
+  if (section.state.saving) {
+    return;
+  }
+  if (typeof section.options.read !== "function") {
+    return;
+  }
+  const snapshot = section.options.read();
+  const fingerprint = JSON.stringify(snapshot);
+  const changed = fingerprint !== section.state.lastAppliedFingerprint;
+  section.state.dirty = changed;
+  if (changed) {
+    setRecorderStatus(key, "Unsaved changes", "info");
+  } else if (!section.state.hasExternalUpdate) {
+    setRecorderStatus(key, "", null);
+  }
+  updateRecorderButtons(key);
+}
+
+function resetRecorderSection(key) {
+  const section = getRecorderSection(key);
+  if (section.state.saving) {
+    return;
+  }
+  if (section.state.pendingSnapshot) {
+    applyRecorderSectionData(key, section.state.pendingSnapshot, { markPristine: true });
+    setRecorderStatus(key, "Loaded updated settings from disk.", "info", { autoHide: true, duration: 2500 });
+    section.state.pendingSnapshot = null;
+    section.state.hasExternalUpdate = false;
+    return;
+  }
+  if (section.state.current) {
+    applyRecorderSectionData(key, section.state.current, { markPristine: true });
+    setRecorderStatus(key, "Reverted unsaved changes.", "info", { autoHide: true, duration: 2200 });
+  }
+}
+
+function summariseRestartResults(results) {
+  if (!Array.isArray(results) || results.length === 0) {
+    return { message: "Saved changes.", state: "success" };
+  }
+  const summary = [];
+  let hasFailure = false;
+  for (const entry of results) {
+    if (!entry || typeof entry !== "object") {
+      continue;
+    }
+    const unit = typeof entry.unit === "string" && entry.unit ? entry.unit : "service";
+    const ok = entry.ok !== false;
+    hasFailure = hasFailure || !ok;
+    summary.push(`${unit}${ok ? "" : " (failed)"}`);
+  }
+  const joined = summary.length > 0 ? summary.join(", ") : "services";
+  return {
+    message: `Saved changes. Restarted ${joined}.`,
+    state: hasFailure ? "warning" : "success",
+  };
+}
+
+async function saveRecorderSection(key) {
+  const section = getRecorderSection(key);
+  if (section.state.saving || !section.state.dirty) {
+    return;
+  }
+  if (typeof section.options.read !== "function" || !section.options.endpoint) {
+    return;
+  }
+
+  const payload = section.options.read();
+  section.state.saving = true;
+  updateRecorderButtons(key);
+  setRecorderStatus(key, "Saving…", "pending");
+
+  try {
+    const response = await fetch(apiPath(section.options.endpoint), {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload),
+    });
+
+    let body = null;
+    try {
+      body = await response.json();
+    } catch (error) {
+      body = null;
+    }
+
+    if (!response.ok) {
+      const message = body && typeof body.error === "string"
+        ? body.error
+        : `Request failed with ${response.status}`;
+      throw new Error(message);
+    }
+
+    const canonical = typeof section.options.fromResponse === "function"
+      ? section.options.fromResponse(body)
+      : section.options.defaults();
+    applyRecorderSectionData(key, canonical, { markPristine: true });
+    section.state.loaded = true;
+
+    if (body && typeof body.config_path === "string") {
+      updateRecorderConfigPath(body.config_path);
+    }
+
+    const { message, state } = summariseRestartResults(body ? body.restart_results : null);
+    setRecorderStatus(key, message, state, { autoHide: true, duration: 3600 });
+    fetchConfig({ silent: true });
+    fetchServices({ silent: true });
+  } catch (error) {
+    const message = error && error.message ? error.message : "Unable to save settings.";
+    setRecorderStatus(key, message, "error");
+  } finally {
+    section.state.saving = false;
+    updateRecorderButtons(key);
+  }
+}
+
+async function fetchRecorderSection(key) {
+  const section = getRecorderSection(key);
+  if (!section.options.endpoint) {
+    return;
+  }
+  try {
+    const response = await fetch(apiPath(section.options.endpoint), { cache: "no-store" });
+    if (!response.ok) {
+      throw new Error(`Request failed with ${response.status}`);
+    }
+    const payload = await response.json();
+    const canonical = typeof section.options.fromResponse === "function"
+      ? section.options.fromResponse(payload)
+      : section.options.defaults();
+    applyRecorderSectionData(key, canonical, { markPristine: true });
+    section.state.loaded = true;
+    if (payload && typeof payload.config_path === "string") {
+      updateRecorderConfigPath(payload.config_path);
+    }
+    setRecorderStatus(key, "", null);
+  } catch (error) {
+    console.error(`Failed to fetch ${key} settings`, error);
+    setRecorderStatus(key, "Unable to load settings.", "error");
+  }
+}
+
+function syncRecorderSectionsFromConfig(config) {
+  if (!config || typeof config !== "object") {
+    return;
+  }
+  recorderState.latestConfig = config;
+  for (const [key, section] of recorderState.sections.entries()) {
+    if (typeof section.options.fromConfig !== "function") {
+      continue;
+    }
+    const canonical = section.options.fromConfig(config);
+    handleRecorderConfigSnapshot(key, canonical);
+  }
+  if (!recorderState.loaded) {
+    recorderState.loaded = true;
+  }
+}
+
+function handleRecorderConfigSnapshot(key, canonical) {
+  const section = getRecorderSection(key);
+  const fingerprint = JSON.stringify(canonical);
+  section.state.current = canonical;
+
+  if (!section.state.loaded && !section.state.saving) {
+    applyRecorderSectionData(key, canonical, { markPristine: true });
+    section.state.loaded = true;
+    return;
+  }
+
+  if (fingerprint === section.state.lastAppliedFingerprint) {
+    if (!section.state.dirty && !section.state.saving) {
+      applyRecorderSectionData(key, canonical, { markPristine: true });
+    }
+    return;
+  }
+
+  if (!section.state.dirty && !section.state.saving) {
+    applyRecorderSectionData(key, canonical, { markPristine: true });
+    return;
+  }
+
+  section.state.pendingSnapshot = canonical;
+  section.state.hasExternalUpdate = true;
+  setRecorderStatus(key, "Updated on disk. Reset to load changes.", "info");
+  updateRecorderButtons(key);
+}
+
+function updateRecorderConfigPath(path) {
+  if (typeof path !== "string") {
+    return;
+  }
+  recorderState.configPath = path;
+  if (recorderDom.configPath) {
+    recorderDom.configPath.textContent = path || "(unknown)";
+  }
+}
+
+function ensureRecorderSectionsLoaded() {
+  if (recorderState.loadingPromise) {
+    return recorderState.loadingPromise;
+  }
+  const keys = Array.from(recorderState.sections.keys());
+  if (keys.length === 0) {
+    recorderState.loaded = true;
+    return Promise.resolve();
+  }
+
+  for (const key of keys) {
+    setRecorderStatus(key, "Loading settings…", "pending");
+  }
+
+  const promise = Promise.all(keys.map((key) => fetchRecorderSection(key)))
+    .catch((error) => {
+      console.error("Failed to load recorder settings", error);
+    })
+    .finally(() => {
+      recorderState.loadingPromise = null;
+      recorderState.loaded = true;
+    });
+
+  recorderState.loadingPromise = promise;
+  return promise;
+}
+
+function registerRecorderSection(options) {
+  const {
+    key,
+    endpoint,
+    defaults = () => ({}),
+    fromConfig,
+    fromResponse,
+    read,
+    apply,
+    form,
+    saveButton,
+    resetButton,
+    status,
+  } = options;
+
+  if (!key) {
+    return;
+  }
+
+  const section = {
+    options: {
+      key,
+      endpoint,
+      defaults,
+      fromConfig,
+      fromResponse,
+      read,
+      apply,
+      form,
+      saveButton,
+      resetButton,
+      status,
+    },
+    state: {
+      key,
+      current: defaults(),
+      lastAppliedFingerprint: "",
+      dirty: false,
+      saving: false,
+      loaded: false,
+      pendingSnapshot: null,
+      hasExternalUpdate: false,
+      statusTimeoutId: null,
+    },
+  };
+
+  recorderState.sections.set(key, section);
+
+  if (form) {
+    form.addEventListener("submit", (event) => {
+      event.preventDefault();
+      saveRecorderSection(key);
+    });
+    form.addEventListener("input", () => {
+      markRecorderSectionDirty(key);
+    });
+    form.addEventListener("change", () => {
+      markRecorderSectionDirty(key);
+    });
+    form.setAttribute("novalidate", "novalidate");
+  }
+
+  if (resetButton) {
+    resetButton.addEventListener("click", () => {
+      resetRecorderSection(key);
+    });
+  }
+
+  updateRecorderButtons(key);
+}
+
+function registerRecorderSections() {
+  if (!recorderDom.sections) {
+    return;
+  }
+
+  const definitions = [
+    {
+      key: "audio",
+      dom: recorderDom.sections.audio,
+      endpoint: "/api/config/audio",
+      defaults: audioDefaults,
+      fromConfig: canonicalAudioFromConfig,
+      fromResponse: (payload) => canonicalAudioSettings(payload ? payload.audio : null),
+      read: readAudioForm,
+      apply: applyAudioForm,
+    },
+    {
+      key: "segmenter",
+      dom: recorderDom.sections.segmenter,
+      endpoint: "/api/config/segmenter",
+      defaults: segmenterDefaults,
+      fromConfig: canonicalSegmenterFromConfig,
+      fromResponse: (payload) => canonicalSegmenterSettings(payload ? payload.segmenter : null),
+      read: readSegmenterForm,
+      apply: applySegmenterForm,
+    },
+    {
+      key: "adaptive_rms",
+      dom: recorderDom.sections.adaptive_rms,
+      endpoint: "/api/config/adaptive-rms",
+      defaults: adaptiveDefaults,
+      fromConfig: canonicalAdaptiveFromConfig,
+      fromResponse: (payload) => canonicalAdaptiveSettings(payload ? payload.adaptive_rms : null),
+      read: readAdaptiveForm,
+      apply: applyAdaptiveForm,
+    },
+    {
+      key: "ingest",
+      dom: recorderDom.sections.ingest,
+      endpoint: "/api/config/ingest",
+      defaults: ingestDefaults,
+      fromConfig: canonicalIngestFromConfig,
+      fromResponse: (payload) => canonicalIngestSettings(payload ? payload.ingest : null),
+      read: readIngestForm,
+      apply: applyIngestForm,
+    },
+    {
+      key: "logging",
+      dom: recorderDom.sections.logging,
+      endpoint: "/api/config/logging",
+      defaults: loggingDefaults,
+      fromConfig: canonicalLoggingFromConfig,
+      fromResponse: (payload) => canonicalLoggingSettings(payload ? payload.logging : null),
+      read: readLoggingForm,
+      apply: applyLoggingForm,
+    },
+    {
+      key: "streaming",
+      dom: recorderDom.sections.streaming,
+      endpoint: "/api/config/streaming",
+      defaults: streamingDefaults,
+      fromConfig: canonicalStreamingFromConfig,
+      fromResponse: (payload) => canonicalStreamingSettings(payload ? payload.streaming : null),
+      read: readStreamingForm,
+      apply: applyStreamingForm,
+    },
+    {
+      key: "dashboard",
+      dom: recorderDom.sections.dashboard,
+      endpoint: "/api/config/dashboard",
+      defaults: dashboardDefaults,
+      fromConfig: canonicalDashboardFromConfig,
+      fromResponse: (payload) => canonicalDashboardSettings(payload ? payload.dashboard : null),
+      read: readDashboardForm,
+      apply: applyDashboardForm,
+    },
+  ];
+
+  for (const definition of definitions) {
+    const domRefs = definition.dom;
+    if (!domRefs || !domRefs.form) {
+      continue;
+    }
+    registerRecorderSection({
+      key: definition.key,
+      endpoint: definition.endpoint,
+      defaults: definition.defaults,
+      fromConfig: definition.fromConfig,
+      fromResponse: definition.fromResponse,
+      read: definition.read,
+      apply: definition.apply,
+      form: domRefs.form,
+      saveButton: domRefs.save,
+      resetButton: domRefs.reset,
+      status: domRefs.status,
+    });
+  }
+
+  if (!recorderDialogState.activeSection) {
+    const first = firstRecorderSectionKey();
+    if (first) {
+      setActiveRecorderSection(first);
+    }
+  } else {
+    setActiveRecorderSection(recorderDialogState.activeSection);
+  }
+}
+
+function applyAudioForm(data) {
+  const section = recorderDom.sections.audio;
+  if (!section) {
+    return;
+  }
+  if (section.device) {
+    section.device.value = data.device ?? "";
+  }
+  if (section.sampleRate) {
+    section.sampleRate.value = String(data.sample_rate);
+  }
+  if (section.frameMs) {
+    section.frameMs.value = String(data.frame_ms);
+  }
+  if (section.gain) {
+    section.gain.value = String(data.gain);
+  }
+  if (section.vad) {
+    section.vad.value = String(data.vad_aggressiveness);
+  }
+}
+
+function readAudioForm() {
+  const section = recorderDom.sections.audio;
+  if (!section) {
+    return audioDefaults();
+  }
+  const payload = {
+    device: section.device ? section.device.value : "",
+    sample_rate: section.sampleRate ? Number(section.sampleRate.value) : undefined,
+    frame_ms: section.frameMs ? Number(section.frameMs.value) : undefined,
+    gain: section.gain ? Number(section.gain.value) : undefined,
+    vad_aggressiveness: section.vad ? Number(section.vad.value) : undefined,
+  };
+  return canonicalAudioSettings(payload);
+}
+
+function applySegmenterForm(data) {
+  const section = recorderDom.sections.segmenter;
+  if (!section) {
+    return;
+  }
+  const mapping = [
+    [section.prePad, data.pre_pad_ms],
+    [section.postPad, data.post_pad_ms],
+    [section.threshold, data.rms_threshold],
+    [section.keepWindow, data.keep_window_frames],
+    [section.startConsecutive, data.start_consecutive],
+    [section.keepConsecutive, data.keep_consecutive],
+    [section.flushBytes, data.flush_threshold_bytes],
+    [section.maxQueue, data.max_queue_frames],
+  ];
+  for (const [input, value] of mapping) {
+    if (input) {
+      input.value = String(value);
+    }
+  }
+  if (section.useRnnoise) {
+    section.useRnnoise.checked = data.use_rnnoise;
+  }
+  if (section.useNoisereduce) {
+    section.useNoisereduce.checked = data.use_noisereduce;
+  }
+  if (section.denoiseBeforeVad) {
+    section.denoiseBeforeVad.checked = data.denoise_before_vad;
+  }
+}
+
+function readSegmenterForm() {
+  const section = recorderDom.sections.segmenter;
+  if (!section) {
+    return segmenterDefaults();
+  }
+  const payload = {
+    pre_pad_ms: section.prePad ? Number(section.prePad.value) : undefined,
+    post_pad_ms: section.postPad ? Number(section.postPad.value) : undefined,
+    rms_threshold: section.threshold ? Number(section.threshold.value) : undefined,
+    keep_window_frames: section.keepWindow ? Number(section.keepWindow.value) : undefined,
+    start_consecutive: section.startConsecutive ? Number(section.startConsecutive.value) : undefined,
+    keep_consecutive: section.keepConsecutive ? Number(section.keepConsecutive.value) : undefined,
+    flush_threshold_bytes: section.flushBytes ? Number(section.flushBytes.value) : undefined,
+    max_queue_frames: section.maxQueue ? Number(section.maxQueue.value) : undefined,
+    use_rnnoise: section.useRnnoise ? section.useRnnoise.checked : false,
+    use_noisereduce: section.useNoisereduce ? section.useNoisereduce.checked : false,
+    denoise_before_vad: section.denoiseBeforeVad ? section.denoiseBeforeVad.checked : false,
+  };
+  return canonicalSegmenterSettings(payload);
+}
+
+function applyAdaptiveForm(data) {
+  const section = recorderDom.sections.adaptive_rms;
+  if (!section) {
+    return;
+  }
+  if (section.enabled) {
+    section.enabled.checked = data.enabled;
+  }
+  if (section.minThresh) {
+    section.minThresh.value = String(data.min_thresh);
+  }
+  if (section.margin) {
+    section.margin.value = String(data.margin);
+  }
+  if (section.updateInterval) {
+    section.updateInterval.value = String(data.update_interval_sec);
+  }
+  if (section.window) {
+    section.window.value = String(data.window_sec);
+  }
+  if (section.hysteresis) {
+    section.hysteresis.value = String(data.hysteresis_tolerance);
+  }
+  if (section.release) {
+    section.release.value = String(data.release_percentile);
+  }
+}
+
+function readAdaptiveForm() {
+  const section = recorderDom.sections.adaptive_rms;
+  if (!section) {
+    return adaptiveDefaults();
+  }
+  const payload = {
+    enabled: section.enabled ? section.enabled.checked : false,
+    min_thresh: section.minThresh ? Number(section.minThresh.value) : undefined,
+    margin: section.margin ? Number(section.margin.value) : undefined,
+    update_interval_sec: section.updateInterval ? Number(section.updateInterval.value) : undefined,
+    window_sec: section.window ? Number(section.window.value) : undefined,
+    hysteresis_tolerance: section.hysteresis ? Number(section.hysteresis.value) : undefined,
+    release_percentile: section.release ? Number(section.release.value) : undefined,
+  };
+  return canonicalAdaptiveSettings(payload);
+}
+
+function applyIngestForm(data) {
+  const section = recorderDom.sections.ingest;
+  if (!section) {
+    return;
+  }
+  if (section.stableChecks) {
+    section.stableChecks.value = String(data.stable_checks);
+  }
+  if (section.stableInterval) {
+    section.stableInterval.value = String(data.stable_interval_sec);
+  }
+  if (section.allowedExt) {
+    section.allowedExt.value = (Array.isArray(data.allowed_ext) ? data.allowed_ext : [])
+      .join("\n");
+  }
+  if (section.ignoreSuffixes) {
+    section.ignoreSuffixes.value = (Array.isArray(data.ignore_suffixes) ? data.ignore_suffixes : [])
+      .join("\n");
+  }
+}
+
+function readIngestForm() {
+  const section = recorderDom.sections.ingest;
+  if (!section) {
+    return ingestDefaults();
+  }
+  const payload = {
+    stable_checks: section.stableChecks ? Number(section.stableChecks.value) : undefined,
+    stable_interval_sec: section.stableInterval ? Number(section.stableInterval.value) : undefined,
+    allowed_ext: section.allowedExt ? section.allowedExt.value : undefined,
+    ignore_suffixes: section.ignoreSuffixes ? section.ignoreSuffixes.value : undefined,
+  };
+  return canonicalIngestSettings(payload);
+}
+
+function applyLoggingForm(data) {
+  const section = recorderDom.sections.logging;
+  if (!section) {
+    return;
+  }
+  if (section.devMode) {
+    section.devMode.checked = data.dev_mode;
+  }
+}
+
+function readLoggingForm() {
+  const section = recorderDom.sections.logging;
+  if (!section) {
+    return loggingDefaults();
+  }
+  const payload = {
+    dev_mode: section.devMode ? section.devMode.checked : false,
+  };
+  return canonicalLoggingSettings(payload);
+}
+
+function applyStreamingForm(data) {
+  const section = recorderDom.sections.streaming;
+  if (!section) {
+    return;
+  }
+  if (section.mode) {
+    section.mode.value = data.mode;
+  }
+  if (section.history) {
+    section.history.value = String(data.webrtc_history_seconds);
+  }
+}
+
+function readStreamingForm() {
+  const section = recorderDom.sections.streaming;
+  if (!section) {
+    return streamingDefaults();
+  }
+  const payload = {
+    mode: section.mode ? section.mode.value : undefined,
+    webrtc_history_seconds: section.history ? Number(section.history.value) : undefined,
+  };
+  return canonicalStreamingSettings(payload);
+}
+
+function applyDashboardForm(data) {
+  const section = recorderDom.sections.dashboard;
+  if (!section) {
+    return;
+  }
+  if (section.apiBase) {
+    section.apiBase.value = data.api_base ?? "";
+  }
+}
+
+function readDashboardForm() {
+  const section = recorderDom.sections.dashboard;
+  if (!section) {
+    return dashboardDefaults();
+  }
+  const payload = {
+    api_base: section.apiBase ? section.apiBase.value : "",
+  };
+  return canonicalDashboardSettings(payload);
+}
+
 function archivalDefaults() {
   return {
     enabled: false,
@@ -4406,6 +5557,10 @@ async function fetchConfig({ silent = false } = {}) {
     configState.prePadSeconds = prePadMs !== null && prePadMs >= 0 ? prePadMs / 1000 : null;
     configState.postPadSeconds = postPadMs !== null && postPadMs >= 0 ? postPadMs / 1000 : null;
     updateWaveformMarkers();
+    if (payload && typeof payload.config_path === "string") {
+      updateRecorderConfigPath(payload.config_path);
+    }
+    syncRecorderSectionsFromConfig(payload);
     syncArchivalSnapshotFromConfig(payload);
   } catch (error) {
     console.error("Failed to fetch config", error);
@@ -4960,6 +6115,252 @@ function toggleAppMenu() {
     closeAppMenu();
   } else {
     openAppMenu();
+  }
+}
+
+function recorderModalFocusableElements() {
+  if (!recorderDom.dialog) {
+    return [];
+  }
+  const selectors =
+    'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])';
+  const nodes = recorderDom.dialog.querySelectorAll(selectors);
+  const focusable = [];
+  for (const node of nodes) {
+    if (!(node instanceof HTMLElement)) {
+      continue;
+    }
+    if (node.hasAttribute("disabled")) {
+      continue;
+    }
+    if (node.getAttribute("aria-hidden") === "true") {
+      continue;
+    }
+    if (node.offsetParent === null && node !== document.activeElement) {
+      continue;
+    }
+    focusable.push(node);
+  }
+  return focusable;
+}
+
+function setRecorderModalVisible(visible) {
+  if (!recorderDom.modal) {
+    return;
+  }
+  recorderDom.modal.dataset.visible = visible ? "true" : "false";
+  recorderDom.modal.setAttribute("aria-hidden", visible ? "false" : "true");
+  if (visible) {
+    recorderDom.modal.removeAttribute("hidden");
+  } else {
+    recorderDom.modal.setAttribute("hidden", "hidden");
+  }
+}
+
+function attachRecorderDialogKeydown() {
+  if (recorderDialogState.keydownHandler) {
+    return;
+  }
+  recorderDialogState.keydownHandler = (event) => {
+    if (!recorderDialogState.open) {
+      return;
+    }
+    const target = event.target;
+    const withinModal =
+      recorderDom.modal &&
+      target instanceof Node &&
+      (target === recorderDom.modal || recorderDom.modal.contains(target));
+    if (event.key === "Escape") {
+      event.preventDefault();
+      closeRecorderDialog();
+      return;
+    }
+    if (event.key !== "Tab" || !withinModal) {
+      return;
+    }
+    const focusable = recorderModalFocusableElements();
+    if (focusable.length === 0) {
+      event.preventDefault();
+      if (recorderDom.dialog) {
+        recorderDom.dialog.focus();
+      }
+      return;
+    }
+    const [first] = focusable;
+    const last = focusable[focusable.length - 1];
+    const active = document.activeElement instanceof HTMLElement ? document.activeElement : null;
+    if (event.shiftKey) {
+      if (!active || active === first || active === recorderDom.dialog) {
+        event.preventDefault();
+        last.focus();
+      }
+    } else if (!active || active === last) {
+      event.preventDefault();
+      first.focus();
+    }
+  };
+  document.addEventListener("keydown", recorderDialogState.keydownHandler, true);
+}
+
+function detachRecorderDialogKeydown() {
+  if (!recorderDialogState.keydownHandler) {
+    return;
+  }
+  document.removeEventListener("keydown", recorderDialogState.keydownHandler, true);
+  recorderDialogState.keydownHandler = null;
+}
+
+function focusRecorderDialog(sectionKey) {
+  if (!recorderDom.dialog) {
+    return;
+  }
+  window.requestAnimationFrame(() => {
+    let target = null;
+    if (sectionKey) {
+      const sectionContainer = recorderDom.dialog.querySelector(
+        `.recorder-section[data-section-key="${sectionKey}"]`
+      );
+      if (sectionContainer instanceof HTMLElement) {
+        const focusable = sectionContainer.querySelector(
+          'input:not([disabled]), select:not([disabled]), textarea:not([disabled]), button:not([disabled]), [tabindex]:not([tabindex="-1"])'
+        );
+        if (focusable instanceof HTMLElement) {
+          target = focusable;
+        }
+      }
+    }
+    if (!target) {
+      const focusable = recorderModalFocusableElements();
+      if (focusable.length > 0) {
+        focusable[0].focus();
+        return;
+      }
+      recorderDom.dialog.focus();
+      return;
+    }
+    target.focus();
+  });
+}
+
+function firstRecorderSectionKey() {
+  for (const key of recorderState.sections.keys()) {
+    return key;
+  }
+  return "";
+}
+
+function resolveRecorderSectionKey(preferred) {
+  if (preferred && recorderState.sections.has(preferred)) {
+    return preferred;
+  }
+  if (recorderDialogState.activeSection && recorderState.sections.has(recorderDialogState.activeSection)) {
+    return recorderDialogState.activeSection;
+  }
+  return firstRecorderSectionKey();
+}
+
+function setActiveRecorderSection(sectionKey, options = {}) {
+  const key = resolveRecorderSectionKey(sectionKey);
+  recorderDialogState.activeSection = key || "";
+
+  if (recorderDom.dialog) {
+    if (key) {
+      recorderDom.dialog.dataset.activeSection = key;
+    } else if (recorderDom.dialog.dataset.activeSection) {
+      delete recorderDom.dialog.dataset.activeSection;
+    }
+  }
+
+  const { menuItems } = recorderDom;
+  if (menuItems && typeof menuItems.length === "number") {
+    for (const item of menuItems) {
+      if (!(item instanceof HTMLElement)) {
+        continue;
+      }
+      const itemKey = item.getAttribute("data-recorder-section");
+      const active = itemKey === key && key;
+      if (active) {
+        item.setAttribute("aria-current", "true");
+        item.dataset.active = "true";
+      } else {
+        item.removeAttribute("aria-current");
+        if (item.dataset.active) {
+          delete item.dataset.active;
+        }
+      }
+    }
+  }
+
+  if (!key) {
+    return;
+  }
+
+  const { scrollIntoView = false } = options;
+  if (!scrollIntoView) {
+    return;
+  }
+  const sectionContainer =
+    recorderDom.dialog &&
+    recorderDom.dialog.querySelector(`.recorder-section[data-section-key="${key}"]`);
+  if (sectionContainer instanceof HTMLElement) {
+    const behavior = prefersReducedMotion() ? "auto" : "smooth";
+    sectionContainer.scrollIntoView({ block: "start", inline: "nearest", behavior });
+  }
+}
+
+function openRecorderDialog(options = {}) {
+  if (!recorderDom.modal || !recorderDom.dialog) {
+    return;
+  }
+  const { focus = true, section = "" } = options;
+  const resolvedSection = resolveRecorderSectionKey(section);
+
+  if (recorderDialogState.open) {
+    setActiveRecorderSection(resolvedSection, { scrollIntoView: true });
+    if (focus) {
+      focusRecorderDialog(resolvedSection);
+    }
+    return;
+  }
+
+  recorderDialogState.open = true;
+  recorderDialogState.previouslyFocused =
+    document.activeElement instanceof HTMLElement ? document.activeElement : null;
+  setRecorderModalVisible(true);
+  attachRecorderDialogKeydown();
+  setActiveRecorderSection(resolvedSection, { scrollIntoView: true });
+
+  if (!recorderState.loaded && !recorderState.loadingPromise) {
+    ensureRecorderSectionsLoaded();
+  }
+
+  if (focus) {
+    focusRecorderDialog(resolvedSection);
+  }
+}
+
+function closeRecorderDialog(options = {}) {
+  if (!recorderDom.modal) {
+    return;
+  }
+  if (!recorderDialogState.open) {
+    return;
+  }
+
+  recorderDialogState.open = false;
+  setRecorderModalVisible(false);
+  detachRecorderDialogKeydown();
+
+  const { restoreFocus = true } = options;
+  const previous = recorderDialogState.previouslyFocused;
+  recorderDialogState.previouslyFocused = null;
+  if (!restoreFocus) {
+    return;
+  }
+  if (previous && typeof previous.focus === "function") {
+    previous.focus();
+  } else if (recorderDom.menuItems && recorderDom.menuItems[0] instanceof HTMLElement) {
+    recorderDom.menuItems[0].focus();
   }
 }
 
@@ -6182,6 +7583,38 @@ function attachEventListeners() {
     });
   }
 
+  if (recorderDom.menuItems && typeof recorderDom.menuItems.length === "number") {
+    for (const item of recorderDom.menuItems) {
+      if (!(item instanceof HTMLElement)) {
+        continue;
+      }
+      item.addEventListener("click", () => {
+        const section = item.getAttribute("data-recorder-section") || "";
+        closeAppMenu({ restoreFocus: false });
+        openRecorderDialog({ section });
+      });
+    }
+  }
+
+  if (recorderDom.close) {
+    recorderDom.close.addEventListener("click", () => {
+      closeRecorderDialog();
+    });
+  }
+
+  if (recorderDom.modal) {
+    recorderDom.modal.addEventListener("mousedown", (event) => {
+      if (event.target === recorderDom.modal) {
+        event.preventDefault();
+      }
+    });
+    recorderDom.modal.addEventListener("click", (event) => {
+      if (event.target === recorderDom.modal) {
+        closeRecorderDialog();
+      }
+    });
+  }
+
   if (dom.archivalOpen) {
     dom.archivalOpen.addEventListener("click", () => {
       closeAppMenu({ restoreFocus: false });
@@ -6589,6 +8022,9 @@ function initialize() {
   setLiveButtonState(false);
   setLiveStatus("Idle");
   setLiveToggleDisabled(true, "Checking recorder service status…");
+  setRecorderModalVisible(false);
+  updateRecorderConfigPath(recorderState.configPath);
+  registerRecorderSections();
   setServicesModalVisible(false);
   applyArchivalData(archivalDefaults(), { markPristine: true });
   updateArchivalConfigPath(archivalState.configPath);

--- a/lib/webui/templates/dashboard.html
+++ b/lib/webui/templates/dashboard.html
@@ -70,26 +70,95 @@
               hidden
               data-visible="false"
             >
-              <button
-                id="archival-open"
-                class="menu-item"
-                type="button"
-                role="menuitem"
-                aria-haspopup="dialog"
-                aria-expanded="false"
-              >
-                Archival settings
-              </button>
-              <button
-                id="services-open"
-                class="menu-item"
-                type="button"
-                role="menuitem"
-                aria-haspopup="dialog"
-                aria-expanded="false"
-              >
-                Services
-              </button>
+              <div class="menu-section" role="none">
+                <div class="menu-section-title" role="presentation">Recorder configuration</div>
+                <button
+                  id="recorder-menu-audio"
+                  class="menu-item recorder-menu-item"
+                  type="button"
+                  role="menuitem"
+                  data-recorder-section="audio"
+                >
+                  Audio input &amp; gain
+                </button>
+                <button
+                  id="recorder-menu-segmenter"
+                  class="menu-item recorder-menu-item"
+                  type="button"
+                  role="menuitem"
+                  data-recorder-section="segmenter"
+                >
+                  Event detection
+                </button>
+                <button
+                  id="recorder-menu-adaptive"
+                  class="menu-item recorder-menu-item"
+                  type="button"
+                  role="menuitem"
+                  data-recorder-section="adaptive_rms"
+                >
+                  Adaptive RMS
+                </button>
+                <button
+                  id="recorder-menu-ingest"
+                  class="menu-item recorder-menu-item"
+                  type="button"
+                  role="menuitem"
+                  data-recorder-section="ingest"
+                >
+                  Ingest pipeline
+                </button>
+                <button
+                  id="recorder-menu-logging"
+                  class="menu-item recorder-menu-item"
+                  type="button"
+                  role="menuitem"
+                  data-recorder-section="logging"
+                >
+                  Logging &amp; diagnostics
+                </button>
+                <button
+                  id="recorder-menu-streaming"
+                  class="menu-item recorder-menu-item"
+                  type="button"
+                  role="menuitem"
+                  data-recorder-section="streaming"
+                >
+                  Live streaming
+                </button>
+                <button
+                  id="recorder-menu-dashboard"
+                  class="menu-item recorder-menu-item"
+                  type="button"
+                  role="menuitem"
+                  data-recorder-section="dashboard"
+                >
+                  Dashboard API access
+                </button>
+              </div>
+              <div class="menu-section" role="none">
+                <div class="menu-section-title" role="presentation">Operations</div>
+                <button
+                  id="archival-open"
+                  class="menu-item"
+                  type="button"
+                  role="menuitem"
+                  aria-haspopup="dialog"
+                  aria-expanded="false"
+                >
+                  Archival settings
+                </button>
+                <button
+                  id="services-open"
+                  class="menu-item"
+                  type="button"
+                  role="menuitem"
+                  aria-haspopup="dialog"
+                  aria-expanded="false"
+                >
+                  Services
+                </button>
+              </div>
             </div>
           </div>
           <h1>Dashboard</h1>
@@ -519,6 +588,391 @@
             aria-label="Service statuses"
           ></div>
           <div id="services-empty" class="services-empty" hidden>No managed services configured.</div>
+        </div>
+      </div>
+    </div>
+    <div
+      id="recorder-settings-modal"
+      class="settings-modal"
+      hidden
+      data-visible="false"
+      aria-hidden="true"
+    >
+      <div
+        id="recorder-settings-dialog"
+        class="settings-dialog card recorder-settings-dialog"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="recorder-settings-title"
+        aria-describedby="recorder-settings-description"
+        tabindex="-1"
+        data-active-section=""
+      >
+        <div class="card-header settings-dialog-header">
+          <div class="card-heading">
+            <h2 id="recorder-settings-title">Recorder configuration</h2>
+            <p id="recorder-settings-description" class="card-subtitle">
+              Tune audio capture, event detection, ingest, and streaming settings without leaving the dashboard.
+            </p>
+          </div>
+          <div class="settings-dialog-actions">
+            <button id="recorder-settings-close" class="ghost-button small" type="button">
+              Close
+            </button>
+          </div>
+        </div>
+        <div class="settings-dialog-body recorder-settings-body">
+          <div class="settings-footnote">
+            Saved to <code id="recorder-settings-config-path"></code>
+          </div>
+
+          <section
+            class="settings-section recorder-section"
+            data-section-key="audio"
+            aria-labelledby="recorder-audio-title"
+          >
+            <div class="settings-section-header">
+              <h3 id="recorder-audio-title" class="settings-section-title">Audio input &amp; gain</h3>
+              <p class="settings-section-description">
+                Select the ALSA capture device and frame characteristics used by the recorder pipeline.
+              </p>
+            </div>
+            <form id="audio-form" class="settings-subform" novalidate>
+              <div class="settings-field">
+                <label for="audio-device">ALSA device</label>
+                <input id="audio-device" type="text" autocomplete="off" />
+                <p class="field-description">
+                  Matches the identifier reported by <code>arecord -l</code>, for example
+                  <code>hw:CARD=Device,DEV=0</code>.
+                </p>
+              </div>
+              <div class="settings-field">
+                <label for="audio-sample-rate">Sample rate</label>
+                <select id="audio-sample-rate">
+                  <option value="48000">48&nbsp;kHz (recommended)</option>
+                  <option value="32000">32&nbsp;kHz</option>
+                  <option value="16000">16&nbsp;kHz</option>
+                </select>
+                <p class="field-description">
+                  Higher rates improve VAD accuracy and WebRTC stream quality at the cost of CPU and storage.
+                </p>
+              </div>
+              <div class="settings-field">
+                <label for="audio-frame-ms">Frame duration</label>
+                <select id="audio-frame-ms">
+                  <option value="10">10&nbsp;ms</option>
+                  <option value="20">20&nbsp;ms</option>
+                  <option value="30">30&nbsp;ms</option>
+                </select>
+                <p class="field-description">
+                  Shorter frames reduce latency; 20&nbsp;ms balances responsiveness and CPU load.
+                </p>
+              </div>
+              <div class="settings-field">
+                <label for="audio-gain">Software gain</label>
+                <input id="audio-gain" type="number" min="0.1" max="16" step="0.1" />
+                <p class="field-description">
+                  Linear multiplier applied before detection. Values above 4 can cause clipping on loud inputs.
+                </p>
+              </div>
+              <div class="settings-field">
+                <label for="audio-vad">VAD aggressiveness</label>
+                <select id="audio-vad">
+                  <option value="0">0 – permissive (captures most sounds)</option>
+                  <option value="1">1 – low</option>
+                  <option value="2">2 – balanced</option>
+                  <option value="3">3 – strict (filters background noise)</option>
+                </select>
+                <p class="field-description">
+                  Controls the WebRTC voice detector sensitivity. Higher values reject more noise but may miss quiet speech.
+                </p>
+              </div>
+              <div class="settings-section-footer">
+                <div id="audio-status" class="form-status" role="status" aria-live="polite" aria-hidden="true"></div>
+                <div class="button-row">
+                  <button id="audio-reset" class="ghost-button" type="button" disabled>Reset</button>
+                  <button id="audio-save" class="primary-button" type="submit" disabled>Save changes</button>
+                </div>
+              </div>
+            </form>
+          </section>
+
+          <section
+            class="settings-section recorder-section"
+            data-section-key="segmenter"
+            aria-labelledby="recorder-segmenter-title"
+          >
+            <div class="settings-section-header">
+              <h3 id="recorder-segmenter-title" class="settings-section-title">Event detection</h3>
+              <p class="settings-section-description">
+                Adjust trigger windows, thresholds, and buffer sizes used while segmenting audio into recordings.
+              </p>
+            </div>
+            <form id="segmenter-form" class="settings-subform" novalidate>
+              <div class="settings-field">
+                <label for="segmenter-pre-pad">Pre-roll (ms)</label>
+                <input id="segmenter-pre-pad" type="number" min="0" step="100" />
+                <p class="field-description">Amount of context preserved before the trigger fires.</p>
+              </div>
+              <div class="settings-field">
+                <label for="segmenter-post-pad">Post-roll (ms)</label>
+                <input id="segmenter-post-pad" type="number" min="0" step="100" />
+                <p class="field-description">How long to continue recording after activity stops.</p>
+              </div>
+              <div class="settings-field">
+                <label for="segmenter-threshold">RMS threshold</label>
+                <input id="segmenter-threshold" type="number" min="0" step="10" />
+                <p class="field-description">Linear RMS trigger level after gain. Dial in with <code>room_tuner.py</code>.</p>
+              </div>
+              <div class="settings-field">
+                <label for="segmenter-keep-window">Keep window (frames)</label>
+                <input id="segmenter-keep-window" type="number" min="1" step="1" />
+                <p class="field-description">Sliding window size used to refresh the post-roll timer.</p>
+              </div>
+              <div class="settings-field">
+                <label for="segmenter-start-consecutive">Start frames required</label>
+                <input id="segmenter-start-consecutive" type="number" min="1" step="1" />
+                <p class="field-description">Consecutive active frames required before starting a recording.</p>
+              </div>
+              <div class="settings-field">
+                <label for="segmenter-keep-consecutive">Keep frames required</label>
+                <input id="segmenter-keep-consecutive" type="number" min="1" step="1" />
+                <p class="field-description">Active frames needed within the window to continue an in-progress recording.</p>
+              </div>
+              <div class="settings-field">
+                <label for="segmenter-flush-bytes">Flush threshold (bytes)</label>
+                <input id="segmenter-flush-bytes" type="number" min="4096" step="1024" />
+                <p class="field-description">Controls how often buffered WAV data is flushed to disk.</p>
+              </div>
+              <div class="settings-field">
+                <label for="segmenter-max-queue">Max queued frames</label>
+                <input id="segmenter-max-queue" type="number" min="16" step="16" />
+                <p class="field-description">Upper bound on pending audio frames before applying backpressure.</p>
+              </div>
+              <div class="settings-field checkbox-field">
+                <div class="field-control">
+                  <input id="segmenter-use-rnnoise" type="checkbox" />
+                  <label for="segmenter-use-rnnoise">Enable RNNoise denoising</label>
+                </div>
+                <p class="field-description">High quality but CPU intensive. Best suited for more powerful Pis.</p>
+              </div>
+              <div class="settings-field checkbox-field">
+                <div class="field-control">
+                  <input id="segmenter-use-noisereduce" type="checkbox" />
+                  <label for="segmenter-use-noisereduce">Enable spectral noise reduction</label>
+                </div>
+                <p class="field-description">Experimental filter that can reduce steady background noise.</p>
+              </div>
+              <div class="settings-field checkbox-field">
+                <div class="field-control">
+                  <input id="segmenter-denoise-before-vad" type="checkbox" />
+                  <label for="segmenter-denoise-before-vad">Denoise before VAD</label>
+                </div>
+                <p class="field-description">Applies denoising prior to voice detection. Can reduce sensitivity.</p>
+              </div>
+              <div class="settings-section-footer">
+                <div id="segmenter-status" class="form-status" role="status" aria-live="polite" aria-hidden="true"></div>
+                <div class="button-row">
+                  <button id="segmenter-reset" class="ghost-button" type="button" disabled>Reset</button>
+                  <button id="segmenter-save" class="primary-button" type="submit" disabled>Save changes</button>
+                </div>
+              </div>
+            </form>
+          </section>
+
+          <section
+            class="settings-section recorder-section"
+            data-section-key="adaptive_rms"
+            aria-labelledby="recorder-adaptive-title"
+          >
+            <div class="settings-section-header">
+              <h3 id="recorder-adaptive-title" class="settings-section-title">Adaptive RMS</h3>
+              <p class="settings-section-description">
+                Automatically adjusts the RMS trigger as the room quiets down or becomes noisier.
+              </p>
+            </div>
+            <form id="adaptive-form" class="settings-subform" novalidate>
+              <div class="settings-field checkbox-field">
+                <div class="field-control">
+                  <input id="adaptive-enabled" type="checkbox" />
+                  <label for="adaptive-enabled">Enable adaptive thresholding</label>
+                </div>
+                <p class="field-description">Tracks background noise and scales the trigger dynamically.</p>
+              </div>
+              <div class="settings-field">
+                <label for="adaptive-min-thresh">Minimum threshold</label>
+                <input id="adaptive-min-thresh" type="number" min="0" max="1" step="0.001" />
+                <p class="field-description">Floor for the normalized RMS threshold (0–1 scale).</p>
+              </div>
+              <div class="settings-field">
+                <label for="adaptive-margin">Noise margin</label>
+                <input id="adaptive-margin" type="number" min="0.5" max="10" step="0.05" />
+                <p class="field-description">Multiplier applied to the observed background noise floor.</p>
+              </div>
+              <div class="settings-field">
+                <label for="adaptive-update-interval">Update interval (s)</label>
+                <input id="adaptive-update-interval" type="number" min="0.5" max="120" step="0.5" />
+                <p class="field-description">How frequently the threshold is recomputed.</p>
+              </div>
+              <div class="settings-field">
+                <label for="adaptive-window">Window length (s)</label>
+                <input id="adaptive-window" type="number" min="1" max="300" step="1" />
+                <p class="field-description">Rolling sample window for background RMS estimation.</p>
+              </div>
+              <div class="settings-field">
+                <label for="adaptive-hysteresis">Hysteresis tolerance</label>
+                <input id="adaptive-hysteresis" type="number" min="0" max="1" step="0.01" />
+                <p class="field-description">Minimum proportional change before adopting a new threshold.</p>
+              </div>
+              <div class="settings-field">
+                <label for="adaptive-release">Release percentile</label>
+                <input id="adaptive-release" type="number" min="0.05" max="1" step="0.01" />
+                <p class="field-description">Percentile of the noise distribution used when relaxing the threshold.</p>
+              </div>
+              <div class="settings-section-footer">
+                <div id="adaptive-status" class="form-status" role="status" aria-live="polite" aria-hidden="true"></div>
+                <div class="button-row">
+                  <button id="adaptive-reset" class="ghost-button" type="button" disabled>Reset</button>
+                  <button id="adaptive-save" class="primary-button" type="submit" disabled>Save changes</button>
+                </div>
+              </div>
+            </form>
+          </section>
+
+          <section
+            class="settings-section recorder-section"
+            data-section-key="ingest"
+            aria-labelledby="recorder-ingest-title"
+          >
+            <div class="settings-section-header">
+              <h3 id="recorder-ingest-title" class="settings-section-title">Ingest pipeline</h3>
+              <p class="settings-section-description">
+                Control how files dropped into the ingest directory are validated and accepted.
+              </p>
+            </div>
+            <form id="ingest-form" class="settings-subform" novalidate>
+              <div class="settings-field">
+                <label for="ingest-stable-checks">Stable checks required</label>
+                <input id="ingest-stable-checks" type="number" min="1" max="20" step="1" />
+                <p class="field-description">Number of size checks before a file is considered ready.</p>
+              </div>
+              <div class="settings-field">
+                <label for="ingest-stable-interval">Check interval (s)</label>
+                <input id="ingest-stable-interval" type="number" min="0.1" max="30" step="0.1" />
+                <p class="field-description">Delay between size checks while watching incoming files.</p>
+              </div>
+              <div class="settings-field">
+                <label for="ingest-allowed-ext">Allowed extensions</label>
+                <textarea id="ingest-allowed-ext" rows="3"></textarea>
+                <p class="field-description">One extension per line (include the leading dot).</p>
+              </div>
+              <div class="settings-field">
+                <label for="ingest-ignore-suffixes">Ignore suffixes</label>
+                <textarea id="ingest-ignore-suffixes" rows="3"></textarea>
+                <p class="field-description">File suffixes that indicate partial downloads or temporary files.</p>
+              </div>
+              <div class="settings-section-footer">
+                <div id="ingest-status" class="form-status" role="status" aria-live="polite" aria-hidden="true"></div>
+                <div class="button-row">
+                  <button id="ingest-reset" class="ghost-button" type="button" disabled>Reset</button>
+                  <button id="ingest-save" class="primary-button" type="submit" disabled>Save changes</button>
+                </div>
+              </div>
+            </form>
+          </section>
+
+          <section
+            class="settings-section recorder-section"
+            data-section-key="logging"
+            aria-labelledby="recorder-logging-title"
+          >
+            <div class="settings-section-header">
+              <h3 id="recorder-logging-title" class="settings-section-title">Logging &amp; diagnostics</h3>
+              <p class="settings-section-description">
+                Enable verbose logging for troubleshooting noisy environments or new deployments.
+              </p>
+            </div>
+            <form id="logging-form" class="settings-subform" novalidate>
+              <div class="settings-field checkbox-field">
+                <div class="field-control">
+                  <input id="logging-dev-mode" type="checkbox" />
+                  <label for="logging-dev-mode">Enable developer debug logs</label>
+                </div>
+                <p class="field-description">Outputs per-second segmenter stats to the journal.</p>
+              </div>
+              <div class="settings-section-footer">
+                <div id="logging-status" class="form-status" role="status" aria-live="polite" aria-hidden="true"></div>
+                <div class="button-row">
+                  <button id="logging-reset" class="ghost-button" type="button" disabled>Reset</button>
+                  <button id="logging-save" class="primary-button" type="submit" disabled>Save changes</button>
+                </div>
+              </div>
+            </form>
+          </section>
+
+          <section
+            class="settings-section recorder-section"
+            data-section-key="streaming"
+            aria-labelledby="recorder-streaming-title"
+          >
+            <div class="settings-section-header">
+              <h3 id="recorder-streaming-title" class="settings-section-title">Live streaming</h3>
+              <p class="settings-section-description">
+                Switch between HLS and WebRTC streaming modes and adjust the WebRTC frame buffer.
+              </p>
+            </div>
+            <form id="streaming-form" class="settings-subform" novalidate>
+              <div class="settings-field">
+                <label for="streaming-mode">Streaming mode</label>
+                <select id="streaming-mode">
+                  <option value="hls">HLS (compatible, higher latency)</option>
+                  <option value="webrtc">WebRTC (low latency)</option>
+                </select>
+                <p class="field-description">The dashboard automatically adjusts its player to match.</p>
+              </div>
+              <div class="settings-field">
+                <label for="streaming-history">WebRTC history (s)</label>
+                <input id="streaming-history" type="number" min="1" max="600" step="0.5" />
+                <p class="field-description">Seconds of PCM buffered for WebRTC listeners. Increase to absorb brief stalls.</p>
+              </div>
+              <div class="settings-section-footer">
+                <div id="streaming-status" class="form-status" role="status" aria-live="polite" aria-hidden="true"></div>
+                <div class="button-row">
+                  <button id="streaming-reset" class="ghost-button" type="button" disabled>Reset</button>
+                  <button id="streaming-save" class="primary-button" type="submit" disabled>Save changes</button>
+                </div>
+              </div>
+            </form>
+          </section>
+
+          <section
+            class="settings-section recorder-section"
+            data-section-key="dashboard"
+            aria-labelledby="recorder-dashboard-title"
+          >
+            <div class="settings-section-header">
+              <h3 id="recorder-dashboard-title" class="settings-section-title">Dashboard API access</h3>
+              <p class="settings-section-description">
+                Point static dashboard builds at a remote recorder by overriding the API base URL.
+              </p>
+            </div>
+            <form id="dashboard-form" class="settings-subform" novalidate>
+              <div class="settings-field">
+                <label for="dashboard-api-base">API base URL</label>
+                <input id="dashboard-api-base" type="text" autocomplete="off" />
+                <p class="field-description">
+                  When set, static dashboards use this origin for API and streaming requests (example: <code>https://recorder.local:8080</code>).
+                </p>
+              </div>
+              <div class="settings-section-footer">
+                <div id="dashboard-status" class="form-status" role="status" aria-live="polite" aria-hidden="true"></div>
+                <div class="button-row">
+                  <button id="dashboard-reset" class="ghost-button" type="button" disabled>Reset</button>
+                  <button id="dashboard-save" class="primary-button" type="submit" disabled>Save changes</button>
+                </div>
+              </div>
+            </form>
+          </section>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- add focus management, visibility toggles, and open/close logic for the recorder settings modal, wiring menu entries to launch specific sections
- keep recorder sections in sync with backend config responses and ensure defaults load via initialize()
- highlight the active recorder menu entry for clearer navigation

## Testing
- pytest tests/test_web_dashboard.py *(fails: file not found)*
- pytest tests/test_25_web_streamer.py
- pytest tests/test_37_web_dashboard.py

------
https://chatgpt.com/codex/tasks/task_e_68d8100ae1a48327b420605078f6a767