### PR TITLE
TR-14 Add bulk download and rename support for recordings

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,38 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**Desktop (please complete the following information):**
+ - OS: [e.g. iOS]
+ - Browser [e.g. chrome, safari]
+ - Version [e.g. 22]
+
+**Smartphone (please complete the following information):**
+ - Device: [e.g. iPhone6]
+ - OS: [e.g. iOS8.1]
+ - Browser [e.g. stock browser, safari]
+ - Version [e.g. 22]
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,20 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,26 @@
 
 ---
 
+## For Automated AI/LLM Agents
+IMPORTANT: 
+Before starting to work and after checking out code:
+1. Ensure the `origin` remote exists and points to the GitHub repo. Do not remove it! You will need it later. If it was removed, re-add it.
+
+Before pushing:
+1. Run: git fetch origin && git rebase origin/<base-branch>
+   - If rebase fails, discard local changes and re-run the implementation against the updated branch.
+2. Run tests (export DEV=1 && pytest -q). All tests must pass.
+3. Push back to the same branch on origin with:
+   git push origin HEAD:<branch-name>
+
+If you are review another Agent's PR:
+- Always leave a short review comment summarizing what you did, test results, and risk assessment.
+- If all tests pass and the PR is safe to merge, submit a formal GitHub PR review with "Approve" status (not just a 👍 reaction).
+- If there are issues or risks, submit a "Comment" or "Request changes" review instead, explaining why.
+- Reactions (👍) alone are not sufficient; every PR must have a visible comment and, when ready, a formal approval.
+
+---
+
 ## Design & Architecture Impression (high-level guidance)
 Tricorder is a moderately complex system where the complexity arises from its domain (real-time audio capture, concurrency, subprocess orchestration, and resource-constrained embedded deployment) rather than from ad-hoc structure. The project intentionally manages complexity by separating responsibilities into dedicated components (capture/segmenter, encoder, HLS tee, web streamer, ingest pipeline) and by using clear inter-process or inter-thread boundaries (queues, helper threads, subprocesses).
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,128 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity
+and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the
+  overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or
+  advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email
+  address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+@JoshuaDodds.
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series
+of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or
+permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior,  harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within
+the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.0, available at
+https://www.contributor-covenant.org/version/2/0/code_of_conduct.html.
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct
+enforcement ladder](https://github.com/mozilla/diversity).
+
+[homepage]: https://www.contributor-covenant.org
+
+For answers to common questions about this code of conduct, see the FAQ at
+https://www.contributor-covenant.org/faq. Translations are available at
+https://www.contributor-covenant.org/translations.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,41 @@
+# Contributing to Tricorder
+
+Thank you — contributions keep Tricorder healthy. This short guide explains how to contribute safely and effectively.
+
+## Quick start
+1. Fork the repo and create a branch: `git checkout -b fix/short-description`.
+2. Run tests: `pytest -q`.
+3. Add tests for new behavior and update docs where appropriate.
+4. Open a pull request describing the change, risk, and test steps.
+
+## Issues
+- Search existing issues first; add details if you find a duplicate.
+- For bug reports include: device (Pi model), OS/version, minimal reproduction steps, logs, and expected vs actual behavior.
+- For feature requests describe the user problem, proposed UX, and fallback behavior.
+
+## Pull Request Expectations
+- Small focused PRs are preferred.
+- Include test(s) for behavioral changes.
+- Update `README.md` and `config.yaml` for new runtime options.
+- Provide a short “risk statement” for runtime-impacting changes.
+- If you change systemd units or install scripts, test on a Pi or document why not.
+
+## Coding standards
+- Python: target Python 3.10, follow existing module style, use `snake_case`, constants `UPPER_SNAKE_CASE`, type hints welcome.
+- Frontend: ES modules + vanilla CSS; keep compatibility with Raspberry Pi OS Chromium.
+- Shell: `#!/usr/bin/env bash` and `set -euo pipefail`.
+
+## Tests & CI
+- Run `pytest -q` locally.
+- New dependencies must be justified and added to `requirements*.txt`.
+- Ensure CI passes; if a change cannot run on CI (hardware dependency), document how maintainers can verify it.
+
+## Security & Sensitive Data
+- Do not include secrets or PII in commits.
+- Follow the `SECURITY.md` policy for reporting vulnerabilities.
+
+## Communication
+- Use issues to propose large design changes before coding.
+- Be respectful and patient in reviews.
+
+Thanks — maintainers will review PRs as quickly as possible.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Joshua Dodds
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -249,7 +249,7 @@ Copy `updater.env-example` to `/etc/tricorder/update.env` (or another path refer
 - `TRICORDER_UPDATE_DIR` – Working directory for the updater checkout (default `/apps/tricorder/repo`).
 - `TRICORDER_INSTALL_BASE` / `TRICORDER_INSTALL_SCRIPT` – Override install location or script if needed.
 - `TRICORDER_UPDATE_SERVICES` – Space-separated units to restart after an update.
-- `DEV=1` – Disable the updater without removing the timer.
+- `DEV=1` – Disable the updater and mark the install as dev mode so the systemd unit stays inactive even after a reboot.
 
 The timer is configured for short intervals in tests; adjust to a longer cadence in production.
 

--- a/README.md
+++ b/README.md
@@ -346,10 +346,11 @@ Common tunables include:
 Select any recording in the dashboard preview pane to open the new **Clip editor**. The inline tool lets you trim the beginning/end of a take or extract a sub-clip without leaving the browser:
 
 - Scrub the waveform or audio player, then use **Set from playhead** to capture precise start/end times. Times may also be entered manually as `MM:SS.mmm` (hours supported).
+- Leave **Overwrite existing?** enabled to replace the selected clip using its current name. Uncheck it to automatically swap in a unique filename; if you typed your own name we preserve it unless a suffix is needed to avoid collisions.
 - Adjust the generated clip name or supply your own; invalid characters are replaced automatically to match on-device storage rules.
 - Click **Save clip** to render a new `.opus` file and waveform sidecar via the existing ffmpeg/Opus pipeline. Reusing an existing clip name replaces that clip in place while leaving the source recording untouched, and each replacement keeps a short-lived undo history that can be restored from the editor.
 
-Clip requests preserve the original day folder, reuse the recording's timestamp (offset by the chosen start), and overwrite an existing clip only when you reuse its name; the source recording itself is never modified.
+Clip requests preserve the original day folder, reuse the recording's timestamp (offset by the chosen start), and overwrite an existing clip when you keep **Overwrite existing?** checked; toggle it off to save the export beside the current clip instead. The source recording itself is never modified.
 
 To manually test the overwrite + undo workflow in the dashboard:
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,19 @@
+# Security Policy
+
+## Reporting a Vulnerability
+If you find a security issue, please report it privately to the owner of this Project or use GitHub Security Advisories for this repository. Do NOT open a public issue for vulnerabilities.
+
+Provide:
+- Affected component (e.g., live_stream_daemon, web UI)
+- Steps to reproduce or a proof-of-concept (if possible)
+- Impact assessment (data exposure, remote code execution, etc.)
+- Suggested mitigations (if any)
+
+We will acknowledge receipt within 48 hours and work on a fix. If you prefer a monetary bounty, include contact details and proposed terms.
+
+## Supported versions
+We support the `main` branch and the last tagged release. Older releases can be considered on a case-by-case basis.
+
+## Disclosure timeline
+After a fix is available, we will coordinate the public disclosure with the reporter and release a patched version and instructions for updating.
+

--- a/lib/web_streamer.py
+++ b/lib/web_streamer.py
@@ -1833,12 +1833,31 @@ def build_app() -> web.Application:
                 return parsed
         return None
 
+    def _to_bool(value: object, default: bool = True) -> bool:
+        if isinstance(value, bool):
+            return value
+        if value is None:
+            return default
+        if isinstance(value, str):
+            text = value.strip().lower()
+            if not text:
+                return default
+            if text in {"0", "false", "no", "off"}:
+                return False
+            if text in {"1", "true", "yes", "on"}:
+                return True
+            return default
+        if isinstance(value, (int, float)):
+            return value != 0
+        return bool(value)
+
     def _create_clip_sync(
         source_rel_path: str,
         start_seconds: float,
         end_seconds: float,
         clip_name: str | None,
         source_start_epoch: float | None,
+        allow_overwrite: bool = True,
     ) -> dict[str, object]:
         if not source_rel_path:
             raise ClipError("source path is required")
@@ -1882,6 +1901,9 @@ def build_app() -> web.Application:
 
         final_path = target_dir / f"{base_name}.opus"
         final_waveform = final_path.with_suffix(final_path.suffix + ".waveform.json")
+
+        if final_path.exists() and not allow_overwrite:
+            raise ClipError("clip already exists")
 
         try:
             rel_path = final_path.relative_to(recordings_root_resolved)
@@ -2484,6 +2506,7 @@ def build_app() -> web.Application:
 
         loop = asyncio.get_running_loop()
         try:
+            allow_overwrite = _to_bool(data.get("allow_overwrite"), True)
             payload = await loop.run_in_executor(
                 None,
                 functools.partial(
@@ -2493,6 +2516,7 @@ def build_app() -> web.Application:
                     end_value,
                     clip_name,
                     source_start_epoch,
+                    allow_overwrite,
                 ),
             )
         except ClipError as exc:

--- a/lib/webui/static/css/dashboard.css
+++ b/lib/webui/static/css/dashboard.css
@@ -1166,6 +1166,73 @@ button.small {
   width: 100%;
 }
 
+.clipper-overwrite-row {
+  grid-column: 1 / -1;
+  display: flex;
+  justify-content: flex-start;
+}
+
+.clipper-overwrite-toggle {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.55rem;
+  font-size: 0.85rem;
+  color: var(--text-muted);
+  cursor: pointer;
+  user-select: none;
+}
+
+.clipper-overwrite-toggle input {
+  position: absolute;
+  opacity: 0;
+  width: 1px;
+  height: 1px;
+}
+
+.clipper-overwrite-slider {
+  position: relative;
+  width: 2.1rem;
+  height: 1.1rem;
+  border-radius: 999px;
+  background: rgba(148, 163, 184, 0.3);
+  transition: background 0.2s ease;
+  flex-shrink: 0;
+}
+
+.clipper-overwrite-slider::after {
+  content: "";
+  position: absolute;
+  top: 0.15rem;
+  left: 0.15rem;
+  width: 0.8rem;
+  height: 0.8rem;
+  border-radius: 50%;
+  background: var(--surface);
+  box-shadow: 0 1px 2px rgba(15, 23, 42, 0.2);
+  transition: transform 0.2s ease;
+}
+
+.clipper-overwrite-toggle input:checked + .clipper-overwrite-slider {
+  background: var(--primary);
+}
+
+.clipper-overwrite-toggle input:checked + .clipper-overwrite-slider::after {
+  transform: translateX(1rem);
+}
+
+.clipper-overwrite-toggle input:focus-visible + .clipper-overwrite-slider {
+  box-shadow: 0 0 0 3px var(--input-focus-ring);
+}
+
+.clipper-overwrite-toggle input:disabled + .clipper-overwrite-slider {
+  background: rgba(148, 163, 184, 0.2);
+}
+
+.clipper-overwrite-toggle input:disabled + .clipper-overwrite-slider::after {
+  box-shadow: none;
+}
+
 .clipper-footer {
   display: flex;
   flex-wrap: wrap;

--- a/lib/webui/static/css/dashboard.css
+++ b/lib/webui/static/css/dashboard.css
@@ -2240,7 +2240,8 @@ body[data-scroll-locked="true"] {
   font-size: 0.95rem;
 }
 
-.confirm-modal {
+.confirm-modal,
+.rename-modal {
   position: fixed;
   inset: 0;
   display: flex;
@@ -2256,13 +2257,15 @@ body[data-scroll-locked="true"] {
   transition: opacity 0.2s ease, visibility 0.2s ease;
 }
 
-.confirm-modal[data-visible="true"] {
+.confirm-modal[data-visible="true"],
+.rename-modal[data-visible="true"] {
   opacity: 1;
   visibility: visible;
   pointer-events: auto;
 }
 
-.confirm-dialog {
+.confirm-dialog,
+.rename-dialog {
   width: min(420px, 100%);
   border-radius: 1rem;
   background: var(--card-bg);
@@ -2274,7 +2277,12 @@ body[data-scroll-locked="true"] {
   gap: 1rem;
 }
 
-.confirm-title {
+.rename-dialog {
+  width: min(480px, 100%);
+}
+
+.confirm-title,
+.rename-title {
   margin: 0;
   font-size: 1.1rem;
   letter-spacing: -0.01em;
@@ -2292,7 +2300,27 @@ body[data-scroll-locked="true"] {
   gap: 0.75rem;
 }
 
-.confirm-actions button {
+.rename-form {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.rename-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.75rem;
+}
+
+.rename-error {
+  margin: 0;
+  color: var(--danger);
+  font-size: 0.85rem;
+  min-height: 1.1em;
+}
+
+.confirm-actions button,
+.rename-actions button {
   min-width: 96px;
 }
 

--- a/lib/webui/static/css/dashboard.css
+++ b/lib/webui/static/css/dashboard.css
@@ -423,17 +423,33 @@ body {
 
 .header-actions {
   display: flex;
+  flex-direction: column;
+  align-items: flex-end;
   gap: 0.75rem;
+}
+
+.header-controls {
+  display: flex;
   align-items: center;
+  justify-content: flex-end;
+  gap: 0.75rem;
   flex-wrap: wrap;
 }
 
-.header-status {
+.header-status-group {
   display: flex;
   flex-direction: column;
-  align-items: flex-start;
-  gap: 0.35rem;
-  min-width: 0;
+  align-items: flex-end;
+  gap: 0.4rem;
+  width: 100%;
+}
+
+.status-labels {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 0.5rem;
+  flex-wrap: wrap;
 }
 
 .rms-indicator {
@@ -468,7 +484,7 @@ body {
   color: var(--text-strong);
 }
 
-.recording-indicator {
+.status-pill {
   display: inline-flex;
   align-items: center;
   gap: 0.45rem;
@@ -484,6 +500,18 @@ body {
   white-space: nowrap;
 }
 
+.status-pill[data-visible="false"] {
+  display: none;
+}
+
+.status-pill .indicator-text {
+  white-space: nowrap;
+}
+
+.recording-indicator {
+  color: var(--text-muted);
+}
+
 .recording-indicator .indicator-dot {
   width: 0.55rem;
   height: 0.55rem;
@@ -491,10 +519,6 @@ body {
   background: var(--ghost-border-soft);
   box-shadow: 0 0 0 4px rgba(148, 163, 184, 0.15);
   transition: background 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
-}
-
-.recording-indicator .indicator-text {
-  white-space: nowrap;
 }
 
 .recording-indicator[data-state="active"] {
@@ -591,6 +615,8 @@ body {
   letter-spacing: 0.04em;
   color: var(--danger);
   white-space: normal;
+  justify-content: flex-end;
+  text-align: right;
 }
 
 .connection-status[data-visible="true"] {
@@ -2269,8 +2295,26 @@ body[data-scroll-locked="true"] {
 
   .header-actions {
     width: 100%;
+    align-items: flex-start;
+    gap: 0.75rem;
+  }
+
+  .header-controls {
+    width: 100%;
     justify-content: flex-start;
-    gap: 0.5rem;
+  }
+
+  .header-status-group {
+    align-items: flex-start;
+  }
+
+  .status-labels {
+    justify-content: flex-start;
+  }
+
+  .connection-status {
+    justify-content: flex-start;
+    text-align: left;
   }
 
   .titles {

--- a/lib/webui/static/js/dashboard.js
+++ b/lib/webui/static/js/dashboard.js
@@ -212,6 +212,7 @@ const dom = {
   clipperStartInput: document.getElementById("clipper-start"),
   clipperEndInput: document.getElementById("clipper-end"),
   clipperNameInput: document.getElementById("clipper-name"),
+  clipperOverwriteToggle: document.getElementById("clipper-overwrite-toggle"),
   clipperSetStart: document.getElementById("clipper-set-start"),
   clipperSetEnd: document.getElementById("clipper-set-end"),
   clipperReset: document.getElementById("clipper-reset"),
@@ -744,6 +745,7 @@ const clipperState = {
   nameDirty: false,
   lastRecordPath: null,
   undoTokens: new Map(),
+  overwriteExisting: true,
 };
 
 const liveState = {
@@ -1896,11 +1898,89 @@ function sanitizeClipName(value) {
   return truncated.replace(/^[._-]+|[._-]+$/g, "");
 }
 
-function generateClipDefaultName(record, startSeconds, endSeconds) {
-  const baseName = record && typeof record.name === "string" && record.name ? record.name : "clip";
+function getRecordDirectoryPath(record) {
+  if (record && typeof record === "object" && typeof record.path === "string") {
+    const path = record.path;
+    const lastSlash = path.lastIndexOf("/");
+    return lastSlash > 0 ? path.slice(0, lastSlash) : "";
+  }
+  if (typeof record === "string" && record) {
+    const lastSlash = record.lastIndexOf("/");
+    return lastSlash > 0 ? record.slice(0, lastSlash) : "";
+  }
+  return "";
+}
+
+function deriveRecordBaseName(record) {
+  if (record && typeof record === "object" && typeof record.name === "string" && record.name.trim()) {
+    const sanitized = sanitizeClipName(record.name.trim());
+    if (sanitized) {
+      return sanitized;
+    }
+  }
+  let candidate = "";
+  if (record && typeof record === "object" && typeof record.path === "string" && record.path) {
+    const parts = record.path.split("/");
+    candidate = parts[parts.length - 1] || "";
+  }
+  if (!candidate && typeof record === "string") {
+    const parts = record.split("/");
+    candidate = parts[parts.length - 1] || "";
+  }
+  if (candidate.includes(".")) {
+    const dot = candidate.lastIndexOf(".");
+    candidate = dot > 0 ? candidate.slice(0, dot) : candidate;
+  }
+  const sanitized = sanitizeClipName(candidate);
+  return sanitized || "clip";
+}
+
+function getOverwriteClipName(record) {
+  return deriveRecordBaseName(record);
+}
+
+function generateClipRangeName(record, startSeconds, endSeconds) {
+  const baseName = deriveRecordBaseName(record);
   const slug = `${baseName}_${formatTimeSlug(startSeconds)}-${formatTimeSlug(endSeconds)}`;
   const sanitized = sanitizeClipName(slug);
-  return sanitized || "clip";
+  return sanitized || baseName || "clip";
+}
+
+function ensureUniqueClipName(name, record) {
+  const sanitized = sanitizeClipName(name);
+  const baseName = sanitized || "clip";
+  const directory = getRecordDirectoryPath(record);
+  const extension =
+    record && typeof record === "object" && typeof record.extension === "string" && record.extension
+      ? record.extension
+      : "opus";
+  const prefix = directory ? `${directory}/` : "";
+  const knownPaths = new Set();
+  for (const entry of state.records) {
+    if (entry && typeof entry.path === "string") {
+      knownPaths.add(entry.path);
+    }
+  }
+  let candidate = baseName;
+  let suffix = 1;
+  while (true) {
+    const targetPath = `${prefix}${candidate}.${extension}`;
+    if (knownPaths.has(targetPath)) {
+      candidate = `${baseName}-${suffix}`;
+      suffix += 1;
+      continue;
+    }
+    break;
+  }
+  return candidate;
+}
+
+function computeClipDefaultName(record, startSeconds, endSeconds, overwriteExisting = true) {
+  if (overwriteExisting) {
+    return getOverwriteClipName(record);
+  }
+  const rangeName = generateClipRangeName(record, startSeconds, endSeconds);
+  return ensureUniqueClipName(rangeName, record);
 }
 
 function formatClipLengthText(seconds) {
@@ -3455,7 +3535,12 @@ function updateClipperName(record = state.current) {
     dom.clipperNameInput.value = "";
     return;
   }
-  const defaultName = generateClipDefaultName(record, clipperState.startSeconds, clipperState.endSeconds);
+  const defaultName = computeClipDefaultName(
+    record,
+    clipperState.startSeconds,
+    clipperState.endSeconds,
+    clipperState.overwriteExisting,
+  );
   dom.clipperNameInput.value = defaultName;
   clipperState.nameDirty = false;
 }
@@ -3540,6 +3625,10 @@ function updateClipperUI({ updateInputs = true, updateName = true } = {}) {
   if (dom.clipperNameInput) {
     dom.clipperNameInput.disabled = clipperState.busy;
   }
+  if (dom.clipperOverwriteToggle) {
+    dom.clipperOverwriteToggle.checked = clipperState.overwriteExisting;
+    dom.clipperOverwriteToggle.disabled = clipperState.busy;
+  }
 
   if (dom.clipperUndo) {
     let undoToken = null;
@@ -3575,6 +3664,10 @@ function initializeClipper(record) {
     clipperState.statusState = "idle";
     clipperState.nameDirty = false;
     clipperState.lastRecordPath = record && typeof record.path === "string" ? record.path : null;
+    clipperState.overwriteExisting = true;
+    if (dom.clipperOverwriteToggle) {
+      dom.clipperOverwriteToggle.checked = true;
+    }
     setClipperVisible(false);
     updateClipperStatusElement();
     return;
@@ -3588,6 +3681,10 @@ function initializeClipper(record) {
   clipperState.statusState = "idle";
   clipperState.nameDirty = false;
   clipperState.lastRecordPath = record && typeof record.path === "string" ? record.path : null;
+  clipperState.overwriteExisting = true;
+  if (dom.clipperOverwriteToggle) {
+    dom.clipperOverwriteToggle.checked = true;
+  }
   updateClipperUI({ updateInputs: true });
 }
 
@@ -3679,7 +3776,12 @@ function handleClipperNameInput() {
     return;
   }
   const trimmed = dom.clipperNameInput.value.trim();
-  const defaultName = generateClipDefaultName(state.current, clipperState.startSeconds, clipperState.endSeconds);
+  const defaultName = computeClipDefaultName(
+    state.current,
+    clipperState.startSeconds,
+    clipperState.endSeconds,
+    clipperState.overwriteExisting,
+  );
   clipperState.nameDirty = trimmed.length > 0 && trimmed !== defaultName;
 }
 
@@ -3690,6 +3792,59 @@ function handleClipperNameBlur() {
   if (!dom.clipperNameInput.value.trim()) {
     updateClipperName();
   }
+}
+
+function handleClipperOverwriteChange() {
+  if (!dom.clipperOverwriteToggle) {
+    return;
+  }
+  const next = Boolean(dom.clipperOverwriteToggle.checked);
+  if (clipperState.overwriteExisting === next) {
+    return;
+  }
+  clipperState.overwriteExisting = next;
+  if (!state.current || !Number.isFinite(clipperState.durationSeconds)) {
+    updateClipperUI({ updateInputs: false, updateName: false });
+    return;
+  }
+  const defaultOverwrite = computeClipDefaultName(
+    state.current,
+    clipperState.startSeconds,
+    clipperState.endSeconds,
+    true,
+  );
+  const defaultUnique = computeClipDefaultName(
+    state.current,
+    clipperState.startSeconds,
+    clipperState.endSeconds,
+    false,
+  );
+  if (!dom.clipperNameInput) {
+    clipperState.nameDirty = false;
+    updateClipperUI({ updateInputs: false, updateName: false });
+    return;
+  }
+  if (next) {
+    dom.clipperNameInput.value = defaultOverwrite;
+    clipperState.nameDirty = false;
+  } else {
+    const trimmed = dom.clipperNameInput.value.trim();
+    if (!trimmed || trimmed === defaultOverwrite) {
+      dom.clipperNameInput.value = defaultUnique;
+      clipperState.nameDirty = false;
+    } else {
+      const sanitized = sanitizeClipName(trimmed);
+      if (!sanitized) {
+        dom.clipperNameInput.value = defaultUnique;
+        clipperState.nameDirty = false;
+      } else {
+        const ensured = ensureUniqueClipName(sanitized, state.current);
+        dom.clipperNameInput.value = ensured;
+        clipperState.nameDirty = ensured !== defaultUnique;
+      }
+    }
+  }
+  updateClipperUI({ updateInputs: false, updateName: false });
 }
 
 function handleClipperReset() {
@@ -3794,7 +3949,12 @@ async function submitClipperForm(event) {
   }
 
   const record = state.current;
-  const defaultName = generateClipDefaultName(record, clipperState.startSeconds, clipperState.endSeconds);
+  const defaultName = computeClipDefaultName(
+    record,
+    clipperState.startSeconds,
+    clipperState.endSeconds,
+    clipperState.overwriteExisting,
+  );
   let clipName = defaultName;
   if (dom.clipperNameInput) {
     const trimmed = dom.clipperNameInput.value.trim();
@@ -3806,12 +3966,20 @@ async function submitClipperForm(event) {
       }
       dom.clipperNameInput.value = sanitized;
       clipName = sanitized;
-      clipperState.nameDirty = clipName !== defaultName;
     } else {
       dom.clipperNameInput.value = defaultName;
-      clipperState.nameDirty = false;
     }
   }
+
+  if (!clipperState.overwriteExisting) {
+    const ensured = ensureUniqueClipName(clipName, record);
+    if (ensured !== clipName && dom.clipperNameInput) {
+      dom.clipperNameInput.value = ensured;
+    }
+    clipName = ensured;
+  }
+
+  clipperState.nameDirty = clipName !== defaultName;
 
   const payload = {
     source_path: record.path,
@@ -3819,6 +3987,10 @@ async function submitClipperForm(event) {
     end_seconds: clipperState.endSeconds,
     clip_name: clipName,
   };
+
+  if (!clipperState.overwriteExisting) {
+    payload.allow_overwrite = false;
+  }
 
   const startEpoch = getRecordStartSeconds(record);
   if (startEpoch !== null) {
@@ -8820,6 +8992,10 @@ function attachEventListeners() {
   if (dom.clipperNameInput) {
     dom.clipperNameInput.addEventListener("input", handleClipperNameInput);
     dom.clipperNameInput.addEventListener("blur", handleClipperNameBlur);
+  }
+
+  if (dom.clipperOverwriteToggle) {
+    dom.clipperOverwriteToggle.addEventListener("change", handleClipperOverwriteChange);
   }
 
   if (dom.clipperForm) {

--- a/lib/webui/static/js/dashboard.js
+++ b/lib/webui/static/js/dashboard.js
@@ -124,6 +124,8 @@ const dom = {
   toggleAll: document.getElementById("toggle-all"),
   selectAll: document.getElementById("select-all"),
   clearSelection: document.getElementById("clear-selection"),
+  downloadSelected: document.getElementById("download-selected"),
+  renameSelected: document.getElementById("rename-selected"),
   deleteSelected: document.getElementById("delete-selected"),
   refreshIndicator: document.getElementById("refresh-indicator"),
   themeToggle: document.getElementById("theme-toggle"),
@@ -229,6 +231,13 @@ const dom = {
   confirmMessage: document.getElementById("confirm-modal-message"),
   confirmConfirm: document.getElementById("confirm-modal-confirm"),
   confirmCancel: document.getElementById("confirm-modal-cancel"),
+  renameModal: document.getElementById("rename-modal"),
+  renameDialog: document.getElementById("rename-modal-dialog"),
+  renameForm: document.getElementById("rename-form"),
+  renameInput: document.getElementById("rename-input"),
+  renameError: document.getElementById("rename-error"),
+  renameConfirm: document.getElementById("rename-confirm"),
+  renameCancel: document.getElementById("rename-cancel"),
 };
 
 const recorderDom = {
@@ -717,6 +726,12 @@ function findInteractiveElement(target, event = null) {
 
 let refreshIndicatorTimer = null;
 let pendingSelectionPath = null;
+const renameDialogState = {
+  open: false,
+  target: null,
+  pending: false,
+  previouslyFocused: null,
+};
 
 const waveformState = {
   peaks: null,
@@ -2274,6 +2289,236 @@ if (dom.confirmModal) {
   });
 }
 
+function setRenameModalVisible(visible) {
+  if (!dom.renameModal) {
+    return;
+  }
+  if (visible) {
+    dom.renameModal.hidden = false;
+    dom.renameModal.dataset.visible = "true";
+    dom.renameModal.setAttribute("aria-hidden", "false");
+  } else {
+    dom.renameModal.dataset.visible = "false";
+    dom.renameModal.setAttribute("aria-hidden", "true");
+    dom.renameModal.hidden = true;
+  }
+}
+
+function setRenameDialogError(message) {
+  if (!dom.renameError) {
+    return;
+  }
+  if (typeof message === "string" && message) {
+    dom.renameError.textContent = message;
+    dom.renameError.hidden = false;
+  } else {
+    dom.renameError.textContent = "";
+    dom.renameError.hidden = true;
+  }
+}
+
+function setRenameDialogPending(pending) {
+  renameDialogState.pending = Boolean(pending);
+  if (dom.renameConfirm) {
+    dom.renameConfirm.disabled = pending === true;
+  }
+  if (dom.renameInput) {
+    dom.renameInput.disabled = pending === true;
+  }
+  if (dom.renameCancel) {
+    dom.renameCancel.disabled = pending === true;
+  }
+  updateSelectionUI();
+}
+
+function closeRenameDialog() {
+  if (!renameDialogState.open) {
+    return;
+  }
+  renameDialogState.open = false;
+  const previous = renameDialogState.previouslyFocused;
+  renameDialogState.previouslyFocused = null;
+  renameDialogState.target = null;
+  setRenameDialogPending(false);
+  setRenameDialogError("");
+  setRenameModalVisible(false);
+  if (previous && typeof previous.focus === "function") {
+    window.requestAnimationFrame(() => {
+      previous.focus();
+    });
+  }
+}
+
+function renameDialogFocusableElements() {
+  if (!dom.renameDialog) {
+    return [];
+  }
+  const nodes = dom.renameDialog.querySelectorAll(
+    'button:not([disabled]), input:not([disabled])'
+  );
+  return Array.from(nodes).filter((element) => element instanceof HTMLElement);
+}
+
+function openRenameDialog(record) {
+  if (
+    !dom.renameModal ||
+    !dom.renameDialog ||
+    !dom.renameForm ||
+    !dom.renameInput ||
+    !dom.renameConfirm ||
+    !dom.renameCancel
+  ) {
+    if (
+      record &&
+      typeof record.path === "string" &&
+      typeof window !== "undefined" &&
+      typeof window.prompt === "function"
+    ) {
+      const promptValue = window.prompt(
+        "Enter a new name for the recording",
+        typeof record.name === "string" && record.name ? record.name : record.path
+      );
+      const trimmed = promptValue ? promptValue.trim() : "";
+      if (trimmed) {
+        const extensionValue =
+          typeof record.extension === "string" && record.extension ? record.extension : "";
+        const hasSuffix = trimmed.includes(".");
+        const options = {};
+        if (!hasSuffix && extensionValue) {
+          options.extension = extensionValue;
+        }
+        void renameRecording(record.path, trimmed, options);
+      }
+    }
+    return;
+  }
+
+  renameDialogState.open = true;
+  renameDialogState.target = record || null;
+  renameDialogState.previouslyFocused =
+    document.activeElement instanceof HTMLElement ? document.activeElement : null;
+  setRenameDialogPending(false);
+  setRenameDialogError("");
+
+  if (record && typeof record.name === "string") {
+    dom.renameInput.value = record.name;
+  } else if (record && typeof record.path === "string") {
+    const parts = record.path.split("/");
+    dom.renameInput.value = parts.length ? parts[parts.length - 1] : record.path;
+  } else {
+    dom.renameInput.value = "";
+  }
+  dom.renameInput.dataset.extension =
+    record && typeof record.extension === "string" ? record.extension : "";
+
+  setRenameModalVisible(true);
+
+  window.requestAnimationFrame(() => {
+    window.requestAnimationFrame(() => {
+      if (dom.renameDialog) {
+        dom.renameDialog.focus();
+      }
+      if (dom.renameInput) {
+        dom.renameInput.focus();
+        dom.renameInput.select();
+      }
+    });
+  });
+}
+
+async function handleRenameSubmit(event) {
+  event.preventDefault();
+  if (!renameDialogState.open || renameDialogState.pending) {
+    return;
+  }
+  if (!dom.renameInput) {
+    return;
+  }
+  const value = dom.renameInput.value.trim();
+  if (!value) {
+    setRenameDialogError("Enter a new name.");
+    return;
+  }
+  const target = renameDialogState.target;
+  if (!target || typeof target.path !== "string") {
+    setRenameDialogError("Unable to rename this recording.");
+    return;
+  }
+
+  const hasSuffix = value.includes(".");
+  const extensionValue = dom.renameInput.dataset.extension || target.extension || "";
+  const options = {};
+  if (!hasSuffix && extensionValue) {
+    options.extension = extensionValue;
+  }
+
+  setRenameDialogPending(true);
+  try {
+    await renameRecording(target.path, value, options);
+    closeRenameDialog();
+  } catch (error) {
+    console.error("Rename request failed", error);
+    const message =
+      error instanceof Error && error.message
+        ? error.message
+        : "Unable to rename recording.";
+    setRenameDialogError(message);
+    setRenameDialogPending(false);
+  }
+}
+
+if (dom.renameForm) {
+  dom.renameForm.addEventListener("submit", handleRenameSubmit);
+}
+
+if (dom.renameCancel) {
+  dom.renameCancel.addEventListener("click", () => {
+    if (!renameDialogState.pending) {
+      closeRenameDialog();
+    }
+  });
+}
+
+if (dom.renameModal) {
+  dom.renameModal.addEventListener("click", (event) => {
+    if (!renameDialogState.pending && event.target === dom.renameModal) {
+      closeRenameDialog();
+    }
+  });
+  dom.renameModal.addEventListener("keydown", (event) => {
+    if (!renameDialogState.open) {
+      return;
+    }
+    if (event.key === "Escape") {
+      event.preventDefault();
+      if (!renameDialogState.pending) {
+        closeRenameDialog();
+      }
+      return;
+    }
+    if (event.key === "Tab") {
+      const focusable = renameDialogFocusableElements();
+      if (!focusable.length) {
+        event.preventDefault();
+        return;
+      }
+      const active =
+        document.activeElement instanceof HTMLElement ? document.activeElement : null;
+      let index = focusable.indexOf(active);
+      if (index === -1) {
+        index = 0;
+      }
+      if (event.shiftKey) {
+        index = index <= 0 ? focusable.length - 1 : index - 1;
+      } else {
+        index = index >= focusable.length - 1 ? 0 : index + 1;
+      }
+      event.preventDefault();
+      focusable[index].focus();
+    }
+  });
+}
+
 function clearRefreshIndicatorTimer() {
   if (refreshIndicatorTimer) {
     window.clearTimeout(refreshIndicatorTimer);
@@ -2487,6 +2732,12 @@ function updateSelectionUI(records = null) {
     dom.selectedCountMobile.textContent = selectedText;
   }
   dom.deleteSelected.disabled = state.selections.size === 0;
+  if (dom.downloadSelected) {
+    dom.downloadSelected.disabled = state.selections.size === 0;
+  }
+  if (dom.renameSelected) {
+    dom.renameSelected.disabled = state.selections.size !== 1 || renameDialogState.pending;
+  }
 
   if (!visible.length) {
     dom.toggleAll.checked = false;
@@ -2965,6 +3216,16 @@ function renderRecords() {
     downloadLink.textContent = "Download";
     downloadLink.setAttribute("download", `${record.name}.${record.extension || "opus"}`);
 
+    const renameButton = document.createElement("button");
+    renameButton.type = "button";
+    renameButton.textContent = "Rename";
+    renameButton.classList.add("ghost-button");
+    renameButton.classList.add("small");
+    renameButton.addEventListener("click", (event) => {
+      event.stopPropagation();
+      openRenameDialog(record);
+    });
+
     const deleteButton = document.createElement("button");
     deleteButton.type = "button";
     deleteButton.textContent = "Delete";
@@ -2973,7 +3234,7 @@ function renderRecords() {
       await requestRecordDeletion(record);
     });
 
-    actionWrapper.append(downloadLink, deleteButton);
+    actionWrapper.append(downloadLink, renameButton, deleteButton);
     actionsCell.append(actionWrapper);
     row.append(actionsCell);
 
@@ -8008,6 +8269,163 @@ async function deleteRecordings(paths) {
   }
 }
 
+function extractFilenameFromDisposition(disposition) {
+  if (typeof disposition !== "string" || !disposition) {
+    return null;
+  }
+  const utf8Match = disposition.match(/filename\*=UTF-8''([^;]+)/i);
+  if (utf8Match && utf8Match[1]) {
+    try {
+      return decodeURIComponent(utf8Match[1]);
+    } catch (error) {
+      return utf8Match[1];
+    }
+  }
+  const simpleMatch = disposition.match(/filename="?([^";]+)"?/i);
+  if (simpleMatch && simpleMatch[1]) {
+    return simpleMatch[1];
+  }
+  return null;
+}
+
+async function renameRecording(path, newName, options = {}) {
+  if (typeof path !== "string" || !path || typeof newName !== "string" || !newName) {
+    throw new Error("Invalid rename request");
+  }
+  const payload = {
+    item: path,
+    name: newName,
+  };
+  const extensionValue =
+    options && typeof options.extension === "string" ? options.extension.trim() : "";
+  if (extensionValue) {
+    payload.extension = extensionValue;
+  }
+
+  const response = await fetch(apiPath("/api/recordings/rename"), {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(payload),
+  });
+
+  if (!response.ok) {
+    let message = `Rename failed with status ${response.status}`;
+    try {
+      const errorPayload = await response.json();
+      if (typeof errorPayload.error === "string" && errorPayload.error) {
+        message = errorPayload.error;
+      } else if (Array.isArray(errorPayload.errors) && errorPayload.errors.length) {
+        const combined = errorPayload.errors
+          .map((entry) => {
+            const item = typeof entry.item === "string" ? entry.item : "";
+            const errorText = typeof entry.error === "string" ? entry.error : "";
+            return item ? `${item}: ${errorText}` : errorText;
+          })
+          .filter(Boolean)
+          .join("\n");
+        if (combined) {
+          message = combined;
+        }
+      }
+    } catch (error) {
+      // ignore parse errors
+    }
+    throw new Error(message);
+  }
+
+  const payloadJson = await response.json();
+  const oldPath = typeof payloadJson.old_path === "string" ? payloadJson.old_path : path;
+  const newPath = typeof payloadJson.new_path === "string" ? payloadJson.new_path : path;
+
+  if (state.selections.has(oldPath)) {
+    state.selections.delete(oldPath);
+    state.selections.add(newPath);
+  }
+  if (state.current && state.current.path === oldPath) {
+    pendingSelectionPath = newPath;
+  }
+
+  updateSelectionUI();
+  await fetchRecordings({ silent: false });
+
+  return payloadJson;
+}
+
+async function downloadRecordingsArchive(paths) {
+  if (!Array.isArray(paths) || !paths.length) {
+    return;
+  }
+
+  const response = await fetch(apiPath("/api/recordings/bulk-download"), {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ items: paths }),
+  });
+
+  if (!response.ok) {
+    let message = `Download failed with status ${response.status}`;
+    try {
+      const errorPayload = await response.json();
+      if (typeof errorPayload.error === "string" && errorPayload.error) {
+        message = errorPayload.error;
+      } else if (Array.isArray(errorPayload.errors) && errorPayload.errors.length) {
+        const combined = errorPayload.errors
+          .map((entry) => {
+            const item = typeof entry.item === "string" ? entry.item : "";
+            const errorText = typeof entry.error === "string" ? entry.error : "";
+            return item ? `${item}: ${errorText}` : errorText;
+          })
+          .filter(Boolean)
+          .join("\n");
+        if (combined) {
+          message = combined;
+        }
+      }
+    } catch (error) {
+      // ignore parse errors
+    }
+    throw new Error(message);
+  }
+
+  const blob = await response.blob();
+  const disposition = response.headers.get("Content-Disposition");
+  let filename = extractFilenameFromDisposition(disposition);
+  if (!filename) {
+    const now = new Date();
+    if (!Number.isNaN(now.getTime())) {
+      const timestamp =
+        `${now.getFullYear()}` +
+        `${String(now.getMonth() + 1).padStart(2, "0")}` +
+        `${String(now.getDate()).padStart(2, "0")}` +
+        `-${String(now.getHours()).padStart(2, "0")}` +
+        `${String(now.getMinutes()).padStart(2, "0")}` +
+        `${String(now.getSeconds()).padStart(2, "0")}`;
+      filename = `tricorder-recordings-${timestamp}.zip`;
+    } else {
+      filename = "tricorder-recordings.zip";
+    }
+  }
+
+  if (typeof window === "undefined" || !window.URL || !window.document) {
+    return;
+  }
+
+  const blobUrl = window.URL.createObjectURL(blob);
+  const link = document.createElement("a");
+  link.href = blobUrl;
+  link.download = filename || "recordings.zip";
+  document.body.append(link);
+  link.click();
+  link.remove();
+  window.setTimeout(() => {
+    window.URL.revokeObjectURL(blobUrl);
+  }, 1000);
+}
+
 function applyFiltersFromInputs() {
   const search = dom.filterSearch ? dom.filterSearch.value.trim() : "";
   const day = dom.filterDay ? dom.filterDay.value.trim() : "";
@@ -8911,6 +9329,46 @@ function attachEventListeners() {
     const paths = Array.from(state.selections.values());
     await deleteRecordings(paths);
   });
+
+  if (dom.downloadSelected) {
+    dom.downloadSelected.addEventListener("click", async () => {
+      if (!state.selections.size) {
+        return;
+      }
+      const paths = Array.from(state.selections.values());
+      dom.downloadSelected.disabled = true;
+      try {
+        await downloadRecordingsArchive(paths);
+      } catch (error) {
+        console.error("Bulk download failed", error);
+        const message =
+          error instanceof Error && error.message
+            ? error.message
+            : "Unable to download recordings.";
+        if (typeof window !== "undefined" && typeof window.alert === "function") {
+          window.alert(message);
+        }
+      } finally {
+        updateSelectionUI();
+      }
+    });
+  }
+
+  if (dom.renameSelected) {
+    dom.renameSelected.addEventListener("click", () => {
+      if (renameDialogState.pending || state.selections.size !== 1) {
+        return;
+      }
+      const [selectedPath] = Array.from(state.selections.values());
+      if (typeof selectedPath !== "string" || !selectedPath) {
+        return;
+      }
+      const record = state.records.find((entry) => entry.path === selectedPath);
+      if (record) {
+        openRenameDialog(record);
+      }
+    });
+  }
 
   if (dom.waveformContainer) {
     dom.waveformContainer.addEventListener("pointerdown", handleWaveformPointerDown);

--- a/lib/webui/static/js/dashboard.js
+++ b/lib/webui/static/js/dashboard.js
@@ -40,6 +40,13 @@ function apiPath(path) {
   return `${API_BASE}${normalized}`;
 }
 
+function nowMilliseconds() {
+  if (typeof performance !== "undefined" && typeof performance.now === "function") {
+    return performance.now();
+  }
+  return Date.now();
+}
+
 const AUTO_REFRESH_INTERVAL_MS = 1000;
 const OFFLINE_REFRESH_INTERVAL_MS = 5000;
 const REFRESH_INDICATOR_DELAY_MS = 600;
@@ -123,8 +130,12 @@ const dom = {
   connectionStatus: document.getElementById("connection-status"),
   recordingIndicator: document.getElementById("recording-indicator"),
   recordingIndicatorText: document.getElementById("recording-indicator-text"),
+  recordingMeta: document.getElementById("recording-meta"),
+  recordingMetaText: document.getElementById("recording-meta-text"),
   rmsIndicator: document.getElementById("rms-indicator"),
   rmsIndicatorValue: document.getElementById("rms-indicator-value"),
+  encodingStatus: document.getElementById("encoding-status"),
+  encodingStatusText: document.getElementById("encoding-status-text"),
   applyFilters: document.getElementById("apply-filters"),
   clearFilters: document.getElementById("clear-filters"),
   filterSearch: document.getElementById("filter-search"),
@@ -877,6 +888,35 @@ const rmsIndicatorState = {
   value: null,
 };
 
+const recordingMetaState = {
+  active: false,
+  baseDuration: 0,
+  baseTime: 0,
+  sizeBytes: 0,
+  text: "",
+};
+
+const recordingMetaTicker = {
+  handle: null,
+  usingAnimationFrame: false,
+};
+
+const encodingStatusState = {
+  visible: false,
+  hasActive: false,
+  durationBase: 0,
+  baseTime: 0,
+  text: "",
+  activeLabel: "",
+  pendingCount: 0,
+  nextLabel: "",
+};
+
+const encodingStatusTicker = {
+  handle: null,
+  usingAnimationFrame: false,
+};
+
 function clampLimitValue(value) {
   let candidate = value;
   if (typeof candidate === "string") {
@@ -1273,6 +1313,8 @@ function applyRecordingIndicator(state, message) {
 function setRecordingIndicatorUnknown(message = "Status unavailable") {
   applyRecordingIndicator("unknown", message);
   hideRmsIndicator();
+  hideRecordingMeta();
+  hideEncodingStatus();
 }
 
 function setRecordingIndicatorStatus(rawStatus) {
@@ -1310,7 +1352,7 @@ function setRecordingIndicatorStatus(rawStatus) {
       }
       const trigger = toFiniteOrNull(event.trigger_rms);
       if (trigger !== null) {
-        detail = `RMS ${Math.round(trigger)}`;
+        detail = `Triggered @ ${Math.round(trigger)}`;
       } else if (typeof event.base_name === "string" && event.base_name) {
         detail = event.base_name;
       }
@@ -1343,6 +1385,299 @@ function setRecordingIndicatorStatus(rawStatus) {
   }
 
   applyRecordingIndicator(state, message);
+}
+
+function scheduleRecordingMetaTick() {
+  if (!recordingMetaState.active) {
+    return;
+  }
+  if (recordingMetaTicker.handle !== null) {
+    return;
+  }
+  if (
+    typeof window !== "undefined" &&
+    typeof window.requestAnimationFrame === "function"
+  ) {
+    recordingMetaTicker.handle = window.requestAnimationFrame(handleRecordingMetaTick);
+    recordingMetaTicker.usingAnimationFrame = true;
+  } else {
+    recordingMetaTicker.handle = setTimeout(() => {
+      recordingMetaTicker.handle = null;
+      handleRecordingMetaTick();
+    }, 500);
+    recordingMetaTicker.usingAnimationFrame = false;
+  }
+}
+
+function cancelRecordingMetaTick() {
+  if (recordingMetaTicker.handle === null) {
+    return;
+  }
+  if (
+    recordingMetaTicker.usingAnimationFrame &&
+    typeof window !== "undefined" &&
+    typeof window.cancelAnimationFrame === "function"
+  ) {
+    window.cancelAnimationFrame(recordingMetaTicker.handle);
+  } else {
+    clearTimeout(recordingMetaTicker.handle);
+  }
+  recordingMetaTicker.handle = null;
+  recordingMetaTicker.usingAnimationFrame = false;
+}
+
+function handleRecordingMetaTick() {
+  recordingMetaTicker.handle = null;
+  if (!recordingMetaState.active) {
+    return;
+  }
+  renderRecordingMeta();
+  scheduleRecordingMetaTick();
+}
+
+function renderRecordingMeta() {
+  if (!dom.recordingMeta || !dom.recordingMetaText || !recordingMetaState.active) {
+    return;
+  }
+  const elapsedSeconds = Math.max(
+    0,
+    recordingMetaState.baseDuration + (nowMilliseconds() - recordingMetaState.baseTime) / 1000,
+  );
+  const sizeBytes = Number.isFinite(recordingMetaState.sizeBytes)
+    ? Math.max(0, recordingMetaState.sizeBytes)
+    : 0;
+  const text = `${formatShortDuration(elapsedSeconds)} • ${formatBytes(sizeBytes)}`;
+  if (text === recordingMetaState.text) {
+    return;
+  }
+  dom.recordingMetaText.textContent = text;
+  dom.recordingMeta.dataset.visible = "true";
+  dom.recordingMeta.setAttribute("aria-hidden", "false");
+  recordingMetaState.text = text;
+}
+
+function hideRecordingMeta() {
+  if (!dom.recordingMeta || !dom.recordingMetaText) {
+    return;
+  }
+  cancelRecordingMetaTick();
+  recordingMetaState.active = false;
+  recordingMetaState.baseDuration = 0;
+  recordingMetaState.baseTime = nowMilliseconds();
+  recordingMetaState.sizeBytes = 0;
+  recordingMetaState.text = "";
+  dom.recordingMeta.dataset.visible = "false";
+  dom.recordingMeta.setAttribute("aria-hidden", "true");
+  dom.recordingMetaText.textContent = "";
+}
+
+function updateRecordingMeta(rawStatus) {
+  if (!dom.recordingMeta || !dom.recordingMetaText) {
+    return;
+  }
+  const status = rawStatus && typeof rawStatus === "object" ? rawStatus : null;
+  const capturing = status ? Boolean(status.capturing) : false;
+  if (!capturing) {
+    hideRecordingMeta();
+    return;
+  }
+  const durationSeconds = status ? toFiniteOrNull(status.event_duration_seconds) : null;
+  const sizeBytes = status ? toFiniteOrNull(status.event_size_bytes) : null;
+  const event = status && typeof status.event === "object" ? status.event : null;
+  const startedEpoch = event ? toFiniteOrNull(event.started_epoch) : null;
+
+  if (durationSeconds !== null) {
+    recordingMetaState.baseDuration = Math.max(0, durationSeconds);
+    recordingMetaState.baseTime = nowMilliseconds();
+  } else if (startedEpoch !== null) {
+    recordingMetaState.baseDuration = Math.max(0, Date.now() / 1000 - startedEpoch);
+    recordingMetaState.baseTime = nowMilliseconds();
+  } else if (!recordingMetaState.active) {
+    recordingMetaState.baseDuration = 0;
+    recordingMetaState.baseTime = nowMilliseconds();
+  }
+
+  if (sizeBytes !== null) {
+    recordingMetaState.sizeBytes = Math.max(0, sizeBytes);
+  }
+
+  recordingMetaState.active = true;
+  recordingMetaState.text = "";
+  renderRecordingMeta();
+  scheduleRecordingMetaTick();
+}
+
+function scheduleEncodingStatusTick() {
+  if (!encodingStatusState.hasActive) {
+    return;
+  }
+  if (encodingStatusTicker.handle !== null) {
+    return;
+  }
+  if (
+    typeof window !== "undefined" &&
+    typeof window.requestAnimationFrame === "function"
+  ) {
+    encodingStatusTicker.handle = window.requestAnimationFrame(handleEncodingStatusTick);
+    encodingStatusTicker.usingAnimationFrame = true;
+  } else {
+    encodingStatusTicker.handle = setTimeout(() => {
+      encodingStatusTicker.handle = null;
+      handleEncodingStatusTick();
+    }, 500);
+    encodingStatusTicker.usingAnimationFrame = false;
+  }
+}
+
+function cancelEncodingStatusTick() {
+  if (encodingStatusTicker.handle === null) {
+    return;
+  }
+  if (
+    encodingStatusTicker.usingAnimationFrame &&
+    typeof window !== "undefined" &&
+    typeof window.cancelAnimationFrame === "function"
+  ) {
+    window.cancelAnimationFrame(encodingStatusTicker.handle);
+  } else {
+    clearTimeout(encodingStatusTicker.handle);
+  }
+  encodingStatusTicker.handle = null;
+  encodingStatusTicker.usingAnimationFrame = false;
+}
+
+function handleEncodingStatusTick() {
+  encodingStatusTicker.handle = null;
+  if (!encodingStatusState.hasActive) {
+    return;
+  }
+  renderEncodingStatus();
+  scheduleEncodingStatusTick();
+}
+
+function renderEncodingStatus() {
+  if (!dom.encodingStatus || !dom.encodingStatusText) {
+    return;
+  }
+  if (!encodingStatusState.visible) {
+    if (dom.encodingStatus.dataset.visible !== "false") {
+      dom.encodingStatus.dataset.visible = "false";
+      dom.encodingStatus.setAttribute("aria-hidden", "true");
+      dom.encodingStatusText.textContent = "";
+    }
+    encodingStatusState.text = "";
+    return;
+  }
+  let durationSeconds = Math.max(0, encodingStatusState.durationBase);
+  if (encodingStatusState.hasActive) {
+    durationSeconds = Math.max(
+      0,
+      encodingStatusState.durationBase + (nowMilliseconds() - encodingStatusState.baseTime) / 1000,
+    );
+  }
+  const parts = [];
+  if (encodingStatusState.hasActive) {
+    parts.push("Encoding active");
+    if (encodingStatusState.activeLabel) {
+      parts.push(encodingStatusState.activeLabel);
+    }
+    parts.push(formatShortDuration(durationSeconds));
+    if (encodingStatusState.pendingCount > 0) {
+      parts.push(
+        encodingStatusState.pendingCount === 1
+          ? "1 pending"
+          : `${encodingStatusState.pendingCount} pending`,
+      );
+    }
+  } else {
+    parts.push("Encoding pending");
+    if (encodingStatusState.pendingCount > 0) {
+      parts.push(
+        encodingStatusState.pendingCount === 1
+          ? "1 job queued"
+          : `${encodingStatusState.pendingCount} jobs queued`,
+      );
+    }
+    if (encodingStatusState.nextLabel) {
+      parts.push(`Next: ${encodingStatusState.nextLabel}`);
+    }
+  }
+  const text = parts.join(" • ");
+  if (text === encodingStatusState.text) {
+    return;
+  }
+  dom.encodingStatusText.textContent = text;
+  dom.encodingStatus.dataset.visible = "true";
+  dom.encodingStatus.setAttribute("aria-hidden", "false");
+  encodingStatusState.text = text;
+}
+
+function hideEncodingStatus() {
+  if (!dom.encodingStatus || !dom.encodingStatusText) {
+    return;
+  }
+  cancelEncodingStatusTick();
+  encodingStatusState.visible = false;
+  encodingStatusState.hasActive = false;
+  encodingStatusState.durationBase = 0;
+  encodingStatusState.baseTime = nowMilliseconds();
+  encodingStatusState.activeLabel = "";
+  encodingStatusState.pendingCount = 0;
+  encodingStatusState.nextLabel = "";
+  encodingStatusState.text = "";
+  dom.encodingStatus.dataset.visible = "false";
+  dom.encodingStatus.setAttribute("aria-hidden", "true");
+  dom.encodingStatusText.textContent = "";
+}
+
+function updateEncodingStatus(rawStatus) {
+  if (!dom.encodingStatus || !dom.encodingStatusText) {
+    return;
+  }
+  const status = rawStatus && typeof rawStatus === "object" ? rawStatus : null;
+  const encoding = status && typeof status.encoding === "object" ? status.encoding : null;
+  const pending = encoding && Array.isArray(encoding.pending) ? encoding.pending : [];
+  const active = encoding && encoding.active && typeof encoding.active === "object"
+    ? encoding.active
+    : null;
+
+  if ((!pending || pending.length === 0) && !active) {
+    hideEncodingStatus();
+    return;
+  }
+
+  encodingStatusState.visible = true;
+  encodingStatusState.pendingCount = Array.isArray(pending) ? pending.length : 0;
+  encodingStatusState.nextLabel =
+    encodingStatusState.pendingCount > 0 && typeof pending[0].base_name === "string"
+      ? pending[0].base_name
+      : "";
+
+  if (active) {
+    encodingStatusState.hasActive = true;
+    encodingStatusState.activeLabel =
+      typeof active.base_name === "string" ? active.base_name : "";
+    const startedAt = toFiniteOrNull(active.started_at);
+    let baseDuration = toFiniteOrNull(active.duration_seconds);
+    if (!Number.isFinite(baseDuration)) {
+      baseDuration = startedAt !== null ? Math.max(0, Date.now() / 1000 - startedAt) : 0;
+    }
+    encodingStatusState.durationBase = Math.max(0, baseDuration || 0);
+    encodingStatusState.baseTime = nowMilliseconds();
+  } else {
+    encodingStatusState.hasActive = false;
+    encodingStatusState.activeLabel = "";
+    encodingStatusState.durationBase = 0;
+    encodingStatusState.baseTime = nowMilliseconds();
+  }
+
+  encodingStatusState.text = "";
+  renderEncodingStatus();
+  if (encodingStatusState.hasActive) {
+    scheduleEncodingStatusTick();
+  } else {
+    cancelEncodingStatusTick();
+  }
 }
 
 function hideRmsIndicator() {
@@ -1432,6 +1767,22 @@ function formatDuration(seconds) {
     return "--";
   }
   const totalSeconds = Math.round(seconds);
+  const hours = Math.floor(totalSeconds / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const secs = totalSeconds % 60;
+  if (hours > 0) {
+    return `${hours}:${minutes.toString().padStart(2, "0")}:${secs
+      .toString()
+      .padStart(2, "0")}`;
+  }
+  return `${minutes}:${secs.toString().padStart(2, "0")}`;
+}
+
+function formatShortDuration(seconds) {
+  if (!Number.isFinite(seconds) || seconds <= 0) {
+    return "0:00";
+  }
+  const totalSeconds = Math.floor(seconds);
   const hours = Math.floor(totalSeconds / 3600);
   const minutes = Math.floor((totalSeconds % 3600) / 60);
   const secs = totalSeconds % 60;
@@ -4399,6 +4750,8 @@ async function fetchRecordings(options = {}) {
     updatePaginationControls();
     setRecordingIndicatorStatus(payload.capture_status);
     updateRmsIndicator(payload.capture_status);
+    updateRecordingMeta(payload.capture_status);
+    updateEncodingStatus(payload.capture_status);
     handleFetchSuccess();
   } catch (error) {
     console.error("Failed to load recordings", error);

--- a/lib/webui/templates/dashboard.html
+++ b/lib/webui/templates/dashboard.html
@@ -435,6 +435,13 @@
                       placeholder="New clip name"
                     />
                   </label>
+                  <div class="clipper-overwrite-row">
+                    <label class="clipper-overwrite-toggle" for="clipper-overwrite-toggle">
+                      <input id="clipper-overwrite-toggle" type="checkbox" checked />
+                      <span class="clipper-overwrite-slider" aria-hidden="true"></span>
+                      <span class="clipper-overwrite-label">Overwrite existing?</span>
+                    </label>
+                  </div>
                 </div>
                 <div class="clipper-footer">
                   <div id="clipper-length" class="clipper-length" role="status" aria-live="polite">

--- a/lib/webui/templates/dashboard.html
+++ b/lib/webui/templates/dashboard.html
@@ -174,17 +174,73 @@
           <h1>Dashboard</h1>
         </div>
         <div class="header-actions">
-          <div class="header-status">
+          <div class="header-controls">
             <div
-              id="recording-indicator"
-              class="recording-indicator"
+              id="rms-indicator"
+              class="rms-indicator"
               role="status"
               aria-live="polite"
-              aria-hidden="false"
-              data-state="unknown"
+              aria-hidden="true"
+              data-visible="false"
             >
-              <span class="indicator-dot" aria-hidden="true"></span>
-              <span id="recording-indicator-text" class="indicator-text">Loading status…</span>
+              <span class="label">RMS:</span>
+              <span id="rms-indicator-value" class="value">0</span>
+            </div>
+            <button
+              id="theme-toggle"
+              class="ghost-button"
+              type="button"
+              aria-pressed="false"
+              aria-label="Toggle light and dark theme"
+            >
+              Toggle theme
+            </button>
+            <button id="live-stream-toggle" class="primary-button" type="button">Live Stream</button>
+            <div
+              id="refresh-indicator"
+              class="refresh-indicator"
+              role="status"
+              aria-live="polite"
+              aria-hidden="true"
+              data-visible="false"
+            >
+              <span class="refresh-spinner" aria-hidden="true"></span>
+              <span class="refresh-text">Refreshing…</span>
+            </div>
+          </div>
+          <div class="header-status-group">
+            <div class="status-labels">
+              <div
+                id="recording-indicator"
+                class="status-pill recording-indicator"
+                role="status"
+                aria-live="polite"
+                aria-hidden="false"
+                data-state="unknown"
+              >
+                <span class="indicator-dot" aria-hidden="true"></span>
+                <span id="recording-indicator-text" class="indicator-text">Loading status…</span>
+              </div>
+              <div
+                id="recording-meta"
+                class="status-pill"
+                role="status"
+                aria-live="polite"
+                aria-hidden="true"
+                data-visible="false"
+              >
+                <span id="recording-meta-text" class="indicator-text"></span>
+              </div>
+              <div
+                id="encoding-status"
+                class="status-pill"
+                role="status"
+                aria-live="polite"
+                aria-hidden="true"
+                data-visible="false"
+              >
+                <span id="encoding-status-text" class="indicator-text"></span>
+              </div>
             </div>
             <div
               id="connection-status"
@@ -195,38 +251,6 @@
               data-visible="false"
             ></div>
           </div>
-          <div
-            id="rms-indicator"
-            class="rms-indicator"
-            role="status"
-            aria-live="polite"
-            aria-hidden="true"
-            data-visible="false"
-          >
-            <span class="label">RMS:</span>
-            <span id="rms-indicator-value" class="value">0</span>
-          </div>
-          <button
-            id="theme-toggle"
-            class="ghost-button"
-            type="button"
-            aria-pressed="false"
-            aria-label="Toggle light and dark theme"
-          >
-            Toggle theme
-          </button>
-          <div
-            id="refresh-indicator"
-            class="refresh-indicator"
-            role="status"
-            aria-live="polite"
-            aria-hidden="true"
-            data-visible="false"
-          >
-            <span class="refresh-spinner" aria-hidden="true"></span>
-            <span class="refresh-text">Refreshing…</span>
-          </div>
-          <button id="live-stream-toggle" class="primary-button" type="button">Live Stream</button>
         </div>
       </header>
       <section class="status-bar">

--- a/lib/webui/templates/dashboard.html
+++ b/lib/webui/templates/dashboard.html
@@ -511,6 +511,12 @@
               <div class="table-actions">
                 <button id="select-all" class="ghost-button small" type="button">Select all</button>
                 <button id="clear-selection" class="ghost-button small" type="button">Clear</button>
+                <button id="download-selected" class="ghost-button small" type="button" disabled>
+                  Download selected
+                </button>
+                <button id="rename-selected" class="ghost-button small" type="button" disabled>
+                  Rename selected
+                </button>
                 <button id="delete-selected" class="danger-button small" type="button" disabled>Delete selected</button>
               </div>
             </div>
@@ -597,6 +603,35 @@
           <button id="confirm-modal-confirm" class="danger-button" type="button">OK</button>
           <button id="confirm-modal-cancel" class="ghost-button" type="button">Cancel</button>
         </div>
+      </div>
+    </div>
+    <div
+      id="rename-modal"
+      class="rename-modal"
+      hidden
+      data-visible="false"
+      aria-hidden="true"
+    >
+      <div
+        id="rename-modal-dialog"
+        class="rename-dialog"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="rename-modal-title"
+        tabindex="-1"
+      >
+        <h2 id="rename-modal-title" class="rename-title">Rename recording</h2>
+        <form id="rename-form" class="rename-form">
+          <label class="input-group">
+            <span>New name</span>
+            <input id="rename-input" type="text" autocomplete="off" required spellcheck="false" />
+          </label>
+          <p id="rename-error" class="rename-error" role="alert" hidden></p>
+          <div class="rename-actions">
+            <button id="rename-cancel" class="ghost-button" type="button">Cancel</button>
+            <button id="rename-confirm" class="primary-button" type="submit">Rename</button>
+          </div>
+        </form>
       </div>
     </div>
     <div

--- a/systemd/tricorder-auto-update.service
+++ b/systemd/tricorder-auto-update.service
@@ -2,11 +2,13 @@
 Description=Tricorder auto-update service
 After=network-online.target
 Wants=network-online.target
+ConditionPathExists=!/apps/tricorder/.dev-mode
 
 [Service]
 Type=oneshot
 EnvironmentFile=-/etc/tricorder/update.env
 WorkingDirectory=/apps/tricorder
+ExecCondition=/bin/sh -c '[ "${DEV:-0}" != "1" ]'
 ExecStart=/apps/tricorder/bin/tricorder_auto_update.sh
 
 [Install]


### PR DESCRIPTION
## Summary
- add `/api/recordings/rename` and `/api/recordings/bulk-download` endpoints that validate paths, move sidecars, and stream archives
- extend the dashboard with bulk download controls, per-record rename actions, and a rename modal wired to the new APIs
- style the rename modal and cover the new behaviour with dashboard tests for rename and bulk download

## Testing
- pytest tests/test_37_web_dashboard.py -q

------
https://chatgpt.com/codex/tasks/task_e_68d8f6971c6883279e8f6585a3be2843