### PR TITLE
Add live RMS indicator to dashboard header

### DIFF
--- a/lib/web_streamer.py
+++ b/lib/web_streamer.py
@@ -1788,7 +1788,10 @@ def build_app() -> web.Application:
         except OSError:
             return {"capturing": False, "updated_at": None}
 
-        status: dict[str, object] = {"capturing": bool(raw.get("capturing", False))}
+        status: dict[str, object] = {
+            "capturing": bool(raw.get("capturing", False)),
+            "service_running": False,
+        }
         updated_at = raw.get("updated_at")
         if isinstance(updated_at, (int, float)):
             status["updated_at"] = float(updated_at)
@@ -1846,6 +1849,22 @@ def build_app() -> web.Application:
         reason = raw.get("last_stop_reason")
         if isinstance(reason, str) and reason:
             status["last_stop_reason"] = reason
+
+        current_rms = raw.get("current_rms")
+        if isinstance(current_rms, (int, float)) and math.isfinite(current_rms):
+            status["current_rms"] = int(current_rms)
+
+        service_running_raw = raw.get("service_running")
+        if isinstance(service_running_raw, bool):
+            status["service_running"] = service_running_raw
+        elif isinstance(service_running_raw, (int, float)):
+            status["service_running"] = bool(service_running_raw)
+        elif isinstance(service_running_raw, str):
+            normalized = service_running_raw.strip().lower()
+            if normalized in {"1", "true", "yes", "on", "running"}:
+                status["service_running"] = True
+            elif normalized in {"0", "false", "no", "off", "stopped"}:
+                status["service_running"] = False
 
         return status
 

--- a/lib/webui/static/css/dashboard.css
+++ b/lib/webui/static/css/dashboard.css
@@ -436,6 +436,38 @@ body {
   min-width: 0;
 }
 
+.rms-indicator {
+  display: none;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.35rem 0.75rem;
+  border-radius: 999px;
+  border: 1px solid var(--ghost-border-muted);
+  background: var(--surface-muted);
+  color: var(--text-muted);
+  font-size: 0.8rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  white-space: nowrap;
+  box-shadow: 0 10px 24px -18px var(--surface-strong);
+}
+
+.rms-indicator[data-visible="true"] {
+  display: inline-flex;
+}
+
+.rms-indicator .label {
+  text-transform: uppercase;
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  color: var(--text-subtle);
+}
+
+.rms-indicator .value {
+  font-variant-numeric: tabular-nums;
+  color: var(--text-strong);
+}
+
 .recording-indicator {
   display: inline-flex;
   align-items: center;

--- a/lib/webui/static/js/dashboard.js
+++ b/lib/webui/static/js/dashboard.js
@@ -123,6 +123,8 @@ const dom = {
   connectionStatus: document.getElementById("connection-status"),
   recordingIndicator: document.getElementById("recording-indicator"),
   recordingIndicatorText: document.getElementById("recording-indicator-text"),
+  rmsIndicator: document.getElementById("rms-indicator"),
+  rmsIndicatorValue: document.getElementById("rms-indicator-value"),
   applyFilters: document.getElementById("apply-filters"),
   clearFilters: document.getElementById("clear-filters"),
   filterSearch: document.getElementById("filter-search"),
@@ -857,6 +859,11 @@ const captureIndicatorState = {
   message: "",
 };
 
+const rmsIndicatorState = {
+  visible: false,
+  value: null,
+};
+
 function clampLimitValue(value) {
   let candidate = value;
   if (typeof candidate === "string") {
@@ -1252,6 +1259,7 @@ function applyRecordingIndicator(state, message) {
 
 function setRecordingIndicatorUnknown(message = "Status unavailable") {
   applyRecordingIndicator("unknown", message);
+  hideRmsIndicator();
 }
 
 function setRecordingIndicatorStatus(rawStatus) {
@@ -1322,6 +1330,45 @@ function setRecordingIndicatorStatus(rawStatus) {
   }
 
   applyRecordingIndicator(state, message);
+}
+
+function hideRmsIndicator() {
+  if (!dom.rmsIndicator || !dom.rmsIndicatorValue) {
+    return;
+  }
+  if (dom.rmsIndicator.dataset.visible !== "false") {
+    dom.rmsIndicator.dataset.visible = "false";
+  }
+  dom.rmsIndicator.setAttribute("aria-hidden", "true");
+  dom.rmsIndicatorValue.textContent = "";
+  rmsIndicatorState.visible = false;
+  rmsIndicatorState.value = null;
+}
+
+function updateRmsIndicator(rawStatus) {
+  if (!dom.rmsIndicator || !dom.rmsIndicatorValue) {
+    return;
+  }
+  const status = rawStatus && typeof rawStatus === "object" ? rawStatus : null;
+  const running = status ? parseBoolean(status.service_running) : false;
+  const rmsValue = status ? toFiniteOrNull(status.current_rms) : null;
+  if (!running || rmsValue === null) {
+    hideRmsIndicator();
+    return;
+  }
+  const whole = Math.trunc(rmsValue);
+  if (!Number.isFinite(whole)) {
+    hideRmsIndicator();
+    return;
+  }
+  if (rmsIndicatorState.visible && rmsIndicatorState.value === whole) {
+    return;
+  }
+  dom.rmsIndicatorValue.textContent = String(whole);
+  dom.rmsIndicator.dataset.visible = "true";
+  dom.rmsIndicator.setAttribute("aria-hidden", "false");
+  rmsIndicatorState.visible = true;
+  rmsIndicatorState.value = whole;
 }
 
 function handleFetchSuccess() {
@@ -4220,6 +4267,7 @@ async function fetchRecordings(options = {}) {
     updateStats();
     updatePaginationControls();
     setRecordingIndicatorStatus(payload.capture_status);
+    updateRmsIndicator(payload.capture_status);
     handleFetchSuccess();
   } catch (error) {
     console.error("Failed to load recordings", error);
@@ -4238,6 +4286,7 @@ async function fetchRecordings(options = {}) {
     updatePaginationControls();
     handleFetchFailure();
     setRecordingIndicatorUnknown();
+    hideRmsIndicator();
     if (dom.lastUpdated) {
       dom.lastUpdated.textContent = "Offline";
     }

--- a/lib/webui/templates/dashboard.html
+++ b/lib/webui/templates/dashboard.html
@@ -185,6 +185,17 @@
               data-visible="false"
             ></div>
           </div>
+          <div
+            id="rms-indicator"
+            class="rms-indicator"
+            role="status"
+            aria-live="polite"
+            aria-hidden="true"
+            data-visible="false"
+          >
+            <span class="label">RMS:</span>
+            <span id="rms-indicator-value" class="value">0</span>
+          </div>
           <button
             id="theme-toggle"
             class="ghost-button"


### PR DESCRIPTION
## Summary
- extend the recorder status writer so it emits throttled current RMS samples along with a flag indicating when voice-recorder.service is running
- surface the new status fields through the dashboard API and add a header RMS badge that appears beside the recording indicator while the service runs
- style and wire the RMS badge so it updates with the latest integer RMS value and hides itself when status is unknown or the service is stopped

## Testing
- pytest tests/test_37_web_dashboard.py
- pytest tests/test_25_web_streamer.py


------
https://chatgpt.com/codex/tasks/task_e_68d8403596788327ae934cc48b9b84dc