### PR TITLE
Suspend dashboard refreshes during interactive edits

### DIFF
--- a/lib/webui/static/js/dashboard.js
+++ b/lib/webui/static/js/dashboard.js
@@ -325,6 +325,7 @@ const timeFormatter = new Intl.DateTimeFormat(userLocales, {
 
 let autoRefreshId = null;
 let configRefreshId = null;
+let configRefreshSuspended = false;
 let healthRefreshId = null;
 let healthFetchInFlight = false;
 let healthFetchQueued = false;
@@ -472,6 +473,9 @@ function stopHealthRefresh() {
 
 function startConfigRefresh() {
   stopConfigRefresh();
+  if (configRefreshSuspended) {
+    return;
+  }
   configRefreshId = window.setInterval(() => {
     fetchConfig({ silent: true });
   }, CONFIG_REFRESH_INTERVAL_MS);
@@ -483,6 +487,7 @@ function stopConfigRefresh() {
     configRefreshId = null;
   }
 }
+
 let autoRefreshIntervalMs = AUTO_REFRESH_INTERVAL_MS;
 let autoRefreshSuspended = false;
 let fetchInFlight = false;
@@ -503,6 +508,9 @@ function isInteractiveFormField(element) {
   }
 
   const tagName = element.tagName;
+  if (tagName === "AUDIO" || tagName === "VIDEO") {
+    return true;
+  }
   if (tagName === "TEXTAREA" || tagName === "SELECT") {
     return true;
   }
@@ -525,6 +533,22 @@ function closestInteractiveFormField(element) {
       return current;
     }
     current = current.parentElement;
+  }
+  return null;
+}
+
+function findInteractiveElement(target, event = null) {
+  const candidate = closestInteractiveFormField(target);
+  if (candidate) {
+    return candidate;
+  }
+  if (event && typeof event.composedPath === "function") {
+    const path = event.composedPath();
+    for (const node of path) {
+      if (node instanceof HTMLElement && isInteractiveFormField(node)) {
+        return node;
+      }
+    }
   }
   return null;
 }
@@ -1006,7 +1030,27 @@ function setAutoRefreshInterval(intervalMs) {
   restartAutoRefresh();
 }
 
+function suspendConfigRefresh() {
+  if (configRefreshSuspended) {
+    return;
+  }
+  configRefreshSuspended = true;
+  stopConfigRefresh();
+}
+
+function resumeConfigRefresh() {
+  if (!configRefreshSuspended) {
+    if (!configRefreshId) {
+      startConfigRefresh();
+    }
+    return;
+  }
+  configRefreshSuspended = false;
+  startConfigRefresh();
+}
+
 function suspendAutoRefresh() {
+  suspendConfigRefresh();
   if (autoRefreshSuspended) {
     return;
   }
@@ -1016,12 +1060,14 @@ function suspendAutoRefresh() {
 
 function resumeAutoRefresh() {
   if (!autoRefreshSuspended) {
+    resumeConfigRefresh();
     if (!autoRefreshId) {
       startAutoRefresh();
     }
     return;
   }
   autoRefreshSuspended = false;
+  resumeConfigRefresh();
   startAutoRefresh();
 }
 
@@ -7495,19 +7541,19 @@ function handleServiceListClick(event) {
 function attachEventListeners() {
   if (typeof document !== "undefined") {
     const handleGlobalFocusIn = (event) => {
-      if (closestInteractiveFormField(event.target)) {
+      if (findInteractiveElement(event.target, event)) {
         suspendAutoRefresh();
       }
     };
 
     const handleGlobalFocusOut = (event) => {
-      if (!closestInteractiveFormField(event.target)) {
+      if (!findInteractiveElement(event.target, event)) {
         return;
       }
       window.requestAnimationFrame(() => {
         const active =
           document.activeElement instanceof HTMLElement ? document.activeElement : null;
-        if (!closestInteractiveFormField(active)) {
+        if (!findInteractiveElement(active)) {
           resumeAutoRefresh();
         }
       });
@@ -7516,7 +7562,7 @@ function attachEventListeners() {
     document.addEventListener("focusin", handleGlobalFocusIn);
     document.addEventListener("focusout", handleGlobalFocusOut);
     document.addEventListener("pointerdown", (event) => {
-      if (closestInteractiveFormField(event.target)) {
+      if (findInteractiveElement(event.target, event)) {
         suspendAutoRefresh();
       }
     });


### PR DESCRIPTION
## Summary
- stop the config poller when dashboard interactions suspend auto-refresh and resume it afterwards
- treat audio/video controls as interactive elements and improve interactive element detection using composed paths
- ensure global focus/pointer handlers use the enhanced detection so live updates pause reliably during UI edits

## Testing
- pytest tests/test_37_web_dashboard.py
- pytest tests/test_25_web_streamer.py

------
https://chatgpt.com/codex/tasks/task_e_68d81d0046ec8327abd5b762cee88b46