### PR TITLE
Add configurable event tags and align downstream consumers

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,12 +273,13 @@ Environment variables override YAML values. Common overrides include:
 - `REC_DIR`, `TMP_DIR`, `DROPBOX_DIR` — paths for recordings, tmpfs, and dropbox.
 - `INGEST_STABLE_CHECKS`, `INGEST_STABLE_INTERVAL_SEC`, `INGEST_ALLOWED_EXT` — ingest tunables.
 - `ADAPTIVE_RMS_*` — detailed control of the adaptive RMS tracker.
+- `EVENT_TAG_HUMAN`, `EVENT_TAG_OTHER`, `EVENT_TAG_BOTH` — override event labels without editing YAML.
 
 Key configuration sections (see `config.yaml` for defaults and documentation):
 
 - `audio` – device, sample rate, frame size, gain, VAD aggressiveness.
 - `paths` – tmpfs, recordings, dropbox, ingest work directory, encoder script path.
-- `segmenter` – pre/post pads, RMS threshold, debounce windows, optional denoise toggles.
+- `segmenter` – pre/post pads, RMS threshold, debounce windows, optional denoise toggles, custom event tags.
 - `adaptive_rms` – background noise follower for automatically raising/lowering thresholds.
 - `ingest` – file stability checks, extension filters, ignore suffixes.
 - `logging` – developer-mode verbosity toggle.
@@ -336,7 +337,7 @@ Set `notifications.enabled` to `true` to emit callbacks after each recorded even
 
 Common tunables include:
 
-- `notifications.allowed_event_types` – restrict alerts to specific event classifications (e.g., `["Human", "Both"]`).
+- `notifications.allowed_event_types` – restrict alerts to specific event classifications (e.g., `["Human", "Both"]`), and canonical names still work if the segmenter tags are renamed.
 - `notifications.min_trigger_rms` – only notify on clips that exceed the configured RMS threshold.
 - `notifications.webhook.headers` / `method` / `timeout_sec` – customize webhook POST requests for downstream services.
 - `notifications.email.subject_template` / `body_template` – adjust the rendered message content for email delivery.

--- a/config.yaml
+++ b/config.yaml
@@ -114,6 +114,13 @@ segmenter:
   # Keep modest to avoid memory spikes. Typical: 256–1024.
   max_queue_frames: 512
 
+  # Optional custom labels for event classifications. These strings are embedded in filenames,
+  # notification payloads, and transcript metadata.
+  event_tags:
+    human: "Human"
+    other: "Other"
+    both: "Both"
+
 adaptive_rms:
   # Enable adaptive thresholding to track background RMS levels. When false, the fixed
   # segmenter.rms_threshold is used.

--- a/lib/notifications.py
+++ b/lib/notifications.py
@@ -8,11 +8,13 @@ import socket
 import ssl
 import threading
 import time
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from email.message import EmailMessage
 from typing import Any
 from urllib.error import URLError
 from urllib.request import Request, urlopen
+
+from lib.config import event_type_aliases, get_cfg
 
 
 def _as_int(value: Any, default: int | None = None) -> int | None:
@@ -34,15 +36,35 @@ def _as_list(value: Any) -> list[str]:
 class NotificationFilters:
     min_trigger_rms: int | None = None
     allowed_types: tuple[str, ...] = ()
+    alias_map: dict[str, str] = field(default_factory=dict)
 
     @classmethod
     def from_cfg(cls, cfg: dict[str, Any] | None) -> "NotificationFilters":
         cfg = cfg or {}
         min_trigger = _as_int(cfg.get("min_trigger_rms"))
-        allowed = tuple(
-            event_type for event_type in _as_list(cfg.get("allowed_event_types"))
+        allowed_input = _as_list(cfg.get("allowed_event_types"))
+        alias_map = event_type_aliases(get_cfg())
+
+        normalised: list[str] = []
+        for raw in allowed_input:
+            token = raw.strip()
+            if not token:
+                continue
+            mapped = alias_map.get(token.lower())
+            normalised.append(mapped if mapped else token)
+
+        deduped: list[str] = []
+        seen: set[str] = set()
+        for item in normalised:
+            if item not in seen:
+                deduped.append(item)
+                seen.add(item)
+
+        return cls(
+            min_trigger_rms=min_trigger,
+            allowed_types=tuple(deduped),
+            alias_map=dict(alias_map),
         )
-        return cls(min_trigger_rms=min_trigger, allowed_types=allowed)
 
     def matches(self, event: dict[str, Any]) -> bool:
         trigger = _as_int(event.get("trigger_rms"))
@@ -52,8 +74,10 @@ class NotificationFilters:
             return False
 
         if self.allowed_types:
-            etype = str(event.get("etype", ""))
-            if etype not in self.allowed_types:
+            raw_type = str(event.get("etype", ""))
+            lookup = raw_type.strip().lower()
+            mapped = self.alias_map.get(lookup, raw_type.strip())
+            if mapped not in self.allowed_types:
                 return False
 
         return True

--- a/lib/segmenter.py
+++ b/lib/segmenter.py
@@ -19,10 +19,11 @@ warnings.filterwarnings(
     message="pkg_resources is deprecated as an API.*"
 )
 import webrtcvad    # noqa
-from lib.config import get_cfg
+from lib.config import get_cfg, resolve_event_tags
 from lib.notifications import build_dispatcher
 
 cfg = get_cfg()
+EVENT_TAGS = resolve_event_tags(cfg)
 NOTIFIER = build_dispatcher(cfg.get("notifications"))
 
 # ANSI colors for booleans (can be disabled via NO_COLOR env)
@@ -889,7 +890,12 @@ class TimelineRecorder:
             self._reset_event_state()
             return
 
-        etype = "Both" if (self.saw_voiced and self.saw_loud) else ("Human" if self.saw_voiced else "Other")
+        if self.saw_voiced and self.saw_loud:
+            etype = EVENT_TAGS["both"]
+        elif self.saw_voiced:
+            etype = EVENT_TAGS["human"]
+        else:
+            etype = EVENT_TAGS["other"]
         avg_rms = (self.sum_rms / self.frames_written) if self.frames_written else 0.0
         trigger_rms = int(self.trigger_rms) if self.trigger_rms is not None else 0
 


### PR DESCRIPTION
## Summary
- add configurable event tag labels with environment overrides and sample config updates
- normalize segmenter, notifications, and transcription to honour custom labels while keeping canonical aliases
- cover the new behaviour with tests and documentation updates

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d8f688e7dc8327b9fa67262a26c1fb