### PR TITLE
TR-5 Step 4: retire HLS extra ffmpeg args

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,9 @@ The default HLS pipeline still relies on `lib.hls_mux.HLSTee` to buffer recent a
 
 HLS artifacts live under `<tmp_dir>/hls` (defaults to `/apps/tricorder/tmp/hls`). `ffmpeg` runs with `-hls_flags delete_segments` so disk usage stays bounded.
 
+The HLS encoder no longer honours legacy `streaming.extra_ffmpeg_args` values. Live previews inherit the same `audio.filter_chain` configuration used for captured events.
+Remove any redundant `-af` flags from existing configs and manage filters through the dashboard instead.
+
 ### WebRTC (optional)
 
 Setting `streaming.mode` to `webrtc` enables a lower-latency path tailored for modern browsers. The live daemon feeds raw PCM frames into `lib.webrtc_buffer.WebRTCBufferWriter`, which persists a circular buffer (`webrtc_buffer.raw`) alongside state metadata inside `<tmp_dir>/webrtc`. The dashboard exchanges SDP offers with `lib.webrtc_stream.WebRTCManager` via:

--- a/config.yaml
+++ b/config.yaml
@@ -18,6 +18,10 @@ audio:
   # 0.5 halves amplitude; 2.0 doubles (~+6 dB); 4.0 (~+12 dB). Too high can clip and inflate RMS.
   gain: 2.5
 
+  # Unified live/recording filter chain. Configure filter presets through the
+  # dashboard; legacy streaming.extra_ffmpeg_args values are ignored.
+  filter_chain: []
+
   # WebRTC VAD aggressiveness. # WebRTC VAD aggressiveness (0..3).
   # 0 = least aggressive (most permissive, more false positives, fewer misses).
   # 3 = most aggressive (strictest, fewer false positives, more misses).
@@ -230,6 +234,8 @@ streaming:
   #   "hls"   – HTTP Live Streaming (higher latency, broad compatibility).
   #   "webrtc" – WebRTC audio stream (lower latency, modern browsers only).
   mode: "hls"
+  # Legacy streaming.extra_ffmpeg_args settings are ignored. Use audio.filter_chain
+  # to configure filters shared by the recorder and live preview.
   # When streaming.mode is "webrtc", audio frames are stored in a shared ring
   # buffer before they are forwarded to WebRTC peers. Increase this to tolerate
   # short stalls at the cost of RAM usage (seconds of audio history).

--- a/tests/test_35_hls.py
+++ b/tests/test_35_hls.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import logging
 import queue
 import shutil
 import time
@@ -46,6 +47,33 @@ def test_hlstee_stop_cleans_outputs(tmp_path):
 
     assert not playlist.exists()
     assert not segment.exists()
+
+
+def test_hlstee_ignores_legacy_extra_args(tmp_path, caplog):
+    caplog.set_level(logging.WARNING, logger="hls_mux")
+    tee = HLSTee(
+        out_dir=str(tmp_path),
+        sample_rate=48000,
+        legacy_extra_ffmpeg_args=["--legacy-flag"],
+    )
+    cmd = tee._build_ffmpeg_command()
+
+    assert "--legacy-flag" not in cmd
+    assert any("deprecated" in record.message for record in caplog.records)
+
+
+def test_hlstee_warns_on_filter_args_when_chain_enabled(tmp_path, caplog):
+    caplog.set_level(logging.WARNING, logger="hls_mux")
+    caplog.clear()
+
+    HLSTee(
+        out_dir=str(tmp_path),
+        sample_rate=48000,
+        legacy_extra_ffmpeg_args=["-af", "highpass=f=80"],
+        filter_chain_enabled=True,
+    )
+
+    assert any("audio.filter_chain" in record.message for record in caplog.records)
 
 
 class DummyHLSTee:


### PR DESCRIPTION
## Summary
- drop the deprecated HLSTee extra_ffmpeg_args path, emitting warnings when legacy filter arguments remain alongside audio.filter_chain
- surface the unified filter guidance in the live daemon, sample config, and README so operators migrate away from bespoke ffmpeg flags
- add coverage that inspects the constructed ffmpeg command to ensure no stray filter options slip through

## Testing
- DEV=1 pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68da432058d88327aab8ac69bfc44e6d