### PR TITLE
Refine dark mode palette and unify form field styling

### DIFF
--- a/lib/webui/static/css/dashboard.css
+++ b/lib/webui/static/css/dashboard.css
@@ -1,78 +1,78 @@
 :root {
   color-scheme: light dark;
-  --bg-gradient: linear-gradient(135deg, #0f172a 0%, #1e293b 40%, #111827 100%);
-  --card-bg: rgba(15, 23, 42, 0.75);
-  --card-border: rgba(148, 163, 184, 0.15);
-  --card-shadow: 0 20px 40px -24px rgba(15, 23, 42, 0.6);
-  --primary: #38bdf8;
-  --primary-text: #020617;
+  --bg-gradient: linear-gradient(135deg, #101215 0%, #16191d 45%, #0c0d10 100%);
+  --card-bg: rgba(24, 26, 32, 0.85);
+  --card-border: rgba(107, 114, 128, 0.22);
+  --card-shadow: 0 20px 40px -24px rgba(3, 4, 7, 0.7);
+  --primary: #60a5fa;
+  --primary-text: #0b0f16;
   --danger: #f87171;
-  --text: #e2e8f0;
-  --text-muted: rgba(226, 232, 240, 0.65);
-  --table-border: rgba(148, 163, 184, 0.18);
-  --code-bg: rgba(15, 23, 42, 0.55);
-  --surface-muted: rgba(15, 23, 42, 0.55);
-  --surface-strong: rgba(15, 23, 42, 0.65);
-  --surface-soft: rgba(15, 23, 42, 0.45);
-  --surface-soft-alt: rgba(15, 23, 42, 0.35);
-  --surface-faint: rgba(15, 23, 42, 0.25);
-  --surface-table: rgba(15, 23, 42, 0.5);
-  --surface-overlay: rgba(15, 23, 42, 0.6);
-  --surface-overlay-strong: rgba(15, 23, 42, 0.7);
-  --surface-table-header: rgba(15, 23, 42, 0.8);
-  --overlay-backdrop: rgba(15, 23, 42, 0.72);
-  --overlay-panel: rgba(15, 23, 42, 0.65);
-  --dialog-surface: rgba(15, 23, 42, 0.82);
-  --overlay-solid: rgba(15, 23, 42, 0.9);
-  --divider: rgba(148, 163, 184, 0.12);
-  --storage-track: rgba(148, 163, 184, 0.2);
-  --ghost-border: rgba(148, 163, 184, 0.35);
-  --ghost-border-hover: rgba(148, 163, 184, 0.6);
-  --ghost-border-muted: rgba(148, 163, 184, 0.25);
-  --ghost-border-strong: rgba(148, 163, 184, 0.28);
-  --ghost-border-soft: rgba(148, 163, 184, 0.4);
-  --danger-bg: rgba(248, 113, 113, 0.15);
-  --danger-border: rgba(248, 113, 113, 0.35);
-  --danger-bg-hover: rgba(248, 113, 113, 0.25);
-  --danger-ring: rgba(248, 113, 113, 0.22);
-  --input-focus-border: rgba(56, 189, 248, 0.7);
-  --input-focus-ring: rgba(56, 189, 248, 0.25);
-  --waveform-bg: linear-gradient(180deg, rgba(15, 23, 42, 0.75), rgba(15, 23, 42, 0.55));
-  --waveform-chip-bg: rgba(15, 23, 42, 0.82);
-  --waveform-chip-shadow: 0 12px 28px rgba(15, 23, 42, 0.45);
-  --waveform-border: rgba(148, 163, 184, 0.18);
-  --marker-label-shadow: 0 6px 18px rgba(15, 23, 42, 0.45);
-  --table-footer-bg: rgba(15, 23, 42, 0.5);
-  --table-row-border: rgba(148, 163, 184, 0.22);
-  --table-row-hover-bg: rgba(56, 189, 248, 0.14);
-  --table-row-active-border: rgba(56, 189, 248, 0.45);
-  --table-row-active-ring: rgba(56, 189, 248, 0.35);
-  --action-chip-bg: rgba(15, 23, 42, 0.55);
-  --action-chip-border: rgba(148, 163, 184, 0.35);
-  --modal-shadow: 0 28px 60px -30px rgba(15, 23, 42, 0.85);
-  --mobile-row-shadow: 0 18px 42px -28px rgba(15, 23, 42, 0.9);
-  --service-status-inactive: rgba(148, 163, 184, 0.85);
-  --service-related-heading: rgba(226, 232, 240, 0.55);
-  --service-related-text: rgba(226, 232, 240, 0.8);
-  --service-related-status: rgba(148, 163, 184, 0.9);
-  --service-details-text: rgba(226, 232, 240, 0.5);
-  --service-message-text: rgba(226, 232, 240, 0.92);
-  --service-message-pending-text: rgba(226, 232, 240, 0.85);
-  --banner-bg: rgba(127, 29, 29, 0.42);
-  --banner-border: rgba(248, 113, 113, 0.35);
-  --banner-shadow: rgba(248, 113, 113, 0.55);
-  --banner-icon-bg: rgba(248, 113, 113, 0.15);
-  --banner-icon-border: rgba(248, 113, 113, 0.45);
+  --text: #f3f4f6;
+  --text-muted: rgba(209, 213, 219, 0.65);
+  --table-border: rgba(107, 114, 128, 0.2);
+  --code-bg: rgba(24, 26, 32, 0.7);
+  --surface-muted: rgba(24, 26, 32, 0.7);
+  --surface-strong: rgba(28, 30, 36, 0.82);
+  --surface-soft: rgba(24, 26, 32, 0.55);
+  --surface-soft-alt: rgba(24, 26, 32, 0.45);
+  --surface-faint: rgba(24, 26, 32, 0.35);
+  --surface-table: rgba(28, 30, 36, 0.65);
+  --surface-overlay: rgba(17, 19, 23, 0.7);
+  --surface-overlay-strong: rgba(12, 14, 17, 0.82);
+  --surface-table-header: rgba(32, 34, 40, 0.85);
+  --overlay-backdrop: rgba(10, 11, 15, 0.75);
+  --overlay-panel: rgba(22, 24, 30, 0.78);
+  --dialog-surface: rgba(20, 22, 28, 0.9);
+  --overlay-solid: rgba(12, 13, 16, 0.92);
+  --divider: rgba(107, 114, 128, 0.18);
+  --storage-track: rgba(107, 114, 128, 0.3);
+  --ghost-border: rgba(107, 114, 128, 0.38);
+  --ghost-border-hover: rgba(156, 163, 175, 0.65);
+  --ghost-border-muted: rgba(107, 114, 128, 0.28);
+  --ghost-border-strong: rgba(156, 163, 175, 0.35);
+  --ghost-border-soft: rgba(156, 163, 175, 0.45);
+  --danger-bg: rgba(248, 113, 113, 0.18);
+  --danger-border: rgba(248, 113, 113, 0.38);
+  --danger-bg-hover: rgba(248, 113, 113, 0.28);
+  --danger-ring: rgba(248, 113, 113, 0.24);
+  --input-focus-border: rgba(96, 165, 250, 0.75);
+  --input-focus-ring: rgba(96, 165, 250, 0.28);
+  --waveform-bg: linear-gradient(180deg, rgba(24, 26, 32, 0.78), rgba(17, 19, 24, 0.6));
+  --waveform-chip-bg: rgba(17, 19, 24, 0.9);
+  --waveform-chip-shadow: 0 12px 28px rgba(12, 13, 16, 0.5);
+  --waveform-border: rgba(107, 114, 128, 0.22);
+  --marker-label-shadow: 0 6px 18px rgba(10, 12, 16, 0.5);
+  --table-footer-bg: rgba(24, 26, 32, 0.6);
+  --table-row-border: rgba(107, 114, 128, 0.25);
+  --table-row-hover-bg: rgba(96, 165, 250, 0.16);
+  --table-row-active-border: rgba(96, 165, 250, 0.48);
+  --table-row-active-ring: rgba(96, 165, 250, 0.38);
+  --action-chip-bg: rgba(24, 26, 32, 0.62);
+  --action-chip-border: rgba(107, 114, 128, 0.42);
+  --modal-shadow: 0 28px 60px -30px rgba(8, 9, 12, 0.88);
+  --mobile-row-shadow: 0 18px 42px -28px rgba(8, 9, 12, 0.92);
+  --service-status-inactive: rgba(156, 163, 175, 0.88);
+  --service-related-heading: rgba(209, 213, 219, 0.58);
+  --service-related-text: rgba(229, 231, 235, 0.82);
+  --service-related-status: rgba(209, 213, 219, 0.88);
+  --service-details-text: rgba(209, 213, 219, 0.55);
+  --service-message-text: rgba(243, 244, 246, 0.94);
+  --service-message-pending-text: rgba(229, 231, 235, 0.88);
+  --banner-bg: rgba(127, 29, 29, 0.48);
+  --banner-border: rgba(248, 113, 113, 0.4);
+  --banner-shadow: rgba(248, 113, 113, 0.58);
+  --banner-icon-bg: rgba(248, 113, 113, 0.18);
+  --banner-icon-border: rgba(248, 113, 113, 0.48);
   --banner-text: #fee2e2;
-  --banner-detail: rgba(254, 226, 226, 0.85);
-  --banner-link: #bae6fd;
-  --banner-link-hover: #f8fafc;
-  --menu-active-bg: rgba(59, 130, 246, 0.22);
-  --menu-active-text: rgba(241, 245, 249, 0.95);
-  --menu-hover-bg: rgba(30, 41, 59, 0.85);
-  --menu-section-muted: rgba(148, 163, 184, 0.75);
+  --banner-detail: rgba(254, 226, 226, 0.88);
+  --banner-link: #bfdbfe;
+  --banner-link-hover: #f3f4f6;
+  --menu-active-bg: rgba(96, 165, 250, 0.22);
+  --menu-active-text: rgba(243, 244, 246, 0.95);
+  --menu-hover-bg: rgba(36, 38, 44, 0.85);
+  --menu-section-muted: rgba(156, 163, 175, 0.75);
   --warning: #fb923c;
-  --warning-ring: rgba(251, 146, 60, 0.25);
+  --warning-ring: rgba(251, 146, 60, 0.28);
   --font-family: "Inter", "Segoe UI", system-ui, -apple-system, BlinkMacSystemFont, "Roboto", "Ubuntu", sans-serif;
 }
 
@@ -1480,7 +1480,7 @@ body[data-scroll-locked="true"] {
 
 .settings-field label {
   font-weight: 600;
-  color: rgba(226, 232, 240, 0.95);
+  color: var(--text);
 }
 
 .settings-field input[type="text"],
@@ -1489,9 +1489,9 @@ body[data-scroll-locked="true"] {
   width: 100%;
   padding: 0.65rem 0.75rem;
   border-radius: 0.75rem;
-  border: 1px solid var(--ghost-border-strong);
+  border: 1px solid var(--card-border);
   background: var(--surface-muted);
-  color: rgba(226, 232, 240, 0.98);
+  color: var(--text);
   font-size: 0.95rem;
   transition: border-color 0.2s ease, box-shadow 0.2s ease;
 }
@@ -1499,8 +1499,8 @@ body[data-scroll-locked="true"] {
 .settings-field input[type="text"]:focus,
 .settings-field select:focus,
 .settings-field textarea:focus {
-  border-color: rgba(59, 130, 246, 0.7);
-  box-shadow: 0 0 0 1px rgba(59, 130, 246, 0.35);
+  border-color: var(--input-focus-border);
+  box-shadow: 0 0 0 3px var(--input-focus-ring);
   outline: none;
 }
 
@@ -1518,7 +1518,7 @@ body[data-scroll-locked="true"] {
 .checkbox-field input[type="checkbox"] {
   width: 1.15rem;
   height: 1.15rem;
-  accent-color: rgba(59, 130, 246, 0.9);
+  accent-color: var(--primary);
 }
 
 .field-description {


### PR DESCRIPTION
## Summary
- retune the dashboard dark theme palette around neutral charcoals instead of blue-green tones
- reuse the new palette variables for inputs and checkboxes so form controls look consistent across the UI

## Testing
- pytest tests/test_37_web_dashboard.py tests/test_25_web_streamer.py


------
https://chatgpt.com/codex/tasks/task_e_68d83b0e01bc8327a7b16ff646ceabc7