### PR TITLE
TR-24 Fix dropbox ingest status and dashboard labeling

### DIFF
--- a/lib/web_streamer.py
+++ b/lib/web_streamer.py
@@ -2470,6 +2470,9 @@ def build_app() -> web.Application:
                     base_name = item.get("base_name")
                     if isinstance(base_name, str) and base_name:
                         entry["base_name"] = base_name
+                    source = item.get("source")
+                    if isinstance(source, str) and source:
+                        entry["source"] = source
                     job_id = item.get("id")
                     if isinstance(job_id, (int, float)) and math.isfinite(job_id):
                         entry["id"] = int(job_id)
@@ -2489,6 +2492,9 @@ def build_app() -> web.Application:
                 base_name = active_raw.get("base_name")
                 if isinstance(base_name, str) and base_name:
                     active_entry["base_name"] = base_name
+                source = active_raw.get("source")
+                if isinstance(source, str) and source:
+                    active_entry["source"] = source
                 job_id = active_raw.get("id")
                 if isinstance(job_id, (int, float)) and math.isfinite(job_id):
                     active_entry["id"] = int(job_id)

--- a/lib/webui/static/css/dashboard.css
+++ b/lib/webui/static/css/dashboard.css
@@ -549,6 +549,17 @@ body[data-theme="light"] .app-menu-toggle {
   white-space: normal;
 }
 
+#recording-meta[data-state="active"] {
+  border-color: var(--danger-border);
+  background: var(--danger-bg);
+  color: var(--danger);
+  box-shadow: 0 10px 24px -18px var(--danger-ring);
+}
+
+#recording-meta[data-state="active"] .indicator-text {
+  color: inherit;
+}
+
 .recording-indicator {
   color: var(--text-muted);
   gap: 0.5rem;

--- a/lib/webui/static/js/dashboard.js
+++ b/lib/webui/static/js/dashboard.js
@@ -939,8 +939,10 @@ const encodingStatusState = {
   baseTime: 0,
   text: "",
   activeLabel: "",
+  activeSource: "",
   pendingCount: 0,
   nextLabel: "",
+  nextSource: "",
 };
 
 const encodingStatusTicker = {
@@ -1477,7 +1479,8 @@ function renderRecordingMeta() {
   const sizeBytes = Number.isFinite(recordingMetaState.sizeBytes)
     ? Math.max(0, recordingMetaState.sizeBytes)
     : 0;
-  const text = `${formatShortDuration(elapsedSeconds)} • ${formatBytes(sizeBytes)}`;
+  const text = `Current Recording: ${formatShortDuration(elapsedSeconds)} • ${formatBytes(sizeBytes)}`;
+  dom.recordingMeta.dataset.state = "active";
   if (text === recordingMetaState.text) {
     return;
   }
@@ -1498,6 +1501,7 @@ function hideRecordingMeta() {
   recordingMetaState.sizeBytes = 0;
   recordingMetaState.text = "";
   dom.recordingMeta.dataset.visible = "false";
+  dom.recordingMeta.dataset.state = "idle";
   dom.recordingMeta.setAttribute("aria-hidden", "true");
   dom.recordingMetaText.textContent = "";
 }
@@ -1608,7 +1612,9 @@ function renderEncodingStatus() {
   }
   const parts = [];
   if (encodingStatusState.hasActive) {
-    parts.push("Encoding active");
+    const sourceLabel = formatEncodingSource(encodingStatusState.activeSource);
+    const statusLabel = sourceLabel ? `Encoding active (${sourceLabel})` : "Encoding active";
+    parts.push(statusLabel);
     if (encodingStatusState.activeLabel) {
       parts.push(encodingStatusState.activeLabel);
     }
@@ -1629,8 +1635,12 @@ function renderEncodingStatus() {
           : `${encodingStatusState.pendingCount} jobs queued`,
       );
     }
+    const nextSourceLabel = formatEncodingSource(encodingStatusState.nextSource);
     if (encodingStatusState.nextLabel) {
-      parts.push(`Next: ${encodingStatusState.nextLabel}`);
+      const suffix = nextSourceLabel ? ` (${nextSourceLabel})` : "";
+      parts.push(`Next: ${encodingStatusState.nextLabel}${suffix}`);
+    } else if (nextSourceLabel) {
+      parts.push(nextSourceLabel);
     }
   }
   const text = parts.join(" • ");
@@ -1653,8 +1663,10 @@ function hideEncodingStatus() {
   encodingStatusState.durationBase = 0;
   encodingStatusState.baseTime = nowMilliseconds();
   encodingStatusState.activeLabel = "";
+  encodingStatusState.activeSource = "";
   encodingStatusState.pendingCount = 0;
   encodingStatusState.nextLabel = "";
+  encodingStatusState.nextSource = "";
   encodingStatusState.text = "";
   dom.encodingStatus.dataset.visible = "false";
   dom.encodingStatus.setAttribute("aria-hidden", "true");
@@ -1683,11 +1695,17 @@ function updateEncodingStatus(rawStatus) {
     encodingStatusState.pendingCount > 0 && typeof pending[0].base_name === "string"
       ? pending[0].base_name
       : "";
+  encodingStatusState.nextSource =
+    encodingStatusState.pendingCount > 0 && typeof pending[0].source === "string"
+      ? normalizeEncodingSource(pending[0].source)
+      : "";
 
   if (active) {
     encodingStatusState.hasActive = true;
     encodingStatusState.activeLabel =
       typeof active.base_name === "string" ? active.base_name : "";
+    encodingStatusState.activeSource =
+      typeof active.source === "string" ? normalizeEncodingSource(active.source) : "";
     const startedAt = toFiniteOrNull(active.started_at);
     let baseDuration = toFiniteOrNull(active.duration_seconds);
     if (!Number.isFinite(baseDuration)) {
@@ -1698,6 +1716,7 @@ function updateEncodingStatus(rawStatus) {
   } else {
     encodingStatusState.hasActive = false;
     encodingStatusState.activeLabel = "";
+    encodingStatusState.activeSource = "";
     encodingStatusState.durationBase = 0;
     encodingStatusState.baseTime = nowMilliseconds();
   }
@@ -1823,6 +1842,30 @@ function formatShortDuration(seconds) {
       .padStart(2, "0")}`;
   }
   return `${minutes}:${secs.toString().padStart(2, "0")}`;
+}
+
+function normalizeEncodingSource(value) {
+  if (typeof value !== "string") {
+    return "";
+  }
+  return value.trim().toLowerCase();
+}
+
+function formatEncodingSource(value) {
+  const normalized = normalizeEncodingSource(value);
+  if (!normalized) {
+    return "";
+  }
+  if (normalized === "live") {
+    return "Live capture";
+  }
+  if (normalized === "dropbox" || normalized === "ingest") {
+    return "Dropbox ingest";
+  }
+  if (normalized === "unknown") {
+    return "Unknown source";
+  }
+  return value.trim();
 }
 
 function formatTimecode(seconds) {

--- a/tests/test_30_dropbox.py
+++ b/tests/test_30_dropbox.py
@@ -195,7 +195,7 @@ def test_process_file_uses_filename_timestamp(tmp_path, monkeypatch):
 
     captured: dict[str, str] = {}
 
-    def fake_enqueue(tmp_wav_path: str, base_name: str) -> None:
+    def fake_enqueue(tmp_wav_path: str, base_name: str, **_kwargs) -> None:
         captured["base_name"] = base_name
         return None
 


### PR DESCRIPTION
## Summary
- keep dropbox ingestion from toggling live capture status while still reporting encoding progress and waiting for encoder completion
- tag encoding jobs with their source and surface that metadata through the dashboard API
- update dashboard status pills to highlight the current recording and distinguish dropbox jobs in the encoding indicator

## Testing
- export DEV=1 && pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68d97364ddec8327adf6d15ed58b0d63