### PR TITLE
TR-5 Codex Task Step 2: Add idle hum analyzer and filter recommendations

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,7 +279,7 @@ Environment variables override YAML values. Common overrides include:
 
 Key configuration sections (see `config.yaml` for defaults and documentation):
 
-- `audio` – device, sample rate, frame size, gain, VAD aggressiveness.
+- `audio` – device, sample rate, frame size, gain, VAD aggressiveness, optional `filter_chain` notch filters.
 - `paths` – tmpfs, recordings, dropbox, ingest work directory, encoder script path.
 - `segmenter` – pre/post pads, RMS threshold, debounce windows, optional denoise toggles, custom event tags.
 - `adaptive_rms` – background noise follower for automatically raising/lowering thresholds.
@@ -288,11 +288,26 @@ Key configuration sections (see `config.yaml` for defaults and documentation):
 - `notifications` – optional webhook/email alerts when events finish recording.
 - `streaming` – live stream transport configuration (HLS/WebRTC).
 
+### Idle hum mitigation
+
+`audio.filter_chain` accepts a list of notch filters executed before the segmenter sees PCM data. Each entry uses the form:
+
+```yaml
+audio:
+  filter_chain:
+    - type: "notch"
+      frequency: 60.0
+      q: 25.0
+      gain_db: -18.0
+```
+
+`room_tuner.py --analyze-noise --auto-filter print` captures a short idle sample, identifies dominant hum frequencies via FFT, and prints a ready-to-paste configuration snippet. Pass `--auto-filter update` to persist the recommendation (combine with `--dry-run` to review without writing).
+
 ---
 
 ## Tuning and utilities
 
-- `room_tuner.py` streams audio from the configured device, reports RMS + VAD stats, and suggests `segmenter.rms_threshold` based on ambient noise (see docstring for usage examples). `reset_usb()` integration allows recovery from flaky USB sound cards during testing.
+- `room_tuner.py` streams audio from the configured device, reports RMS + VAD stats, and suggests `segmenter.rms_threshold` based on ambient noise (see docstring for usage examples). `reset_usb()` integration allows recovery from flaky USB sound cards during testing. Use `--analyze-noise` to capture idle hum fingerprints and `--auto-filter` to print or persist `audio.filter_chain` notch filters.
 - `clear_logs.sh` rotates `journalctl` and wipes recordings/tmpfs directories; useful before running end-to-end tests.
 
 ### Dashboard service controls

--- a/config.yaml
+++ b/config.yaml
@@ -18,6 +18,13 @@ audio:
   # 0.5 halves amplitude; 2.0 doubles (~+6 dB); 4.0 (~+12 dB). Too high can clip and inflate RMS.
   gain: 2.5
 
+  # Optional notch filters applied during capture. Each entry should specify:
+  #   - type: "notch"
+  #   - frequency: center frequency in Hz (float)
+  #   - q: quality factor (float)
+  #   - gain_db: attenuation in decibels (negative to cut)
+  filter_chain: []
+
   # WebRTC VAD aggressiveness. # WebRTC VAD aggressiveness (0..3).
   # 0 = least aggressive (most permissive, more false positives, fewer misses).
   # 3 = most aggressive (strictest, fewer false positives, more misses).

--- a/lib/config.py
+++ b/lib/config.py
@@ -37,6 +37,7 @@ _DEFAULTS: Dict[str, Any] = {
         "frame_ms": 20,
         "gain": 2.5,
         "vad_aggressiveness": 3,
+        "filter_chain": [],
     },
     "paths": {
         "tmp_dir": "/apps/tricorder/tmp",

--- a/lib/noise_analyzer.py
+++ b/lib/noise_analyzer.py
@@ -1,0 +1,122 @@
+"""Utilities for idle-noise analysis and filter suggestions."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable, List, Sequence
+
+import numpy as np
+
+
+@dataclass(frozen=True)
+class HumPeak:
+    """Represents a dominant hum component discovered during FFT analysis."""
+
+    frequency_hz: float
+    magnitude_dbfs: float
+    bandwidth_hz: float
+    q: float
+
+
+def _pcm_to_float32(pcm: bytes) -> np.ndarray:
+    if not pcm:
+        return np.array([], dtype=np.float32)
+    samples = np.frombuffer(pcm, dtype=np.int16).astype(np.float32)
+    return samples / 32768.0
+
+
+def analyze_idle_noise(
+    pcm: bytes,
+    sample_rate_hz: int,
+    *,
+    top_n: int = 3,
+    min_freq_hz: float = 30.0,
+    max_freq_hz: float | None = None,
+) -> List[HumPeak]:
+    """Return the strongest narrow-band components in the supplied PCM buffer."""
+
+    if sample_rate_hz <= 0:
+        raise ValueError("sample_rate_hz must be positive")
+    if max_freq_hz is None:
+        max_freq_hz = sample_rate_hz / 2.0
+    window = _pcm_to_float32(pcm)
+    if window.size == 0:
+        return []
+
+    window = window - np.mean(window)
+    hann = np.hanning(window.size)
+    spectrum = np.fft.rfft(window * hann)
+    magnitudes = np.abs(spectrum)
+    # Convert to dBFS, guard against zeros.
+    magnitudes_db = 20.0 * np.log10(np.maximum(magnitudes, 1e-12))
+
+    freqs = np.fft.rfftfreq(window.size, 1.0 / sample_rate_hz)
+    min_idx = int(np.searchsorted(freqs, max(min_freq_hz, 0.0), side="left"))
+    max_idx = int(np.searchsorted(freqs, max_freq_hz, side="right"))
+    min_idx = max(min_idx, 1)
+    max_idx = min(max_idx, len(freqs))
+    if min_idx >= max_idx:
+        return []
+
+    peaks: list[HumPeak] = []
+    for idx in range(min_idx, max_idx - 1):
+        if idx <= 0 or idx >= len(magnitudes_db) - 1:
+            continue
+        left = magnitudes_db[idx - 1]
+        mid = magnitudes_db[idx]
+        right = magnitudes_db[idx + 1]
+        if mid <= left or mid < right:
+            continue
+        freq = freqs[idx]
+        mag = mid
+        half_power = mid - 3.0
+
+        left_idx = idx
+        while left_idx > min_idx and magnitudes_db[left_idx] > half_power:
+            left_idx -= 1
+        right_idx = idx
+        while right_idx < max_idx - 1 and magnitudes_db[right_idx] > half_power:
+            right_idx += 1
+
+        bandwidth = max(freqs[right_idx] - freqs[left_idx], 1e-6)
+        q = freq / bandwidth if bandwidth > 0 else float("inf")
+        peaks.append(HumPeak(freq, mag, bandwidth, q))
+
+    peaks.sort(key=lambda peak: peak.magnitude_dbfs, reverse=True)
+    return peaks[:top_n]
+
+
+def recommend_notch_filters(
+    peaks: Sequence[HumPeak],
+    *,
+    max_filters: int = 3,
+    min_q: float = 2.0,
+    max_q: float = 50.0,
+    attenuation_db: float = -18.0,
+) -> list[dict[str, float | str]]:
+    """Return notch filter suggestions compatible with audio.filter_chain."""
+
+    filters: list[dict[str, float | str]] = []
+    for peak in peaks[:max_filters]:
+        if peak.frequency_hz <= 0:
+            continue
+        bounded_q = max(min_q, min(max_q, peak.q))
+        filters.append(
+            {
+                "type": "notch",
+                "frequency": round(peak.frequency_hz, 2),
+                "q": round(bounded_q, 2),
+                "gain_db": attenuation_db,
+            }
+        )
+    return filters
+
+
+def summarize_peaks(peaks: Iterable[HumPeak]) -> str:
+    parts: list[str] = []
+    for peak in peaks:
+        parts.append(
+            f"{peak.frequency_hz:.1f} Hz (Q≈{peak.q:.1f}, bandwidth {peak.bandwidth_hz:.1f} Hz, {peak.magnitude_dbfs:.1f} dBFS)"
+        )
+    if not parts:
+        return "no dominant hum components found"
+    return ", ".join(parts)

--- a/room_tuner.py
+++ b/room_tuner.py
@@ -20,17 +20,29 @@ Usage:
 Press Ctrl+C to stop.
 """
 import argparse
+import json
 import os
 import signal
+import statistics
 import subprocess
 import sys
 import time
-import statistics
 from collections import deque
+
 import audioop
 import webrtcvad
-from lib.config import get_cfg
+
+from lib.config import (
+    ConfigPersistenceError,
+    get_cfg,
+    update_audio_settings,
+)
 from lib.fault_handler import reset_usb   # 🔧 added
+from lib.noise_analyzer import (
+    analyze_idle_noise,
+    recommend_notch_filters,
+    summarize_peaks,
+)
 
 cfg = get_cfg()
 SAMPLE_RATE = int(cfg["audio"]["sample_rate"])
@@ -65,6 +77,39 @@ def spawn_arecord(audio_dev: str):
     )
 
 
+def _drain_fd(fd: int | None) -> None:
+    if fd is None:
+        return
+    while True:
+        try:
+            chunk = os.read(fd, 4096)
+            if not chunk:
+                break
+        except BlockingIOError:
+            break
+        except Exception:
+            break
+
+
+def capture_idle_audio(proc, seconds: float, stderr_fd: int | None) -> bytes:
+    if seconds <= 0:
+        return b""
+    target_bytes = int(seconds * SAMPLE_RATE * SAMPLE_WIDTH)
+    captured = bytearray()
+    deadline = time.monotonic() + max(seconds * 1.5, 1.0)
+    while len(captured) < target_bytes:
+        remaining = target_bytes - len(captured)
+        chunk = proc.stdout.read(min(4096, remaining))
+        if chunk:
+            captured.extend(chunk)
+        else:
+            time.sleep(0.05)
+        _drain_fd(stderr_fd)
+        if time.monotonic() >= deadline:
+            break
+    return bytes(captured)
+
+
 def percentile_p95(values):
     if not values:
         return 0.0
@@ -93,9 +138,17 @@ def main() -> int:
     parser.add_argument("--noise-window", type=int, default=60, help="Seconds of unvoiced frames to keep for noise-floor estimation")
     parser.add_argument("--duration", type=int, default=0, help="Optional run duration seconds (0 = indefinite)")
     parser.add_argument("--csv", default="", help="Optional CSV file to write per-interval stats")
+    parser.add_argument("--analyze-noise", action="store_true", help="Capture idle audio and summarize hum components before monitoring")
+    parser.add_argument("--analyze-duration", type=float, default=10.0, help="Seconds of idle audio to capture when analyzing noise")
+    parser.add_argument("--analyze-top", type=int, default=3, help="Number of dominant hum peaks to report")
+    parser.add_argument("--auto-filter", choices=["print", "update"], nargs="?", const="print", help="Recommend or persist audio.filter_chain notch filters (implies --analyze-noise)")
+    parser.add_argument("--dry-run", action="store_true", help="With --auto-filter update, show changes without writing config")
     args = parser.parse_args()
 
     print_banner(args)
+
+    if args.auto_filter and not args.analyze_noise:
+        args.analyze_noise = True
 
     # Prepare VAD
     vad = webrtcvad.Vad(args.aggr)
@@ -140,6 +193,53 @@ def main() -> int:
             pass
 
     buf = bytearray()
+
+    if args.analyze_noise:
+        capture_seconds = max(args.analyze_duration, FRAME_MS / 1000.0)
+        print(f"[room_tuner] Capturing {capture_seconds:.1f}s of idle audio for hum analysis...", flush=True)
+        analysis_pcm = capture_idle_audio(proc, capture_seconds, stderr_fd)
+        if analysis_pcm:
+            buf.extend(analysis_pcm)
+            peaks = analyze_idle_noise(
+                analysis_pcm,
+                SAMPLE_RATE,
+                top_n=max(1, args.analyze_top),
+                min_freq_hz=30.0,
+                max_freq_hz=SAMPLE_RATE / 2.0,
+            )
+            summary = summarize_peaks(peaks)
+            actual_sec = len(analysis_pcm) / (SAMPLE_RATE * SAMPLE_WIDTH)
+            print(
+                f"[room_tuner] Idle analysis ({actual_sec:.2f}s captured): {summary}",
+                flush=True,
+            )
+            if args.auto_filter:
+                filters = recommend_notch_filters(
+                    peaks,
+                    max_filters=max(1, args.analyze_top),
+                )
+                if not filters:
+                    print("[room_tuner] No notch filters recommended.", flush=True)
+                else:
+                    payload = {"filter_chain": filters}
+                    print("[room_tuner] Recommended audio.filter_chain:", flush=True)
+                    print(json.dumps(payload, indent=2), flush=True)
+                    if args.auto_filter == "update":
+                        if args.dry_run:
+                            print("[room_tuner] Dry-run: configuration not modified.", flush=True)
+                        else:
+                            try:
+                                update_audio_settings(payload)
+                                print("[room_tuner] Updated configuration with recommended filters.", flush=True)
+                            except ConfigPersistenceError as exc:
+                                print(
+                                    f"[room_tuner] Failed to update configuration: {exc}",
+                                    file=sys.stderr,
+                                    flush=True,
+                                )
+        else:
+            print("[room_tuner] Unable to capture idle audio for analysis.", flush=True)
+
     last_report = time.monotonic()
     start_time = time.monotonic()
 
@@ -175,16 +275,7 @@ def main() -> int:
         buf.extend(chunk)
 
         # Drain arecord stderr (ignore content)
-        if stderr_fd is not None:
-            try:
-                while True:
-                    err = os.read(stderr_fd, 4096)
-                    if not err:
-                        break
-            except BlockingIOError:
-                pass
-            except Exception:
-                pass
+        _drain_fd(stderr_fd)
 
         # Process frames
         while len(buf) >= FRAME_BYTES:

--- a/tests/test_noise_analyzer.py
+++ b/tests/test_noise_analyzer.py
@@ -1,0 +1,62 @@
+import math
+
+import numpy as np
+import pytest
+
+from lib.noise_analyzer import analyze_idle_noise, recommend_notch_filters, summarize_peaks
+
+SAMPLE_RATE = 48000
+
+
+def synth_pcm(frequencies, duration=2.0, sample_rate=SAMPLE_RATE, amplitudes=None):
+    t = np.arange(int(duration * sample_rate)) / sample_rate
+    signal = np.zeros_like(t)
+    if amplitudes is None:
+        amplitudes = [1.0] * len(frequencies)
+    for freq, amp in zip(frequencies, amplitudes):
+        signal += amp * np.sin(2 * math.pi * freq * t)
+    peak = np.max(np.abs(signal))
+    if peak == 0:
+        return np.zeros_like(t, dtype=np.int16).tobytes()
+    normalized = signal / (peak * 1.05)
+    pcm = (normalized * 32767).astype(np.int16)
+    return pcm.tobytes()
+
+
+def test_analyze_idle_noise_identifies_single_hum():
+    pcm = synth_pcm([60.0])
+    peaks = analyze_idle_noise(pcm, SAMPLE_RATE, top_n=1, min_freq_hz=30.0, max_freq_hz=200.0)
+    assert len(peaks) == 1
+    assert abs(peaks[0].frequency_hz - 60.0) < 1.0
+    assert peaks[0].q > 5.0
+
+
+def test_analyze_idle_noise_returns_multiple_peaks_sorted():
+    pcm = synth_pcm([120.0, 60.0], amplitudes=[0.6, 1.0])
+    peaks = analyze_idle_noise(pcm, SAMPLE_RATE, top_n=2, min_freq_hz=30.0, max_freq_hz=300.0)
+    assert len(peaks) == 2
+    # Stronger 60 Hz tone should appear first
+    assert abs(peaks[0].frequency_hz - 60.0) < 1.0
+    assert abs(peaks[1].frequency_hz - 120.0) < 1.0
+
+
+def test_recommend_notch_filters_uses_peak_metadata():
+    pcm = synth_pcm([180.0])
+    peaks = analyze_idle_noise(pcm, SAMPLE_RATE, top_n=1, min_freq_hz=50.0, max_freq_hz=400.0)
+    filters = recommend_notch_filters(peaks, max_filters=1)
+    assert len(filters) == 1
+    entry = filters[0]
+    assert entry["type"] == "notch"
+    assert entry["frequency"] == pytest.approx(180.0, rel=0.01)
+    assert 2.0 <= entry["q"] <= 50.0
+    assert entry["gain_db"] == -18.0
+
+
+def test_summarize_peaks_formats_description():
+    pcm = synth_pcm([90.0])
+    peaks = analyze_idle_noise(pcm, SAMPLE_RATE, top_n=1, min_freq_hz=50.0, max_freq_hz=200.0)
+    summary = summarize_peaks(peaks)
+    assert "90.0 Hz" in summary
+    assert "Q≈" in summary
+
+


### PR DESCRIPTION
## Summary
- add an FFT-based idle noise analyzer module and expose `--analyze-noise` / `--auto-filter` / `--dry-run` helpers in `room_tuner.py`
- persist recommended notch filters via the new `audio.filter_chain` default and document usage in `config.yaml` and `README`
- cover the analyzer with synthetic PCM unit tests

## Testing
- export DEV=1 && pytest -q


------
https://chatgpt.com/codex/tasks/task_e_68da42cf95a0832797774f50798e667e