### PR TITLE
Disable aiohttp sendfile fast path for recordings downloads

### DIFF
--- a/lib/web_streamer.py
+++ b/lib/web_streamer.py
@@ -884,8 +884,13 @@ async def _restart_units(units: Iterable[str]) -> list[dict[str, Any]]:
         )
     return results
 
-from aiohttp import web
+from aiohttp import web, web_fileresponse
 from aiohttp.web import AppKey
+
+# aiohttp's sendfile() path sometimes times out on slow or lossy networks when
+# downloading large recordings. Force the chunked fallback, which cooperates
+# better with flow control and avoids surfacing TimeoutError to clients.
+web_fileresponse.NOSENDFILE = True
 
 from lib.hls_controller import controller
 from lib import webui, sd_card_health


### PR DESCRIPTION
## Summary
- force aiohttp's FileResponse to use the chunked fallback, avoiding TimeoutError during slow downloads

## Testing
- pytest tests/test_25_web_streamer.py

------
https://chatgpt.com/codex/tasks/task_e_68d8429df58c8327a1d211ba18cf4e2f