### PR TITLE
TR-22: clean up partially encoded ingest retries

### DIFF
--- a/lib/process_dropped_file.py
+++ b/lib/process_dropped_file.py
@@ -1,10 +1,12 @@
 #!/usr/bin/env python3
+import json
 import os
 import re
 import subprocess
 import sys
 import time
 import wave
+from datetime import datetime, timezone
 from contextlib import contextmanager
 from pathlib import Path
 
@@ -24,8 +26,11 @@ STABLE_CHECKS = int(cfg["ingest"]["stable_checks"])
 STABLE_INTERVAL_SEC = float(cfg["ingest"]["stable_interval_sec"])
 DROPBOX_DIR = Path(cfg["paths"]["dropbox_dir"])
 WORK_DIR = Path(cfg["paths"]["ingest_work_dir"])
+REC_DIR = Path(cfg["paths"]["recordings_dir"])
 ALLOWED_EXT = set(x.lower() for x in cfg["ingest"]["allowed_ext"])
 IGNORE_SUFFIXES = set(cfg["ingest"]["ignore_suffixes"])
+RETRY_SUFFIX = "-RETRY"
+OUTPUT_SUFFIXES = (".opus",)
 
 TIMESTAMP_TOKEN_RE = re.compile(r"^\d{2}-\d{2}-\d{2}$")
 COUNTER_TOKEN_RE = re.compile(r"^\d+$")
@@ -182,6 +187,13 @@ def _prepare_work_area() -> None:
 
 def _handle_work_file(work_file: Path) -> None:
     try:
+        try:
+            _cleanup_retry_artifacts(work_file)
+        except Exception as exc:  # noqa: BLE001 - diagnostics only
+            print(
+                f"[ingest] retry cleanup failed for {work_file}: {exc}",
+                flush=True,
+            )
         process_file(str(work_file))
     except Exception as e:
         print(f"[ingest] processing failed for {work_file}: {e}", flush=True)
@@ -211,6 +223,171 @@ def _move_to_work(p: Path) -> Path:
     return dest
 
 
+def _iter_existing_recordings(base_name: str):
+    if not base_name or not REC_DIR.exists():
+        return
+    try:
+        day_dirs = sorted(p for p in REC_DIR.iterdir() if p.is_dir())
+    except FileNotFoundError:
+        return
+    for day_dir in day_dirs:
+        for suffix in OUTPUT_SUFFIXES:
+            candidate = day_dir / f"{base_name}{suffix}"
+            if candidate.exists():
+                yield candidate
+
+
+def _read_waveform_duration(waveform_path: Path) -> float | None:
+    try:
+        with waveform_path.open("r", encoding="utf-8") as handle:
+            payload = json.load(handle)
+    except (OSError, json.JSONDecodeError):
+        return None
+    raw = payload.get("duration_seconds") if isinstance(payload, dict) else None
+    if isinstance(raw, (int, float)) and raw > 0:
+        return float(raw)
+    return None
+
+
+def _probe_audio_duration(path: Path) -> float | None:
+    if not path.exists():
+        return None
+    cmd = [
+        "ffprobe",
+        "-v",
+        "error",
+        "-select_streams",
+        "a:0",
+        "-show_entries",
+        "stream=duration",
+        "-of",
+        "default=noprint_wrappers=1:nokey=1",
+        str(path),
+    ]
+    try:
+        result = subprocess.run(
+            cmd,
+            capture_output=True,
+            text=True,
+            check=True,
+            timeout=5.0,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    duration_text = (result.stdout or "").strip()
+    if not duration_text:
+        return None
+    try:
+        duration = float(duration_text)
+    except ValueError:
+        return None
+    if duration <= 0:
+        return None
+    return duration
+
+
+def _duration_mismatch(expected: float, actual: float) -> bool:
+    diff = abs(expected - actual)
+    tolerance = max(0.5, expected * 0.1, actual * 0.1)
+    return diff > tolerance
+
+
+def _write_placeholder(
+    day_dir: Path,
+    base_name: str,
+    reason: str,
+    extra: dict | None = None,
+) -> Path:
+    day_dir.mkdir(parents=True, exist_ok=True)
+    target = day_dir / f"{base_name}-CORRUPTED_RECORDING.json"
+    payload = {
+        "status": "corrupted",
+        "base_name": base_name,
+        "timestamp": datetime.now(timezone.utc).isoformat(timespec="seconds"),
+        "reason": reason,
+        "detected_by": "ingest-retry-scan",
+    }
+    if extra:
+        payload.update(extra)
+    tmp = target.with_suffix(target.suffix + ".tmp")
+    with tmp.open("w", encoding="utf-8") as handle:
+        json.dump(payload, handle, ensure_ascii=False)
+        handle.write("\n")
+    os.replace(tmp, target)
+    return target
+
+
+def _quarantine_recording(
+    audio_path: Path,
+    *,
+    reason: str,
+    waveform_duration: float | None,
+    audio_duration: float | None,
+) -> None:
+    base_name = audio_path.stem
+    day_dir = audio_path.parent
+    extras: dict[str, object] = {
+        "action": "removed-before-retry",
+    }
+    if waveform_duration is not None:
+        extras["waveform_duration_seconds"] = waveform_duration
+    if audio_duration is not None:
+        extras["audio_duration_seconds"] = audio_duration
+    if waveform_duration is not None and audio_duration is not None:
+        extras["duration_diff_seconds"] = waveform_duration - audio_duration
+
+    related = [audio_path]
+    waveform_path = audio_path.with_suffix(audio_path.suffix + ".waveform.json")
+    transcript_path = audio_path.with_suffix(audio_path.suffix + ".transcript.json")
+    related.append(waveform_path)
+    related.append(transcript_path)
+
+    for candidate in related:
+        try:
+            candidate.unlink(missing_ok=True)
+        except Exception as exc:  # noqa: BLE001 - diagnostics only
+            print(f"[ingest] failed to remove {candidate}: {exc}", flush=True)
+
+    placeholder = _write_placeholder(day_dir, base_name, reason, extras)
+    print(
+        (
+            f"[ingest] quarantined {audio_path} (reason={reason}, "
+            f"waveform={waveform_duration}, audio={audio_duration}) -> {placeholder.name}"
+        ),
+        flush=True,
+    )
+
+
+def _cleanup_retry_artifacts(work_file: Path) -> None:
+    stem = work_file.stem
+    if not stem.endswith(RETRY_SUFFIX):
+        return
+    base_name = stem[: -len(RETRY_SUFFIX)]
+    if not base_name:
+        return
+    for audio_path in _iter_existing_recordings(base_name):
+        waveform_path = audio_path.with_suffix(audio_path.suffix + ".waveform.json")
+        waveform_duration = _read_waveform_duration(waveform_path)
+        if waveform_duration is None:
+            _quarantine_recording(
+                audio_path,
+                reason="missing-waveform",
+                waveform_duration=None,
+                audio_duration=None,
+            )
+            continue
+        audio_duration = _probe_audio_duration(audio_path)
+        if audio_duration is None:
+            continue
+        if _duration_mismatch(waveform_duration, audio_duration):
+            _quarantine_recording(
+                audio_path,
+                reason="duration-mismatch",
+                waveform_duration=waveform_duration,
+                audio_duration=audio_duration,
+            )
+
+
 def _extract_ingest_hint(path: Path) -> RecorderIngestHint | None:
     base = path.stem
     if not base:
@@ -218,8 +395,9 @@ def _extract_ingest_hint(path: Path) -> RecorderIngestHint | None:
 
     normalized = base
     lower = normalized.lower()
-    if lower.endswith("-retry"):
-        normalized = normalized[: -len("-retry")]
+    retry_suffix = RETRY_SUFFIX.lower()
+    if lower.endswith(retry_suffix):
+        normalized = normalized[: -len(RETRY_SUFFIX)]
 
     tokens = [token for token in normalized.split("_") if token]
     timestamp = next((tok for tok in tokens if TIMESTAMP_TOKEN_RE.fullmatch(tok)), None)

--- a/tests/test_30_dropbox.py
+++ b/tests/test_30_dropbox.py
@@ -1,5 +1,6 @@
 import io
 import collections
+import json
 import math
 import struct
 import subprocess
@@ -209,4 +210,70 @@ def test_process_file_uses_filename_timestamp(tmp_path, monkeypatch):
     base = captured["base_name"]
     assert base.startswith("12-34-56_")
     assert base.rsplit("_", 1)[-1] == "3"
+
+
+def test_cleanup_retry_artifacts_detects_duration_mismatch(tmp_path, monkeypatch):
+    recordings_dir = tmp_path / "recordings"
+    day_dir = recordings_dir / "20240102"
+    day_dir.mkdir(parents=True)
+
+    audio_path = day_dir / "clip.opus"
+    audio_path.write_bytes(b"dummy")
+    waveform_path = audio_path.with_suffix(".opus.waveform.json")
+    waveform_payload = {"duration_seconds": 12.0}
+    waveform_path.write_text(json.dumps(waveform_payload))
+
+    monkeypatch.setattr(process_dropped_file, "REC_DIR", recordings_dir)
+    monkeypatch.setattr(process_dropped_file, "OUTPUT_SUFFIXES", (".opus",))
+
+    probe_calls: list[Path] = []
+
+    def fake_probe(path: Path) -> float:
+        probe_calls.append(path)
+        return 3.0
+
+    monkeypatch.setattr(process_dropped_file, "_probe_audio_duration", fake_probe)
+
+    work_dir = tmp_path / "ingest"
+    work_dir.mkdir()
+    work_file = work_dir / "clip-RETRY.wav"
+    work_file.write_bytes(b"input")
+
+    process_dropped_file._cleanup_retry_artifacts(work_file)
+
+    placeholder = day_dir / "clip-CORRUPTED_RECORDING.json"
+    assert placeholder.exists()
+    payload = json.loads(placeholder.read_text())
+    assert payload["reason"] == "duration-mismatch"
+    assert payload["audio_duration_seconds"] == 3.0
+    assert payload["waveform_duration_seconds"] == 12.0
+    assert probe_calls == [audio_path]
+    assert not audio_path.exists()
+    assert not waveform_path.exists()
+
+
+def test_cleanup_retry_artifacts_handles_missing_waveform(tmp_path, monkeypatch):
+    recordings_dir = tmp_path / "recordings"
+    day_dir = recordings_dir / "20240103"
+    day_dir.mkdir(parents=True)
+
+    audio_path = day_dir / "clip.opus"
+    audio_path.write_bytes(b"dummy")
+
+    monkeypatch.setattr(process_dropped_file, "REC_DIR", recordings_dir)
+    monkeypatch.setattr(process_dropped_file, "OUTPUT_SUFFIXES", (".opus",))
+    monkeypatch.setattr(process_dropped_file, "_probe_audio_duration", lambda path: 5.0)
+
+    work_dir = tmp_path / "ingest"
+    work_dir.mkdir(exist_ok=True)
+    work_file = work_dir / "clip-RETRY.wav"
+    work_file.write_bytes(b"input")
+
+    process_dropped_file._cleanup_retry_artifacts(work_file)
+
+    placeholder = day_dir / "clip-CORRUPTED_RECORDING.json"
+    assert placeholder.exists()
+    payload = json.loads(placeholder.read_text())
+    assert payload["reason"] == "missing-waveform"
+    assert not audio_path.exists()
 


### PR DESCRIPTION
## Summary
- detect and quarantine partially encoded recordings before retrying Dropbox ingest jobs
- write placeholders for removed artifacts and expose helper utilities for retry scans
- add regression tests covering duration mismatches and missing waveform metadata

## Testing
- DEV=1 pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d95cbb8cd88327a903f477bf86bb34