### PR TITLE
Add bulk download and rename support for recordings

### DIFF
--- a/lib/webui/static/css/dashboard.css
+++ b/lib/webui/static/css/dashboard.css
@@ -2240,7 +2240,8 @@ body[data-scroll-locked="true"] {
   font-size: 0.95rem;
 }
 
-.confirm-modal {
+.confirm-modal,
+.rename-modal {
   position: fixed;
   inset: 0;
   display: flex;
@@ -2256,13 +2257,15 @@ body[data-scroll-locked="true"] {
   transition: opacity 0.2s ease, visibility 0.2s ease;
 }
 
-.confirm-modal[data-visible="true"] {
+.confirm-modal[data-visible="true"],
+.rename-modal[data-visible="true"] {
   opacity: 1;
   visibility: visible;
   pointer-events: auto;
 }
 
-.confirm-dialog {
+.confirm-dialog,
+.rename-dialog {
   width: min(420px, 100%);
   border-radius: 1rem;
   background: var(--card-bg);
@@ -2274,7 +2277,12 @@ body[data-scroll-locked="true"] {
   gap: 1rem;
 }
 
-.confirm-title {
+.rename-dialog {
+  width: min(480px, 100%);
+}
+
+.confirm-title,
+.rename-title {
   margin: 0;
   font-size: 1.1rem;
   letter-spacing: -0.01em;
@@ -2292,7 +2300,27 @@ body[data-scroll-locked="true"] {
   gap: 0.75rem;
 }
 
-.confirm-actions button {
+.rename-form {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.rename-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.75rem;
+}
+
+.rename-error {
+  margin: 0;
+  color: var(--danger);
+  font-size: 0.85rem;
+  min-height: 1.1em;
+}
+
+.confirm-actions button,
+.rename-actions button {
   min-width: 96px;
 }
 

--- a/lib/webui/static/js/dashboard.js
+++ b/lib/webui/static/js/dashboard.js
@@ -124,6 +124,8 @@ const dom = {
   toggleAll: document.getElementById("toggle-all"),
   selectAll: document.getElementById("select-all"),
   clearSelection: document.getElementById("clear-selection"),
+  downloadSelected: document.getElementById("download-selected"),
+  renameSelected: document.getElementById("rename-selected"),
   deleteSelected: document.getElementById("delete-selected"),
   refreshIndicator: document.getElementById("refresh-indicator"),
   themeToggle: document.getElementById("theme-toggle"),
@@ -229,6 +231,13 @@ const dom = {
   confirmMessage: document.getElementById("confirm-modal-message"),
   confirmConfirm: document.getElementById("confirm-modal-confirm"),
   confirmCancel: document.getElementById("confirm-modal-cancel"),
+  renameModal: document.getElementById("rename-modal"),
+  renameDialog: document.getElementById("rename-modal-dialog"),
+  renameForm: document.getElementById("rename-form"),
+  renameInput: document.getElementById("rename-input"),
+  renameError: document.getElementById("rename-error"),
+  renameConfirm: document.getElementById("rename-confirm"),
+  renameCancel: document.getElementById("rename-cancel"),
 };
 
 const recorderDom = {
@@ -717,6 +726,12 @@ function findInteractiveElement(target, event = null) {
 
 let refreshIndicatorTimer = null;
 let pendingSelectionPath = null;
+const renameDialogState = {
+  open: false,
+  target: null,
+  pending: false,
+  previouslyFocused: null,
+};
 
 const waveformState = {
   peaks: null,
@@ -2274,6 +2289,236 @@ if (dom.confirmModal) {
   });
 }
 
+function setRenameModalVisible(visible) {
+  if (!dom.renameModal) {
+    return;
+  }
+  if (visible) {
+    dom.renameModal.hidden = false;
+    dom.renameModal.dataset.visible = "true";
+    dom.renameModal.setAttribute("aria-hidden", "false");
+  } else {
+    dom.renameModal.dataset.visible = "false";
+    dom.renameModal.setAttribute("aria-hidden", "true");
+    dom.renameModal.hidden = true;
+  }
+}
+
+function setRenameDialogError(message) {
+  if (!dom.renameError) {
+    return;
+  }
+  if (typeof message === "string" && message) {
+    dom.renameError.textContent = message;
+    dom.renameError.hidden = false;
+  } else {
+    dom.renameError.textContent = "";
+    dom.renameError.hidden = true;
+  }
+}
+
+function setRenameDialogPending(pending) {
+  renameDialogState.pending = Boolean(pending);
+  if (dom.renameConfirm) {
+    dom.renameConfirm.disabled = pending === true;
+  }
+  if (dom.renameInput) {
+    dom.renameInput.disabled = pending === true;
+  }
+  if (dom.renameCancel) {
+    dom.renameCancel.disabled = pending === true;
+  }
+  updateSelectionUI();
+}
+
+function closeRenameDialog() {
+  if (!renameDialogState.open) {
+    return;
+  }
+  renameDialogState.open = false;
+  const previous = renameDialogState.previouslyFocused;
+  renameDialogState.previouslyFocused = null;
+  renameDialogState.target = null;
+  setRenameDialogPending(false);
+  setRenameDialogError("");
+  setRenameModalVisible(false);
+  if (previous && typeof previous.focus === "function") {
+    window.requestAnimationFrame(() => {
+      previous.focus();
+    });
+  }
+}
+
+function renameDialogFocusableElements() {
+  if (!dom.renameDialog) {
+    return [];
+  }
+  const nodes = dom.renameDialog.querySelectorAll(
+    'button:not([disabled]), input:not([disabled])'
+  );
+  return Array.from(nodes).filter((element) => element instanceof HTMLElement);
+}
+
+function openRenameDialog(record) {
+  if (
+    !dom.renameModal ||
+    !dom.renameDialog ||
+    !dom.renameForm ||
+    !dom.renameInput ||
+    !dom.renameConfirm ||
+    !dom.renameCancel
+  ) {
+    if (
+      record &&
+      typeof record.path === "string" &&
+      typeof window !== "undefined" &&
+      typeof window.prompt === "function"
+    ) {
+      const promptValue = window.prompt(
+        "Enter a new name for the recording",
+        typeof record.name === "string" && record.name ? record.name : record.path
+      );
+      const trimmed = promptValue ? promptValue.trim() : "";
+      if (trimmed) {
+        const extensionValue =
+          typeof record.extension === "string" && record.extension ? record.extension : "";
+        const hasSuffix = trimmed.includes(".");
+        const options = {};
+        if (!hasSuffix && extensionValue) {
+          options.extension = extensionValue;
+        }
+        void renameRecording(record.path, trimmed, options);
+      }
+    }
+    return;
+  }
+
+  renameDialogState.open = true;
+  renameDialogState.target = record || null;
+  renameDialogState.previouslyFocused =
+    document.activeElement instanceof HTMLElement ? document.activeElement : null;
+  setRenameDialogPending(false);
+  setRenameDialogError("");
+
+  if (record && typeof record.name === "string") {
+    dom.renameInput.value = record.name;
+  } else if (record && typeof record.path === "string") {
+    const parts = record.path.split("/");
+    dom.renameInput.value = parts.length ? parts[parts.length - 1] : record.path;
+  } else {
+    dom.renameInput.value = "";
+  }
+  dom.renameInput.dataset.extension =
+    record && typeof record.extension === "string" ? record.extension : "";
+
+  setRenameModalVisible(true);
+
+  window.requestAnimationFrame(() => {
+    window.requestAnimationFrame(() => {
+      if (dom.renameDialog) {
+        dom.renameDialog.focus();
+      }
+      if (dom.renameInput) {
+        dom.renameInput.focus();
+        dom.renameInput.select();
+      }
+    });
+  });
+}
+
+async function handleRenameSubmit(event) {
+  event.preventDefault();
+  if (!renameDialogState.open || renameDialogState.pending) {
+    return;
+  }
+  if (!dom.renameInput) {
+    return;
+  }
+  const value = dom.renameInput.value.trim();
+  if (!value) {
+    setRenameDialogError("Enter a new name.");
+    return;
+  }
+  const target = renameDialogState.target;
+  if (!target || typeof target.path !== "string") {
+    setRenameDialogError("Unable to rename this recording.");
+    return;
+  }
+
+  const hasSuffix = value.includes(".");
+  const extensionValue = dom.renameInput.dataset.extension || target.extension || "";
+  const options = {};
+  if (!hasSuffix && extensionValue) {
+    options.extension = extensionValue;
+  }
+
+  setRenameDialogPending(true);
+  try {
+    await renameRecording(target.path, value, options);
+    closeRenameDialog();
+  } catch (error) {
+    console.error("Rename request failed", error);
+    const message =
+      error instanceof Error && error.message
+        ? error.message
+        : "Unable to rename recording.";
+    setRenameDialogError(message);
+    setRenameDialogPending(false);
+  }
+}
+
+if (dom.renameForm) {
+  dom.renameForm.addEventListener("submit", handleRenameSubmit);
+}
+
+if (dom.renameCancel) {
+  dom.renameCancel.addEventListener("click", () => {
+    if (!renameDialogState.pending) {
+      closeRenameDialog();
+    }
+  });
+}
+
+if (dom.renameModal) {
+  dom.renameModal.addEventListener("click", (event) => {
+    if (!renameDialogState.pending && event.target === dom.renameModal) {
+      closeRenameDialog();
+    }
+  });
+  dom.renameModal.addEventListener("keydown", (event) => {
+    if (!renameDialogState.open) {
+      return;
+    }
+    if (event.key === "Escape") {
+      event.preventDefault();
+      if (!renameDialogState.pending) {
+        closeRenameDialog();
+      }
+      return;
+    }
+    if (event.key === "Tab") {
+      const focusable = renameDialogFocusableElements();
+      if (!focusable.length) {
+        event.preventDefault();
+        return;
+      }
+      const active =
+        document.activeElement instanceof HTMLElement ? document.activeElement : null;
+      let index = focusable.indexOf(active);
+      if (index === -1) {
+        index = 0;
+      }
+      if (event.shiftKey) {
+        index = index <= 0 ? focusable.length - 1 : index - 1;
+      } else {
+        index = index >= focusable.length - 1 ? 0 : index + 1;
+      }
+      event.preventDefault();
+      focusable[index].focus();
+    }
+  });
+}
+
 function clearRefreshIndicatorTimer() {
   if (refreshIndicatorTimer) {
     window.clearTimeout(refreshIndicatorTimer);
@@ -2487,6 +2732,12 @@ function updateSelectionUI(records = null) {
     dom.selectedCountMobile.textContent = selectedText;
   }
   dom.deleteSelected.disabled = state.selections.size === 0;
+  if (dom.downloadSelected) {
+    dom.downloadSelected.disabled = state.selections.size === 0;
+  }
+  if (dom.renameSelected) {
+    dom.renameSelected.disabled = state.selections.size !== 1 || renameDialogState.pending;
+  }
 
   if (!visible.length) {
     dom.toggleAll.checked = false;
@@ -2965,6 +3216,16 @@ function renderRecords() {
     downloadLink.textContent = "Download";
     downloadLink.setAttribute("download", `${record.name}.${record.extension || "opus"}`);
 
+    const renameButton = document.createElement("button");
+    renameButton.type = "button";
+    renameButton.textContent = "Rename";
+    renameButton.classList.add("ghost-button");
+    renameButton.classList.add("small");
+    renameButton.addEventListener("click", (event) => {
+      event.stopPropagation();
+      openRenameDialog(record);
+    });
+
     const deleteButton = document.createElement("button");
     deleteButton.type = "button";
     deleteButton.textContent = "Delete";
@@ -2973,7 +3234,7 @@ function renderRecords() {
       await requestRecordDeletion(record);
     });
 
-    actionWrapper.append(downloadLink, deleteButton);
+    actionWrapper.append(downloadLink, renameButton, deleteButton);
     actionsCell.append(actionWrapper);
     row.append(actionsCell);
 
@@ -8008,6 +8269,163 @@ async function deleteRecordings(paths) {
   }
 }
 
+function extractFilenameFromDisposition(disposition) {
+  if (typeof disposition !== "string" || !disposition) {
+    return null;
+  }
+  const utf8Match = disposition.match(/filename\*=UTF-8''([^;]+)/i);
+  if (utf8Match && utf8Match[1]) {
+    try {
+      return decodeURIComponent(utf8Match[1]);
+    } catch (error) {
+      return utf8Match[1];
+    }
+  }
+  const simpleMatch = disposition.match(/filename="?([^";]+)"?/i);
+  if (simpleMatch && simpleMatch[1]) {
+    return simpleMatch[1];
+  }
+  return null;
+}
+
+async function renameRecording(path, newName, options = {}) {
+  if (typeof path !== "string" || !path || typeof newName !== "string" || !newName) {
+    throw new Error("Invalid rename request");
+  }
+  const payload = {
+    item: path,
+    name: newName,
+  };
+  const extensionValue =
+    options && typeof options.extension === "string" ? options.extension.trim() : "";
+  if (extensionValue) {
+    payload.extension = extensionValue;
+  }
+
+  const response = await fetch(apiPath("/api/recordings/rename"), {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(payload),
+  });
+
+  if (!response.ok) {
+    let message = `Rename failed with status ${response.status}`;
+    try {
+      const errorPayload = await response.json();
+      if (typeof errorPayload.error === "string" && errorPayload.error) {
+        message = errorPayload.error;
+      } else if (Array.isArray(errorPayload.errors) && errorPayload.errors.length) {
+        const combined = errorPayload.errors
+          .map((entry) => {
+            const item = typeof entry.item === "string" ? entry.item : "";
+            const errorText = typeof entry.error === "string" ? entry.error : "";
+            return item ? `${item}: ${errorText}` : errorText;
+          })
+          .filter(Boolean)
+          .join("\n");
+        if (combined) {
+          message = combined;
+        }
+      }
+    } catch (error) {
+      // ignore parse errors
+    }
+    throw new Error(message);
+  }
+
+  const payloadJson = await response.json();
+  const oldPath = typeof payloadJson.old_path === "string" ? payloadJson.old_path : path;
+  const newPath = typeof payloadJson.new_path === "string" ? payloadJson.new_path : path;
+
+  if (state.selections.has(oldPath)) {
+    state.selections.delete(oldPath);
+    state.selections.add(newPath);
+  }
+  if (state.current && state.current.path === oldPath) {
+    pendingSelectionPath = newPath;
+  }
+
+  updateSelectionUI();
+  await fetchRecordings({ silent: false });
+
+  return payloadJson;
+}
+
+async function downloadRecordingsArchive(paths) {
+  if (!Array.isArray(paths) || !paths.length) {
+    return;
+  }
+
+  const response = await fetch(apiPath("/api/recordings/bulk-download"), {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ items: paths }),
+  });
+
+  if (!response.ok) {
+    let message = `Download failed with status ${response.status}`;
+    try {
+      const errorPayload = await response.json();
+      if (typeof errorPayload.error === "string" && errorPayload.error) {
+        message = errorPayload.error;
+      } else if (Array.isArray(errorPayload.errors) && errorPayload.errors.length) {
+        const combined = errorPayload.errors
+          .map((entry) => {
+            const item = typeof entry.item === "string" ? entry.item : "";
+            const errorText = typeof entry.error === "string" ? entry.error : "";
+            return item ? `${item}: ${errorText}` : errorText;
+          })
+          .filter(Boolean)
+          .join("\n");
+        if (combined) {
+          message = combined;
+        }
+      }
+    } catch (error) {
+      // ignore parse errors
+    }
+    throw new Error(message);
+  }
+
+  const blob = await response.blob();
+  const disposition = response.headers.get("Content-Disposition");
+  let filename = extractFilenameFromDisposition(disposition);
+  if (!filename) {
+    const now = new Date();
+    if (!Number.isNaN(now.getTime())) {
+      const timestamp =
+        `${now.getFullYear()}` +
+        `${String(now.getMonth() + 1).padStart(2, "0")}` +
+        `${String(now.getDate()).padStart(2, "0")}` +
+        `-${String(now.getHours()).padStart(2, "0")}` +
+        `${String(now.getMinutes()).padStart(2, "0")}` +
+        `${String(now.getSeconds()).padStart(2, "0")}`;
+      filename = `tricorder-recordings-${timestamp}.zip`;
+    } else {
+      filename = "tricorder-recordings.zip";
+    }
+  }
+
+  if (typeof window === "undefined" || !window.URL || !window.document) {
+    return;
+  }
+
+  const blobUrl = window.URL.createObjectURL(blob);
+  const link = document.createElement("a");
+  link.href = blobUrl;
+  link.download = filename || "recordings.zip";
+  document.body.append(link);
+  link.click();
+  link.remove();
+  window.setTimeout(() => {
+    window.URL.revokeObjectURL(blobUrl);
+  }, 1000);
+}
+
 function applyFiltersFromInputs() {
   const search = dom.filterSearch ? dom.filterSearch.value.trim() : "";
   const day = dom.filterDay ? dom.filterDay.value.trim() : "";
@@ -8911,6 +9329,46 @@ function attachEventListeners() {
     const paths = Array.from(state.selections.values());
     await deleteRecordings(paths);
   });
+
+  if (dom.downloadSelected) {
+    dom.downloadSelected.addEventListener("click", async () => {
+      if (!state.selections.size) {
+        return;
+      }
+      const paths = Array.from(state.selections.values());
+      dom.downloadSelected.disabled = true;
+      try {
+        await downloadRecordingsArchive(paths);
+      } catch (error) {
+        console.error("Bulk download failed", error);
+        const message =
+          error instanceof Error && error.message
+            ? error.message
+            : "Unable to download recordings.";
+        if (typeof window !== "undefined" && typeof window.alert === "function") {
+          window.alert(message);
+        }
+      } finally {
+        updateSelectionUI();
+      }
+    });
+  }
+
+  if (dom.renameSelected) {
+    dom.renameSelected.addEventListener("click", () => {
+      if (renameDialogState.pending || state.selections.size !== 1) {
+        return;
+      }
+      const [selectedPath] = Array.from(state.selections.values());
+      if (typeof selectedPath !== "string" || !selectedPath) {
+        return;
+      }
+      const record = state.records.find((entry) => entry.path === selectedPath);
+      if (record) {
+        openRenameDialog(record);
+      }
+    });
+  }
 
   if (dom.waveformContainer) {
     dom.waveformContainer.addEventListener("pointerdown", handleWaveformPointerDown);

--- a/lib/webui/templates/dashboard.html
+++ b/lib/webui/templates/dashboard.html
@@ -511,6 +511,12 @@
               <div class="table-actions">
                 <button id="select-all" class="ghost-button small" type="button">Select all</button>
                 <button id="clear-selection" class="ghost-button small" type="button">Clear</button>
+                <button id="download-selected" class="ghost-button small" type="button" disabled>
+                  Download selected
+                </button>
+                <button id="rename-selected" class="ghost-button small" type="button" disabled>
+                  Rename selected
+                </button>
                 <button id="delete-selected" class="danger-button small" type="button" disabled>Delete selected</button>
               </div>
             </div>
@@ -597,6 +603,35 @@
           <button id="confirm-modal-confirm" class="danger-button" type="button">OK</button>
           <button id="confirm-modal-cancel" class="ghost-button" type="button">Cancel</button>
         </div>
+      </div>
+    </div>
+    <div
+      id="rename-modal"
+      class="rename-modal"
+      hidden
+      data-visible="false"
+      aria-hidden="true"
+    >
+      <div
+        id="rename-modal-dialog"
+        class="rename-dialog"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="rename-modal-title"
+        tabindex="-1"
+      >
+        <h2 id="rename-modal-title" class="rename-title">Rename recording</h2>
+        <form id="rename-form" class="rename-form">
+          <label class="input-group">
+            <span>New name</span>
+            <input id="rename-input" type="text" autocomplete="off" required spellcheck="false" />
+          </label>
+          <p id="rename-error" class="rename-error" role="alert" hidden></p>
+          <div class="rename-actions">
+            <button id="rename-cancel" class="ghost-button" type="button">Cancel</button>
+            <button id="rename-confirm" class="primary-button" type="submit">Rename</button>
+          </div>
+        </form>
       </div>
     </div>
     <div


### PR DESCRIPTION
## Summary
- add `/api/recordings/rename` and `/api/recordings/bulk-download` endpoints that validate paths, move sidecars, and stream archives
- extend the dashboard with bulk download controls, per-record rename actions, and a rename modal wired to the new APIs
- style the rename modal and cover the new behaviour with dashboard tests for rename and bulk download

## Testing
- pytest tests/test_37_web_dashboard.py -q

------
https://chatgpt.com/codex/tasks/task_e_68d8f6971c6883279e8f6585a3be2843