### PR TITLE
Default clip editor to overwrite existing clips

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,10 +332,11 @@ Common tunables include:
 Select any recording in the dashboard preview pane to open the new **Clip editor**. The inline tool lets you trim the beginning/end of a take or extract a sub-clip without leaving the browser:
 
 - Scrub the waveform or audio player, then use **Set from playhead** to capture precise start/end times. Times may also be entered manually as `MM:SS.mmm` (hours supported).
+- Leave **Overwrite existing?** enabled to replace the selected clip using its current name. Uncheck it to automatically swap in a unique filename; if you typed your own name we preserve it unless a suffix is needed to avoid collisions.
 - Adjust the generated clip name or supply your own; invalid characters are replaced automatically to match on-device storage rules.
 - Click **Save clip** to render a new `.opus` file and waveform sidecar via the existing ffmpeg/Opus pipeline. Reusing an existing clip name replaces that clip in place while leaving the source recording untouched, and each replacement keeps a short-lived undo history that can be restored from the editor.
 
-Clip requests preserve the original day folder, reuse the recording's timestamp (offset by the chosen start), and overwrite an existing clip only when you reuse its name; the source recording itself is never modified.
+Clip requests preserve the original day folder, reuse the recording's timestamp (offset by the chosen start), and overwrite an existing clip when you keep **Overwrite existing?** checked; toggle it off to save the export beside the current clip instead. The source recording itself is never modified.
 
 To manually test the overwrite + undo workflow in the dashboard:
 

--- a/lib/webui/static/css/dashboard.css
+++ b/lib/webui/static/css/dashboard.css
@@ -1140,6 +1140,73 @@ button.small {
   width: 100%;
 }
 
+.clipper-overwrite-row {
+  grid-column: 1 / -1;
+  display: flex;
+  justify-content: flex-start;
+}
+
+.clipper-overwrite-toggle {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.55rem;
+  font-size: 0.85rem;
+  color: var(--text-muted);
+  cursor: pointer;
+  user-select: none;
+}
+
+.clipper-overwrite-toggle input {
+  position: absolute;
+  opacity: 0;
+  width: 1px;
+  height: 1px;
+}
+
+.clipper-overwrite-slider {
+  position: relative;
+  width: 2.1rem;
+  height: 1.1rem;
+  border-radius: 999px;
+  background: rgba(148, 163, 184, 0.3);
+  transition: background 0.2s ease;
+  flex-shrink: 0;
+}
+
+.clipper-overwrite-slider::after {
+  content: "";
+  position: absolute;
+  top: 0.15rem;
+  left: 0.15rem;
+  width: 0.8rem;
+  height: 0.8rem;
+  border-radius: 50%;
+  background: var(--surface);
+  box-shadow: 0 1px 2px rgba(15, 23, 42, 0.2);
+  transition: transform 0.2s ease;
+}
+
+.clipper-overwrite-toggle input:checked + .clipper-overwrite-slider {
+  background: var(--primary);
+}
+
+.clipper-overwrite-toggle input:checked + .clipper-overwrite-slider::after {
+  transform: translateX(1rem);
+}
+
+.clipper-overwrite-toggle input:focus-visible + .clipper-overwrite-slider {
+  box-shadow: 0 0 0 3px var(--input-focus-ring);
+}
+
+.clipper-overwrite-toggle input:disabled + .clipper-overwrite-slider {
+  background: rgba(148, 163, 184, 0.2);
+}
+
+.clipper-overwrite-toggle input:disabled + .clipper-overwrite-slider::after {
+  box-shadow: none;
+}
+
 .clipper-footer {
   display: flex;
   flex-wrap: wrap;

--- a/lib/webui/static/js/dashboard.js
+++ b/lib/webui/static/js/dashboard.js
@@ -196,6 +196,7 @@ const dom = {
   clipperStartInput: document.getElementById("clipper-start"),
   clipperEndInput: document.getElementById("clipper-end"),
   clipperNameInput: document.getElementById("clipper-name"),
+  clipperOverwriteToggle: document.getElementById("clipper-overwrite-toggle"),
   clipperSetStart: document.getElementById("clipper-set-start"),
   clipperSetEnd: document.getElementById("clipper-set-end"),
   clipperReset: document.getElementById("clipper-reset"),
@@ -728,6 +729,7 @@ const clipperState = {
   nameDirty: false,
   lastRecordPath: null,
   undoTokens: new Map(),
+  overwriteExisting: true,
 };
 
 const liveState = {
@@ -1534,11 +1536,89 @@ function sanitizeClipName(value) {
   return truncated.replace(/^[._-]+|[._-]+$/g, "");
 }
 
-function generateClipDefaultName(record, startSeconds, endSeconds) {
-  const baseName = record && typeof record.name === "string" && record.name ? record.name : "clip";
+function getRecordDirectoryPath(record) {
+  if (record && typeof record === "object" && typeof record.path === "string") {
+    const path = record.path;
+    const lastSlash = path.lastIndexOf("/");
+    return lastSlash > 0 ? path.slice(0, lastSlash) : "";
+  }
+  if (typeof record === "string" && record) {
+    const lastSlash = record.lastIndexOf("/");
+    return lastSlash > 0 ? record.slice(0, lastSlash) : "";
+  }
+  return "";
+}
+
+function deriveRecordBaseName(record) {
+  if (record && typeof record === "object" && typeof record.name === "string" && record.name.trim()) {
+    const sanitized = sanitizeClipName(record.name.trim());
+    if (sanitized) {
+      return sanitized;
+    }
+  }
+  let candidate = "";
+  if (record && typeof record === "object" && typeof record.path === "string" && record.path) {
+    const parts = record.path.split("/");
+    candidate = parts[parts.length - 1] || "";
+  }
+  if (!candidate && typeof record === "string") {
+    const parts = record.split("/");
+    candidate = parts[parts.length - 1] || "";
+  }
+  if (candidate.includes(".")) {
+    const dot = candidate.lastIndexOf(".");
+    candidate = dot > 0 ? candidate.slice(0, dot) : candidate;
+  }
+  const sanitized = sanitizeClipName(candidate);
+  return sanitized || "clip";
+}
+
+function getOverwriteClipName(record) {
+  return deriveRecordBaseName(record);
+}
+
+function generateClipRangeName(record, startSeconds, endSeconds) {
+  const baseName = deriveRecordBaseName(record);
   const slug = `${baseName}_${formatTimeSlug(startSeconds)}-${formatTimeSlug(endSeconds)}`;
   const sanitized = sanitizeClipName(slug);
-  return sanitized || "clip";
+  return sanitized || baseName || "clip";
+}
+
+function ensureUniqueClipName(name, record) {
+  const sanitized = sanitizeClipName(name);
+  const baseName = sanitized || "clip";
+  const directory = getRecordDirectoryPath(record);
+  const extension =
+    record && typeof record === "object" && typeof record.extension === "string" && record.extension
+      ? record.extension
+      : "opus";
+  const prefix = directory ? `${directory}/` : "";
+  const knownPaths = new Set();
+  for (const entry of state.records) {
+    if (entry && typeof entry.path === "string") {
+      knownPaths.add(entry.path);
+    }
+  }
+  let candidate = baseName;
+  let suffix = 1;
+  while (true) {
+    const targetPath = `${prefix}${candidate}.${extension}`;
+    if (knownPaths.has(targetPath)) {
+      candidate = `${baseName}-${suffix}`;
+      suffix += 1;
+      continue;
+    }
+    break;
+  }
+  return candidate;
+}
+
+function computeClipDefaultName(record, startSeconds, endSeconds, overwriteExisting = true) {
+  if (overwriteExisting) {
+    return getOverwriteClipName(record);
+  }
+  const rangeName = generateClipRangeName(record, startSeconds, endSeconds);
+  return ensureUniqueClipName(rangeName, record);
 }
 
 function formatClipLengthText(seconds) {
@@ -3093,7 +3173,12 @@ function updateClipperName(record = state.current) {
     dom.clipperNameInput.value = "";
     return;
   }
-  const defaultName = generateClipDefaultName(record, clipperState.startSeconds, clipperState.endSeconds);
+  const defaultName = computeClipDefaultName(
+    record,
+    clipperState.startSeconds,
+    clipperState.endSeconds,
+    clipperState.overwriteExisting,
+  );
   dom.clipperNameInput.value = defaultName;
   clipperState.nameDirty = false;
 }
@@ -3178,6 +3263,10 @@ function updateClipperUI({ updateInputs = true, updateName = true } = {}) {
   if (dom.clipperNameInput) {
     dom.clipperNameInput.disabled = clipperState.busy;
   }
+  if (dom.clipperOverwriteToggle) {
+    dom.clipperOverwriteToggle.checked = clipperState.overwriteExisting;
+    dom.clipperOverwriteToggle.disabled = clipperState.busy;
+  }
 
   if (dom.clipperUndo) {
     let undoToken = null;
@@ -3213,6 +3302,10 @@ function initializeClipper(record) {
     clipperState.statusState = "idle";
     clipperState.nameDirty = false;
     clipperState.lastRecordPath = record && typeof record.path === "string" ? record.path : null;
+    clipperState.overwriteExisting = true;
+    if (dom.clipperOverwriteToggle) {
+      dom.clipperOverwriteToggle.checked = true;
+    }
     setClipperVisible(false);
     updateClipperStatusElement();
     return;
@@ -3226,6 +3319,10 @@ function initializeClipper(record) {
   clipperState.statusState = "idle";
   clipperState.nameDirty = false;
   clipperState.lastRecordPath = record && typeof record.path === "string" ? record.path : null;
+  clipperState.overwriteExisting = true;
+  if (dom.clipperOverwriteToggle) {
+    dom.clipperOverwriteToggle.checked = true;
+  }
   updateClipperUI({ updateInputs: true });
 }
 
@@ -3317,7 +3414,12 @@ function handleClipperNameInput() {
     return;
   }
   const trimmed = dom.clipperNameInput.value.trim();
-  const defaultName = generateClipDefaultName(state.current, clipperState.startSeconds, clipperState.endSeconds);
+  const defaultName = computeClipDefaultName(
+    state.current,
+    clipperState.startSeconds,
+    clipperState.endSeconds,
+    clipperState.overwriteExisting,
+  );
   clipperState.nameDirty = trimmed.length > 0 && trimmed !== defaultName;
 }
 
@@ -3328,6 +3430,59 @@ function handleClipperNameBlur() {
   if (!dom.clipperNameInput.value.trim()) {
     updateClipperName();
   }
+}
+
+function handleClipperOverwriteChange() {
+  if (!dom.clipperOverwriteToggle) {
+    return;
+  }
+  const next = Boolean(dom.clipperOverwriteToggle.checked);
+  if (clipperState.overwriteExisting === next) {
+    return;
+  }
+  clipperState.overwriteExisting = next;
+  if (!state.current || !Number.isFinite(clipperState.durationSeconds)) {
+    updateClipperUI({ updateInputs: false, updateName: false });
+    return;
+  }
+  const defaultOverwrite = computeClipDefaultName(
+    state.current,
+    clipperState.startSeconds,
+    clipperState.endSeconds,
+    true,
+  );
+  const defaultUnique = computeClipDefaultName(
+    state.current,
+    clipperState.startSeconds,
+    clipperState.endSeconds,
+    false,
+  );
+  if (!dom.clipperNameInput) {
+    clipperState.nameDirty = false;
+    updateClipperUI({ updateInputs: false, updateName: false });
+    return;
+  }
+  if (next) {
+    dom.clipperNameInput.value = defaultOverwrite;
+    clipperState.nameDirty = false;
+  } else {
+    const trimmed = dom.clipperNameInput.value.trim();
+    if (!trimmed || trimmed === defaultOverwrite) {
+      dom.clipperNameInput.value = defaultUnique;
+      clipperState.nameDirty = false;
+    } else {
+      const sanitized = sanitizeClipName(trimmed);
+      if (!sanitized) {
+        dom.clipperNameInput.value = defaultUnique;
+        clipperState.nameDirty = false;
+      } else {
+        const ensured = ensureUniqueClipName(sanitized, state.current);
+        dom.clipperNameInput.value = ensured;
+        clipperState.nameDirty = ensured !== defaultUnique;
+      }
+    }
+  }
+  updateClipperUI({ updateInputs: false, updateName: false });
 }
 
 function handleClipperReset() {
@@ -3432,7 +3587,12 @@ async function submitClipperForm(event) {
   }
 
   const record = state.current;
-  const defaultName = generateClipDefaultName(record, clipperState.startSeconds, clipperState.endSeconds);
+  const defaultName = computeClipDefaultName(
+    record,
+    clipperState.startSeconds,
+    clipperState.endSeconds,
+    clipperState.overwriteExisting,
+  );
   let clipName = defaultName;
   if (dom.clipperNameInput) {
     const trimmed = dom.clipperNameInput.value.trim();
@@ -3444,12 +3604,20 @@ async function submitClipperForm(event) {
       }
       dom.clipperNameInput.value = sanitized;
       clipName = sanitized;
-      clipperState.nameDirty = clipName !== defaultName;
     } else {
       dom.clipperNameInput.value = defaultName;
-      clipperState.nameDirty = false;
     }
   }
+
+  if (!clipperState.overwriteExisting) {
+    const ensured = ensureUniqueClipName(clipName, record);
+    if (ensured !== clipName && dom.clipperNameInput) {
+      dom.clipperNameInput.value = ensured;
+    }
+    clipName = ensured;
+  }
+
+  clipperState.nameDirty = clipName !== defaultName;
 
   const payload = {
     source_path: record.path,
@@ -8267,6 +8435,10 @@ function attachEventListeners() {
   if (dom.clipperNameInput) {
     dom.clipperNameInput.addEventListener("input", handleClipperNameInput);
     dom.clipperNameInput.addEventListener("blur", handleClipperNameBlur);
+  }
+
+  if (dom.clipperOverwriteToggle) {
+    dom.clipperOverwriteToggle.addEventListener("change", handleClipperOverwriteChange);
   }
 
   if (dom.clipperForm) {

--- a/lib/webui/templates/dashboard.html
+++ b/lib/webui/templates/dashboard.html
@@ -401,6 +401,13 @@
                       placeholder="New clip name"
                     />
                   </label>
+                  <div class="clipper-overwrite-row">
+                    <label class="clipper-overwrite-toggle" for="clipper-overwrite-toggle">
+                      <input id="clipper-overwrite-toggle" type="checkbox" checked />
+                      <span class="clipper-overwrite-slider" aria-hidden="true"></span>
+                      <span class="clipper-overwrite-label">Overwrite existing?</span>
+                    </label>
+                  </div>
                 </div>
                 <div class="clipper-footer">
                   <div id="clipper-length" class="clipper-length" role="status" aria-live="polite">


### PR DESCRIPTION
## Summary
- default the dashboard clip editor to reuse the selected clip name and expose an Overwrite existing? toggle
- ensure opt-out saves use unique filenames by generating or suffixing names that would collide with existing clips
- style the new control and document the updated workflow in the dashboard README section

## Testing
- pytest tests/test_25_web_streamer.py
- pytest tests/test_37_web_dashboard.py

------
https://chatgpt.com/codex/tasks/task_e_68d8d76f92d883279feb9c266265f791