### PR TITLE
Disable auto update when DEV install

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,7 +249,7 @@ Copy `updater.env-example` to `/etc/tricorder/update.env` (or another path refer
 - `TRICORDER_UPDATE_DIR` – Working directory for the updater checkout (default `/apps/tricorder/repo`).
 - `TRICORDER_INSTALL_BASE` / `TRICORDER_INSTALL_SCRIPT` – Override install location or script if needed.
 - `TRICORDER_UPDATE_SERVICES` – Space-separated units to restart after an update.
-- `DEV=1` – Disable the updater without removing the timer.
+- `DEV=1` – Disable the updater and mark the install as dev mode so the systemd unit stays inactive even after a reboot.
 
 The timer is configured for short intervals in tests; adjust to a longer cadence in production.
 

--- a/install.sh
+++ b/install.sh
@@ -15,6 +15,7 @@ VENV="$BASE/venv"
 SYSTEMD_DIR="/etc/systemd/system"
 PY_VER=$(python3 -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")')
 SITE=$VENV/lib/python$PY_VER/site-packages
+DEV_SENTINEL="$BASE/.dev-mode"
 
 UNITS=(voice-recorder.service web-streamer.service sd-card-monitor.service dropbox.service dropbox.path tmpfs-guard.service tmpfs-guard.timer tricorder-auto-update.service tricorder-auto-update.timer tricorder.target)
 
@@ -172,6 +173,7 @@ if [[ "${DEV:-0}" == "1" ]]; then
 fi
 
 if [[ "${DEV:-0}" != "1" ]]; then
+  rm -f "$DEV_SENTINEL"
   say "Enable, reload, and restart Systemd units"
   sudo systemctl daemon-reload
   for unit in voice-recorder.service web-streamer.service sd-card-monitor.service dropbox.service tmpfs-guard.service tricorder-auto-update.service; do
@@ -186,6 +188,8 @@ if [[ "${DEV:-0}" != "1" ]]; then
   sudo systemctl restart tricorder.target || true
 
 else
+  say "DEV=1: marking install as dev mode"
+  touch "$DEV_SENTINEL"
   say "DEV=1: skipping systemctl enable/start"
 fi
 

--- a/systemd/tricorder-auto-update.service
+++ b/systemd/tricorder-auto-update.service
@@ -2,11 +2,13 @@
 Description=Tricorder auto-update service
 After=network-online.target
 Wants=network-online.target
+ConditionPathExists=!/apps/tricorder/.dev-mode
 
 [Service]
 Type=oneshot
 EnvironmentFile=-/etc/tricorder/update.env
 WorkingDirectory=/apps/tricorder
+ExecCondition=/bin/sh -c '[ "${DEV:-0}" != "1" ]'
 ExecStart=/apps/tricorder/bin/tricorder_auto_update.sh
 
 [Install]


### PR DESCRIPTION
## Summary
- write a dev-mode sentinel during DEV=1 installs and clean it up for production installs
- gate the tricorder-auto-update service on the sentinel and DEV flag so dev boxes skip the timer run
- document the persistent dev-mode behavior in the README

## Testing
- export DEV=1 && pytest -q


------
https://chatgpt.com/codex/tasks/task_e_68d8fa02b5e883279ea40156fc140dbd