### PR TITLE
Simplify hamburger toggle branding

### DIFF
--- a/lib/webui/static/css/dashboard.css
+++ b/lib/webui/static/css/dashboard.css
@@ -269,6 +269,7 @@ body {
   align-items: center;
 }
 
+
 .icon-button {
   appearance: none;
   border: none;
@@ -286,6 +287,34 @@ body {
   transition: background 0.2s ease, transform 0.2s ease, border-color 0.2s ease;
 }
 
+.app-menu-toggle {
+  position: relative;
+  overflow: hidden;
+  isolation: isolate;
+  color: rgba(243, 244, 246, 0.82);
+}
+
+.app-menu-toggle::before {
+  content: "";
+  position: absolute;
+  inset: 0.15rem;
+  border-radius: calc(0.75rem - 0.15rem);
+  background-image: url("../img/tricorder-logo.svg");
+  background-size: 175%;
+  background-position: center;
+  background-repeat: no-repeat;
+  opacity: 0.35;
+  filter: saturate(1.1);
+  transition: opacity 0.2s ease, transform 0.2s ease;
+  pointer-events: none;
+  z-index: 0;
+}
+
+.app-menu-toggle:hover::before {
+  opacity: 0.5;
+  transform: scale(1.03);
+}
+
 .icon-button:hover {
   background: var(--surface-strong);
   transform: translateY(-1px);
@@ -300,7 +329,10 @@ body {
   outline-offset: 3px;
 }
 
+
 .menu-icon {
+  position: relative;
+  z-index: 1;
   display: flex;
   flex-direction: column;
   gap: 0.35rem;
@@ -309,9 +341,24 @@ body {
 .menu-icon span {
   display: block;
   width: 1.1rem;
-  height: 0.14rem;
+  height: 0.28rem;
   border-radius: 999px;
-  background: currentColor;
+  background: transparent;
+  border: 1px solid currentColor;
+  opacity: 0.75;
+}
+
+.app-menu-toggle:hover .menu-icon span,
+.app-menu-toggle:focus-visible .menu-icon span {
+  opacity: 0.9;
+}
+
+.app-menu-toggle:active .menu-icon span {
+  opacity: 1;
+}
+
+body[data-theme="light"] .app-menu-toggle {
+  color: rgba(15, 23, 42, 0.72);
 }
 
 .app-menu {
@@ -2414,9 +2461,9 @@ body[data-scroll-locked="true"] {
 
   .titles {
     width: 100%;
-    justify-content: space-between;
+    justify-content: flex-start;
     flex-wrap: wrap;
-    gap: 0.5rem;
+    gap: 0.75rem;
   }
 
   #recordings-table {

--- a/lib/webui/static/img/tricorder-logo.svg
+++ b/lib/webui/static/img/tricorder-logo.svg
@@ -1,0 +1,28 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="Tricorder logo">
+  <defs>
+    <radialGradient id="glow" cx="50%" cy="50%" r="60%">
+      <stop offset="0%" stop-color="#4bdeff" stop-opacity="0.9" />
+      <stop offset="55%" stop-color="#1f5eb3" stop-opacity="0.65" />
+      <stop offset="100%" stop-color="#01102a" stop-opacity="0.85" />
+    </radialGradient>
+    <linearGradient id="accent" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#65fff7" />
+      <stop offset="100%" stop-color="#0bb4d5" />
+    </linearGradient>
+  </defs>
+  <g transform="translate(4 4)">
+    <rect width="56" height="56" rx="14" fill="url(#glow)" />
+    <path
+      d="M12 38h8a1 1 0 0 0 1-1v-7.5l3.1 4.4a1 1 0 0 0 1.6 0l3.1-4.4 3.1 4.4a1 1 0 0 0 1.6 0l3.1-4.4V37a1 1 0 0 0 1 1h7"
+      fill="none"
+      stroke="#9bf4ff"
+      stroke-width="3"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+    />
+    <path
+      d="M14 18h6c1.1 0 2 .9 2 2v6l-4-3-4 3v-6c0-1.1.9-2 2-2zm20.5 0h9a1.5 1.5 0 0 1 1.1 2.5L39.6 26l4.9 6.3A1.5 1.5 0 0 1 43.1 34h-8.6a1.5 1.5 0 0 1-1.5-1.5v-13a1.5 1.5 0 0 1 1.5-1.5z"
+      fill="url(#accent)"
+    />
+  </g>
+</svg>

--- a/lib/webui/templates/dashboard.html
+++ b/lib/webui/templates/dashboard.html
@@ -4,6 +4,7 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>{{ page_title }}</title>
+    <link rel="icon" href="{{ static_url('img/tricorder-logo.svg') }}" type="image/svg+xml" />
     <link rel="stylesheet" href="{{ static_url('css/dashboard.css') }}" />
     <script>
       window.TRICORDER_API_BASE = {{ api_base | default('', true) | tojson }};


### PR DESCRIPTION
## Summary
- remove the redundant header logo so the hamburger toggle remains the sole brand mark
- restyle the hamburger icon bars as translucent outlined strokes that float above the logo backdrop
- tune the toggle color tokens so the outlined bars stay legible in both light and dark themes

## Testing
- export DEV=1 && pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d96986d82483279e4d673ffb9acf64