### PR TITLE
Fix duplicate scroll lock helpers in dashboard

### DIFF
--- a/lib/webui/static/js/dashboard.js
+++ b/lib/webui/static/js/dashboard.js
@@ -474,37 +474,6 @@ let healthFetchQueued = false;
 let configFetchInFlight = false;
 let configFetchQueued = false;
 
-const scrollLockState = {
-  locks: new Set(),
-};
-
-function updateDocumentScrollLock() {
-  if (!document || !document.body) {
-    return;
-  }
-  if (scrollLockState.locks.size > 0) {
-    document.body.dataset.scrollLocked = "true";
-  } else if (document.body.dataset.scrollLocked) {
-    delete document.body.dataset.scrollLocked;
-  }
-}
-
-function lockDocumentScroll(lockId) {
-  if (!lockId) {
-    return;
-  }
-  scrollLockState.locks.add(lockId);
-  updateDocumentScrollLock();
-}
-
-function unlockDocumentScroll(lockId) {
-  if (!lockId) {
-    return;
-  }
-  scrollLockState.locks.delete(lockId);
-  updateDocumentScrollLock();
-}
-
 function formatIsoDateTime(isoString) {
   if (typeof isoString !== "string" || !isoString) {
     return null;


### PR DESCRIPTION
## Summary
- remove the duplicate scroll lock helpers in the dashboard JavaScript so the bundle no longer throws a redeclaration error

## Testing
- pytest tests/test_37_web_dashboard.py
- pytest tests/test_25_web_streamer.py

------
https://chatgpt.com/codex/tasks/task_e_68d8388f97388327a15b6939a297d083