### PR TITLE
Fix keyboard focus after stopping live stream

### DIFF
--- a/lib/webui/static/js/dashboard.js
+++ b/lib/webui/static/js/dashboard.js
@@ -7676,6 +7676,7 @@ function stopLiveStream({ sendSignal = true, useBeacon = false } = {}) {
     dom.liveEncoder.textContent = "stopped";
   }
   setLiveStatus("Idle");
+  releaseLiveAudioFocus();
 }
 
 function openLiveStreamPanel() {
@@ -7712,6 +7713,29 @@ function closeLiveStreamPanel() {
   }
   setLiveButtonState(false);
   stopLiveStream({ sendSignal: true });
+}
+
+function releaseLiveAudioFocus() {
+  if (!dom.liveAudio || typeof document === "undefined") {
+    return;
+  }
+  const active = document.activeElement instanceof HTMLElement ? document.activeElement : null;
+  if (active !== dom.liveAudio) {
+    return;
+  }
+  if (dom.liveToggle && typeof dom.liveToggle.focus === "function" && !dom.liveToggle.disabled) {
+    try {
+      dom.liveToggle.focus();
+      return;
+    } catch (error) {
+      /* ignore focus errors */
+    }
+  }
+  try {
+    dom.liveAudio.blur();
+  } catch (error) {
+    /* ignore blur errors */
+  }
 }
 
 function handleServiceListClick(event) {


### PR DESCRIPTION
## Summary
- add a focus-release helper that blurs the live-stream audio element when the stream stops
- return focus to the live stream toggle so keyboard shortcuts resume controlling the editor

## Testing
- pytest tests/test_37_web_dashboard.py
- pytest tests/test_25_web_streamer.py

## Risk
- Low: front-end focus handling only

------
https://chatgpt.com/codex/tasks/task_e_68d844d57d0083279291cd243e34248e