### PR TITLE
Ensure installer restarts active Dropbox units

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -189,12 +189,19 @@ else
   say "DEV=1: skipping systemctl enable/start"
 fi
 
-say "Reloading systemd & and voice-recorder if running..."
+say "Reloading systemd and restarting active services..."
 sudo systemctl daemon-reload || true
 sudo systemctl restart web-streamer.service || true
 
-if systemctl is-active --quiet voice-recorder.service; then
-  sudo systemctl restart voice-recorder.service || true
-fi
+restart_if_active() {
+  local unit="$1"
+  if systemctl is-active --quiet "$unit"; then
+    sudo systemctl restart "$unit" || true
+  fi
+}
+
+restart_if_active voice-recorder.service
+restart_if_active dropbox.service
+restart_if_active dropbox.path
 
 say "Install complete"


### PR DESCRIPTION
## Summary
- restart Dropbox systemd units from the installer only when they are already active
- reuse a helper to restart the voice recorder, Dropbox service, and Dropbox path units conditionally

## Risk
- Low: only adjusts service restart behavior in the install script.

## Testing
- `DEV=1 pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68d8f97500988327b842b548350ffb5e