### PR TITLE
Increase settings modal height usage

### DIFF
--- a/lib/webui/static/css/dashboard.css
+++ b/lib/webui/static/css/dashboard.css
@@ -1207,7 +1207,7 @@ button.small {
 
 .settings-dialog {
   width: min(640px, 96vw);
-  max-height: min(92vh, 720px);
+  max-height: 90vh;
   display: flex;
   flex-direction: column;
   padding: clamp(1.25rem, 1.5vw + 1rem, 1.75rem);
@@ -1265,7 +1265,7 @@ button.small {
 
 .recorder-settings-dialog {
   width: min(860px, 96vw);
-  max-height: min(92vh, 900px);
+  max-height: 90vh;
 }
 
 .recorder-settings-body {


### PR DESCRIPTION
## Summary
- increase the generic settings modal height limit to fill up to 90% of the viewport
- apply the same viewport-based height limit to the recorder settings dialog so more content is visible at once

## Testing
- pytest tests/test_37_web_dashboard.py
- pytest tests/test_25_web_streamer.py

------
https://chatgpt.com/codex/tasks/task_e_68d8211a32ac832791b6d0d0c99b9804