### PR TITLE
Add status pill row for capture and encoding updates

### DIFF
--- a/lib/web_streamer.py
+++ b/lib/web_streamer.py
@@ -2113,6 +2113,68 @@ def build_app() -> web.Application:
             elif normalized in {"0", "false", "no", "off", "stopped"}:
                 status["service_running"] = False
 
+        duration_seconds = raw.get("event_duration_seconds")
+        if isinstance(duration_seconds, (int, float)) and math.isfinite(duration_seconds):
+            status["event_duration_seconds"] = max(0.0, float(duration_seconds))
+
+        event_size_bytes = raw.get("event_size_bytes")
+        if isinstance(event_size_bytes, (int, float)) and math.isfinite(event_size_bytes):
+            status["event_size_bytes"] = max(0, int(event_size_bytes))
+
+        encoding_raw = raw.get("encoding")
+        if isinstance(encoding_raw, dict):
+            encoding: dict[str, object] = {}
+
+            pending_entries: list[dict[str, object]] = []
+            pending_raw = encoding_raw.get("pending")
+            if isinstance(pending_raw, list):
+                for item in pending_raw:
+                    if not isinstance(item, dict):
+                        continue
+                    entry: dict[str, object] = {}
+                    base_name = item.get("base_name")
+                    if isinstance(base_name, str) and base_name:
+                        entry["base_name"] = base_name
+                    job_id = item.get("id")
+                    if isinstance(job_id, (int, float)) and math.isfinite(job_id):
+                        entry["id"] = int(job_id)
+                    queued_at = item.get("queued_at")
+                    if isinstance(queued_at, (int, float)) and math.isfinite(queued_at):
+                        entry["queued_at"] = float(queued_at)
+                    status_value = item.get("status")
+                    if isinstance(status_value, str) and status_value:
+                        entry["status"] = status_value
+                    if entry:
+                        pending_entries.append(entry)
+            encoding["pending"] = pending_entries
+
+            active_raw = encoding_raw.get("active")
+            if isinstance(active_raw, dict):
+                active_entry: dict[str, object] = {}
+                base_name = active_raw.get("base_name")
+                if isinstance(base_name, str) and base_name:
+                    active_entry["base_name"] = base_name
+                job_id = active_raw.get("id")
+                if isinstance(job_id, (int, float)) and math.isfinite(job_id):
+                    active_entry["id"] = int(job_id)
+                queued_at = active_raw.get("queued_at")
+                if isinstance(queued_at, (int, float)) and math.isfinite(queued_at):
+                    active_entry["queued_at"] = float(queued_at)
+                started_at = active_raw.get("started_at")
+                if isinstance(started_at, (int, float)) and math.isfinite(started_at):
+                    active_entry["started_at"] = float(started_at)
+                duration_value = active_raw.get("duration_seconds")
+                if isinstance(duration_value, (int, float)) and math.isfinite(duration_value):
+                    active_entry["duration_seconds"] = max(0.0, float(duration_value))
+                status_value = active_raw.get("status")
+                if isinstance(status_value, str) and status_value:
+                    active_entry["status"] = status_value
+                if active_entry:
+                    encoding["active"] = active_entry
+
+            if encoding.get("pending") or encoding.get("active"):
+                status["encoding"] = encoding
+
         return status
 
     def _filter_recordings(entries: list[dict[str, object]], request: web.Request) -> dict[str, object]:

--- a/lib/webui/static/css/dashboard.css
+++ b/lib/webui/static/css/dashboard.css
@@ -423,17 +423,33 @@ body {
 
 .header-actions {
   display: flex;
+  flex-direction: column;
+  align-items: flex-end;
   gap: 0.75rem;
+}
+
+.header-controls {
+  display: flex;
   align-items: center;
+  justify-content: flex-end;
+  gap: 0.75rem;
   flex-wrap: wrap;
 }
 
-.header-status {
+.header-status-group {
   display: flex;
   flex-direction: column;
-  align-items: flex-start;
-  gap: 0.35rem;
-  min-width: 0;
+  align-items: flex-end;
+  gap: 0.4rem;
+  width: 100%;
+}
+
+.status-labels {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 0.5rem;
+  flex-wrap: wrap;
 }
 
 .rms-indicator {
@@ -468,7 +484,7 @@ body {
   color: var(--text-strong);
 }
 
-.recording-indicator {
+.status-pill {
   display: inline-flex;
   align-items: center;
   gap: 0.45rem;
@@ -484,6 +500,18 @@ body {
   white-space: nowrap;
 }
 
+.status-pill[data-visible="false"] {
+  display: none;
+}
+
+.status-pill .indicator-text {
+  white-space: nowrap;
+}
+
+.recording-indicator {
+  color: var(--text-muted);
+}
+
 .recording-indicator .indicator-dot {
   width: 0.55rem;
   height: 0.55rem;
@@ -491,10 +519,6 @@ body {
   background: var(--ghost-border-soft);
   box-shadow: 0 0 0 4px rgba(148, 163, 184, 0.15);
   transition: background 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
-}
-
-.recording-indicator .indicator-text {
-  white-space: nowrap;
 }
 
 .recording-indicator[data-state="active"] {
@@ -591,6 +615,8 @@ body {
   letter-spacing: 0.04em;
   color: var(--danger);
   white-space: normal;
+  justify-content: flex-end;
+  text-align: right;
 }
 
 .connection-status[data-visible="true"] {
@@ -2255,8 +2281,26 @@ body[data-scroll-locked="true"] {
 
   .header-actions {
     width: 100%;
+    align-items: flex-start;
+    gap: 0.75rem;
+  }
+
+  .header-controls {
+    width: 100%;
     justify-content: flex-start;
-    gap: 0.5rem;
+  }
+
+  .header-status-group {
+    align-items: flex-start;
+  }
+
+  .status-labels {
+    justify-content: flex-start;
+  }
+
+  .connection-status {
+    justify-content: flex-start;
+    text-align: left;
   }
 
   .titles {

--- a/lib/webui/static/js/dashboard.js
+++ b/lib/webui/static/js/dashboard.js
@@ -40,6 +40,13 @@ function apiPath(path) {
   return `${API_BASE}${normalized}`;
 }
 
+function nowMilliseconds() {
+  if (typeof performance !== "undefined" && typeof performance.now === "function") {
+    return performance.now();
+  }
+  return Date.now();
+}
+
 const AUTO_REFRESH_INTERVAL_MS = 1000;
 const OFFLINE_REFRESH_INTERVAL_MS = 5000;
 const REFRESH_INDICATOR_DELAY_MS = 600;
@@ -123,8 +130,12 @@ const dom = {
   connectionStatus: document.getElementById("connection-status"),
   recordingIndicator: document.getElementById("recording-indicator"),
   recordingIndicatorText: document.getElementById("recording-indicator-text"),
+  recordingMeta: document.getElementById("recording-meta"),
+  recordingMetaText: document.getElementById("recording-meta-text"),
   rmsIndicator: document.getElementById("rms-indicator"),
   rmsIndicatorValue: document.getElementById("rms-indicator-value"),
+  encodingStatus: document.getElementById("encoding-status"),
+  encodingStatusText: document.getElementById("encoding-status-text"),
   applyFilters: document.getElementById("apply-filters"),
   clearFilters: document.getElementById("clear-filters"),
   filterSearch: document.getElementById("filter-search"),
@@ -866,6 +877,35 @@ const rmsIndicatorState = {
   value: null,
 };
 
+const recordingMetaState = {
+  active: false,
+  baseDuration: 0,
+  baseTime: 0,
+  sizeBytes: 0,
+  text: "",
+};
+
+const recordingMetaTicker = {
+  handle: null,
+  usingAnimationFrame: false,
+};
+
+const encodingStatusState = {
+  visible: false,
+  hasActive: false,
+  durationBase: 0,
+  baseTime: 0,
+  text: "",
+  activeLabel: "",
+  pendingCount: 0,
+  nextLabel: "",
+};
+
+const encodingStatusTicker = {
+  handle: null,
+  usingAnimationFrame: false,
+};
+
 function clampLimitValue(value) {
   let candidate = value;
   if (typeof candidate === "string") {
@@ -1262,6 +1302,8 @@ function applyRecordingIndicator(state, message) {
 function setRecordingIndicatorUnknown(message = "Status unavailable") {
   applyRecordingIndicator("unknown", message);
   hideRmsIndicator();
+  hideRecordingMeta();
+  hideEncodingStatus();
 }
 
 function setRecordingIndicatorStatus(rawStatus) {
@@ -1299,7 +1341,7 @@ function setRecordingIndicatorStatus(rawStatus) {
       }
       const trigger = toFiniteOrNull(event.trigger_rms);
       if (trigger !== null) {
-        detail = `RMS ${Math.round(trigger)}`;
+        detail = `Triggered @ ${Math.round(trigger)}`;
       } else if (typeof event.base_name === "string" && event.base_name) {
         detail = event.base_name;
       }
@@ -1332,6 +1374,299 @@ function setRecordingIndicatorStatus(rawStatus) {
   }
 
   applyRecordingIndicator(state, message);
+}
+
+function scheduleRecordingMetaTick() {
+  if (!recordingMetaState.active) {
+    return;
+  }
+  if (recordingMetaTicker.handle !== null) {
+    return;
+  }
+  if (
+    typeof window !== "undefined" &&
+    typeof window.requestAnimationFrame === "function"
+  ) {
+    recordingMetaTicker.handle = window.requestAnimationFrame(handleRecordingMetaTick);
+    recordingMetaTicker.usingAnimationFrame = true;
+  } else {
+    recordingMetaTicker.handle = setTimeout(() => {
+      recordingMetaTicker.handle = null;
+      handleRecordingMetaTick();
+    }, 500);
+    recordingMetaTicker.usingAnimationFrame = false;
+  }
+}
+
+function cancelRecordingMetaTick() {
+  if (recordingMetaTicker.handle === null) {
+    return;
+  }
+  if (
+    recordingMetaTicker.usingAnimationFrame &&
+    typeof window !== "undefined" &&
+    typeof window.cancelAnimationFrame === "function"
+  ) {
+    window.cancelAnimationFrame(recordingMetaTicker.handle);
+  } else {
+    clearTimeout(recordingMetaTicker.handle);
+  }
+  recordingMetaTicker.handle = null;
+  recordingMetaTicker.usingAnimationFrame = false;
+}
+
+function handleRecordingMetaTick() {
+  recordingMetaTicker.handle = null;
+  if (!recordingMetaState.active) {
+    return;
+  }
+  renderRecordingMeta();
+  scheduleRecordingMetaTick();
+}
+
+function renderRecordingMeta() {
+  if (!dom.recordingMeta || !dom.recordingMetaText || !recordingMetaState.active) {
+    return;
+  }
+  const elapsedSeconds = Math.max(
+    0,
+    recordingMetaState.baseDuration + (nowMilliseconds() - recordingMetaState.baseTime) / 1000,
+  );
+  const sizeBytes = Number.isFinite(recordingMetaState.sizeBytes)
+    ? Math.max(0, recordingMetaState.sizeBytes)
+    : 0;
+  const text = `${formatShortDuration(elapsedSeconds)} • ${formatBytes(sizeBytes)}`;
+  if (text === recordingMetaState.text) {
+    return;
+  }
+  dom.recordingMetaText.textContent = text;
+  dom.recordingMeta.dataset.visible = "true";
+  dom.recordingMeta.setAttribute("aria-hidden", "false");
+  recordingMetaState.text = text;
+}
+
+function hideRecordingMeta() {
+  if (!dom.recordingMeta || !dom.recordingMetaText) {
+    return;
+  }
+  cancelRecordingMetaTick();
+  recordingMetaState.active = false;
+  recordingMetaState.baseDuration = 0;
+  recordingMetaState.baseTime = nowMilliseconds();
+  recordingMetaState.sizeBytes = 0;
+  recordingMetaState.text = "";
+  dom.recordingMeta.dataset.visible = "false";
+  dom.recordingMeta.setAttribute("aria-hidden", "true");
+  dom.recordingMetaText.textContent = "";
+}
+
+function updateRecordingMeta(rawStatus) {
+  if (!dom.recordingMeta || !dom.recordingMetaText) {
+    return;
+  }
+  const status = rawStatus && typeof rawStatus === "object" ? rawStatus : null;
+  const capturing = status ? Boolean(status.capturing) : false;
+  if (!capturing) {
+    hideRecordingMeta();
+    return;
+  }
+  const durationSeconds = status ? toFiniteOrNull(status.event_duration_seconds) : null;
+  const sizeBytes = status ? toFiniteOrNull(status.event_size_bytes) : null;
+  const event = status && typeof status.event === "object" ? status.event : null;
+  const startedEpoch = event ? toFiniteOrNull(event.started_epoch) : null;
+
+  if (durationSeconds !== null) {
+    recordingMetaState.baseDuration = Math.max(0, durationSeconds);
+    recordingMetaState.baseTime = nowMilliseconds();
+  } else if (startedEpoch !== null) {
+    recordingMetaState.baseDuration = Math.max(0, Date.now() / 1000 - startedEpoch);
+    recordingMetaState.baseTime = nowMilliseconds();
+  } else if (!recordingMetaState.active) {
+    recordingMetaState.baseDuration = 0;
+    recordingMetaState.baseTime = nowMilliseconds();
+  }
+
+  if (sizeBytes !== null) {
+    recordingMetaState.sizeBytes = Math.max(0, sizeBytes);
+  }
+
+  recordingMetaState.active = true;
+  recordingMetaState.text = "";
+  renderRecordingMeta();
+  scheduleRecordingMetaTick();
+}
+
+function scheduleEncodingStatusTick() {
+  if (!encodingStatusState.hasActive) {
+    return;
+  }
+  if (encodingStatusTicker.handle !== null) {
+    return;
+  }
+  if (
+    typeof window !== "undefined" &&
+    typeof window.requestAnimationFrame === "function"
+  ) {
+    encodingStatusTicker.handle = window.requestAnimationFrame(handleEncodingStatusTick);
+    encodingStatusTicker.usingAnimationFrame = true;
+  } else {
+    encodingStatusTicker.handle = setTimeout(() => {
+      encodingStatusTicker.handle = null;
+      handleEncodingStatusTick();
+    }, 500);
+    encodingStatusTicker.usingAnimationFrame = false;
+  }
+}
+
+function cancelEncodingStatusTick() {
+  if (encodingStatusTicker.handle === null) {
+    return;
+  }
+  if (
+    encodingStatusTicker.usingAnimationFrame &&
+    typeof window !== "undefined" &&
+    typeof window.cancelAnimationFrame === "function"
+  ) {
+    window.cancelAnimationFrame(encodingStatusTicker.handle);
+  } else {
+    clearTimeout(encodingStatusTicker.handle);
+  }
+  encodingStatusTicker.handle = null;
+  encodingStatusTicker.usingAnimationFrame = false;
+}
+
+function handleEncodingStatusTick() {
+  encodingStatusTicker.handle = null;
+  if (!encodingStatusState.hasActive) {
+    return;
+  }
+  renderEncodingStatus();
+  scheduleEncodingStatusTick();
+}
+
+function renderEncodingStatus() {
+  if (!dom.encodingStatus || !dom.encodingStatusText) {
+    return;
+  }
+  if (!encodingStatusState.visible) {
+    if (dom.encodingStatus.dataset.visible !== "false") {
+      dom.encodingStatus.dataset.visible = "false";
+      dom.encodingStatus.setAttribute("aria-hidden", "true");
+      dom.encodingStatusText.textContent = "";
+    }
+    encodingStatusState.text = "";
+    return;
+  }
+  let durationSeconds = Math.max(0, encodingStatusState.durationBase);
+  if (encodingStatusState.hasActive) {
+    durationSeconds = Math.max(
+      0,
+      encodingStatusState.durationBase + (nowMilliseconds() - encodingStatusState.baseTime) / 1000,
+    );
+  }
+  const parts = [];
+  if (encodingStatusState.hasActive) {
+    parts.push("Encoding active");
+    if (encodingStatusState.activeLabel) {
+      parts.push(encodingStatusState.activeLabel);
+    }
+    parts.push(formatShortDuration(durationSeconds));
+    if (encodingStatusState.pendingCount > 0) {
+      parts.push(
+        encodingStatusState.pendingCount === 1
+          ? "1 pending"
+          : `${encodingStatusState.pendingCount} pending`,
+      );
+    }
+  } else {
+    parts.push("Encoding pending");
+    if (encodingStatusState.pendingCount > 0) {
+      parts.push(
+        encodingStatusState.pendingCount === 1
+          ? "1 job queued"
+          : `${encodingStatusState.pendingCount} jobs queued`,
+      );
+    }
+    if (encodingStatusState.nextLabel) {
+      parts.push(`Next: ${encodingStatusState.nextLabel}`);
+    }
+  }
+  const text = parts.join(" • ");
+  if (text === encodingStatusState.text) {
+    return;
+  }
+  dom.encodingStatusText.textContent = text;
+  dom.encodingStatus.dataset.visible = "true";
+  dom.encodingStatus.setAttribute("aria-hidden", "false");
+  encodingStatusState.text = text;
+}
+
+function hideEncodingStatus() {
+  if (!dom.encodingStatus || !dom.encodingStatusText) {
+    return;
+  }
+  cancelEncodingStatusTick();
+  encodingStatusState.visible = false;
+  encodingStatusState.hasActive = false;
+  encodingStatusState.durationBase = 0;
+  encodingStatusState.baseTime = nowMilliseconds();
+  encodingStatusState.activeLabel = "";
+  encodingStatusState.pendingCount = 0;
+  encodingStatusState.nextLabel = "";
+  encodingStatusState.text = "";
+  dom.encodingStatus.dataset.visible = "false";
+  dom.encodingStatus.setAttribute("aria-hidden", "true");
+  dom.encodingStatusText.textContent = "";
+}
+
+function updateEncodingStatus(rawStatus) {
+  if (!dom.encodingStatus || !dom.encodingStatusText) {
+    return;
+  }
+  const status = rawStatus && typeof rawStatus === "object" ? rawStatus : null;
+  const encoding = status && typeof status.encoding === "object" ? status.encoding : null;
+  const pending = encoding && Array.isArray(encoding.pending) ? encoding.pending : [];
+  const active = encoding && encoding.active && typeof encoding.active === "object"
+    ? encoding.active
+    : null;
+
+  if ((!pending || pending.length === 0) && !active) {
+    hideEncodingStatus();
+    return;
+  }
+
+  encodingStatusState.visible = true;
+  encodingStatusState.pendingCount = Array.isArray(pending) ? pending.length : 0;
+  encodingStatusState.nextLabel =
+    encodingStatusState.pendingCount > 0 && typeof pending[0].base_name === "string"
+      ? pending[0].base_name
+      : "";
+
+  if (active) {
+    encodingStatusState.hasActive = true;
+    encodingStatusState.activeLabel =
+      typeof active.base_name === "string" ? active.base_name : "";
+    const startedAt = toFiniteOrNull(active.started_at);
+    let baseDuration = toFiniteOrNull(active.duration_seconds);
+    if (!Number.isFinite(baseDuration)) {
+      baseDuration = startedAt !== null ? Math.max(0, Date.now() / 1000 - startedAt) : 0;
+    }
+    encodingStatusState.durationBase = Math.max(0, baseDuration || 0);
+    encodingStatusState.baseTime = nowMilliseconds();
+  } else {
+    encodingStatusState.hasActive = false;
+    encodingStatusState.activeLabel = "";
+    encodingStatusState.durationBase = 0;
+    encodingStatusState.baseTime = nowMilliseconds();
+  }
+
+  encodingStatusState.text = "";
+  renderEncodingStatus();
+  if (encodingStatusState.hasActive) {
+    scheduleEncodingStatusTick();
+  } else {
+    cancelEncodingStatusTick();
+  }
 }
 
 function hideRmsIndicator() {
@@ -1421,6 +1756,22 @@ function formatDuration(seconds) {
     return "--";
   }
   const totalSeconds = Math.round(seconds);
+  const hours = Math.floor(totalSeconds / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const secs = totalSeconds % 60;
+  if (hours > 0) {
+    return `${hours}:${minutes.toString().padStart(2, "0")}:${secs
+      .toString()
+      .padStart(2, "0")}`;
+  }
+  return `${minutes}:${secs.toString().padStart(2, "0")}`;
+}
+
+function formatShortDuration(seconds) {
+  if (!Number.isFinite(seconds) || seconds <= 0) {
+    return "0:00";
+  }
+  const totalSeconds = Math.floor(seconds);
   const hours = Math.floor(totalSeconds / 3600);
   const minutes = Math.floor((totalSeconds % 3600) / 60);
   const secs = totalSeconds % 60;
@@ -4388,6 +4739,8 @@ async function fetchRecordings(options = {}) {
     updatePaginationControls();
     setRecordingIndicatorStatus(payload.capture_status);
     updateRmsIndicator(payload.capture_status);
+    updateRecordingMeta(payload.capture_status);
+    updateEncodingStatus(payload.capture_status);
     handleFetchSuccess();
   } catch (error) {
     console.error("Failed to load recordings", error);

--- a/lib/webui/templates/dashboard.html
+++ b/lib/webui/templates/dashboard.html
@@ -164,17 +164,73 @@
           <h1>Dashboard</h1>
         </div>
         <div class="header-actions">
-          <div class="header-status">
+          <div class="header-controls">
             <div
-              id="recording-indicator"
-              class="recording-indicator"
+              id="rms-indicator"
+              class="rms-indicator"
               role="status"
               aria-live="polite"
-              aria-hidden="false"
-              data-state="unknown"
+              aria-hidden="true"
+              data-visible="false"
             >
-              <span class="indicator-dot" aria-hidden="true"></span>
-              <span id="recording-indicator-text" class="indicator-text">Loading status…</span>
+              <span class="label">RMS:</span>
+              <span id="rms-indicator-value" class="value">0</span>
+            </div>
+            <button
+              id="theme-toggle"
+              class="ghost-button"
+              type="button"
+              aria-pressed="false"
+              aria-label="Toggle light and dark theme"
+            >
+              Toggle theme
+            </button>
+            <button id="live-stream-toggle" class="primary-button" type="button">Live Stream</button>
+            <div
+              id="refresh-indicator"
+              class="refresh-indicator"
+              role="status"
+              aria-live="polite"
+              aria-hidden="true"
+              data-visible="false"
+            >
+              <span class="refresh-spinner" aria-hidden="true"></span>
+              <span class="refresh-text">Refreshing…</span>
+            </div>
+          </div>
+          <div class="header-status-group">
+            <div class="status-labels">
+              <div
+                id="recording-indicator"
+                class="status-pill recording-indicator"
+                role="status"
+                aria-live="polite"
+                aria-hidden="false"
+                data-state="unknown"
+              >
+                <span class="indicator-dot" aria-hidden="true"></span>
+                <span id="recording-indicator-text" class="indicator-text">Loading status…</span>
+              </div>
+              <div
+                id="recording-meta"
+                class="status-pill"
+                role="status"
+                aria-live="polite"
+                aria-hidden="true"
+                data-visible="false"
+              >
+                <span id="recording-meta-text" class="indicator-text"></span>
+              </div>
+              <div
+                id="encoding-status"
+                class="status-pill"
+                role="status"
+                aria-live="polite"
+                aria-hidden="true"
+                data-visible="false"
+              >
+                <span id="encoding-status-text" class="indicator-text"></span>
+              </div>
             </div>
             <div
               id="connection-status"
@@ -185,38 +241,6 @@
               data-visible="false"
             ></div>
           </div>
-          <div
-            id="rms-indicator"
-            class="rms-indicator"
-            role="status"
-            aria-live="polite"
-            aria-hidden="true"
-            data-visible="false"
-          >
-            <span class="label">RMS:</span>
-            <span id="rms-indicator-value" class="value">0</span>
-          </div>
-          <button
-            id="theme-toggle"
-            class="ghost-button"
-            type="button"
-            aria-pressed="false"
-            aria-label="Toggle light and dark theme"
-          >
-            Toggle theme
-          </button>
-          <div
-            id="refresh-indicator"
-            class="refresh-indicator"
-            role="status"
-            aria-live="polite"
-            aria-hidden="true"
-            data-visible="false"
-          >
-            <span class="refresh-spinner" aria-hidden="true"></span>
-            <span class="refresh-text">Refreshing…</span>
-          </div>
-          <button id="live-stream-toggle" class="primary-button" type="button">Live Stream</button>
         </div>
       </header>
       <section class="status-bar">


### PR DESCRIPTION
## Summary
- track capture event duration/size and encoding queue status in the segmenter status payload
- restyle the dashboard header to introduce a status-pill row for recording, metadata, and encoding updates
- update dashboard scripts to surface the new status labels, live timers, and "Triggered @" wording for active recordings

## Testing
- pytest tests/test_37_web_dashboard.py
- pytest tests/test_25_web_streamer.py

------
https://chatgpt.com/codex/tasks/task_e_68d8dcd2e73883279f253b249e9ed52d