### PR TITLE
Display adaptive RMS threshold in dashboard indicator

### DIFF
--- a/lib/segmenter.py
+++ b/lib/segmenter.py
@@ -69,6 +69,22 @@ class RecorderIngestHint:
     event_counter: int | None = None
 
 
+@dataclass(frozen=True)
+class AdaptiveRmsObservation:
+    """Snapshot emitted whenever the adaptive RMS controller evaluates."""
+
+    timestamp: float
+    updated: bool
+    threshold_linear: int
+    previous_threshold_linear: int
+    candidate_threshold_linear: int
+    p95_norm: float
+    release_norm: float
+    buffer_size: int
+    rms_value: int
+    voiced: bool
+
+
 def pcm16_rms(buf: bytes) -> int:
     """Compute RMS amplitude for signed 16-bit little-endian PCM data."""
     if not buf:
@@ -521,11 +537,12 @@ class AdaptiveRmsController:
         self._last_p95: float | None = None
         self._last_candidate: float | None = None
         self._last_release: float | None = None
+        self._last_observation: AdaptiveRmsObservation | None = None
         initial_norm = max(0.0, min(initial_linear_threshold / self._NORM, 1.0))
         if self.enabled:
             initial_norm = max(self.min_thresh_norm, initial_norm)
         self._current_norm = initial_norm
-        self.debug = True  # todo: set to DEBUG_VERBOSE when done testing
+        self.debug = bool(debug)
 
     @property
     def threshold_linear(self) -> int:
@@ -549,8 +566,13 @@ class AdaptiveRmsController:
     def last_release(self) -> float | None:
         return self._last_release
 
+    def pop_observation(self) -> AdaptiveRmsObservation | None:
+        observation, self._last_observation = self._last_observation, None
+        return observation
+
     def observe(self, rms_value: int, voiced: bool) -> bool:
         if not self.enabled:
+            self._last_observation = None
             return False
 
         norm = max(0.0, min(rms_value / self._NORM, 1.0))
@@ -559,9 +581,11 @@ class AdaptiveRmsController:
 
         now = time.monotonic()
         if (now - self._last_update) < self.update_interval:
+            self._last_observation = None
             return False
 
         if not self._buffer:
+            self._last_observation = None
             return False
 
         self._last_update = now
@@ -580,6 +604,7 @@ class AdaptiveRmsController:
         self._last_candidate = candidate
         self._last_release = release_val
 
+        previous_norm = self._current_norm
         if self._current_norm <= 0.0:
             should_update = True
         else:
@@ -587,24 +612,23 @@ class AdaptiveRmsController:
             should_update = (delta / self._current_norm) >= self.hysteresis_tolerance
 
         if should_update:
-            previous = self._current_norm
             self._current_norm = candidate
-            if self.debug:
-                details = (
-                    f"(p95={p95:.4f}, margin={self.margin:.2f}, "
-                    f"release_pctl={self.release_percentile:.2f}, "
-                    f"release={release_val:.4f})"
-                )
-                print(
-                    "[segmenter] adaptive RMS threshold updated: "
-                    f"prev={int(round(previous * self._NORM))} "
-                    f"new={self.threshold_linear} "
-                    f"{details}",
-                    flush=True,
-                )
-            return True
-
-        return False
+        final_threshold = int(round(self._current_norm * self._NORM))
+        previous_threshold = int(round(previous_norm * self._NORM))
+        candidate_threshold = int(round(candidate * self._NORM))
+        self._last_observation = AdaptiveRmsObservation(
+            timestamp=time.time(),
+            updated=bool(should_update),
+            threshold_linear=final_threshold,
+            previous_threshold_linear=previous_threshold,
+            candidate_threshold_linear=candidate_threshold,
+            p95_norm=p95,
+            release_norm=release_val,
+            buffer_size=len(self._buffer),
+            rms_value=int(rms_value),
+            voiced=bool(voiced),
+        )
+        return should_update
 
 
 class TimelineRecorder:
@@ -737,6 +761,7 @@ class TimelineRecorder:
                 payload["adaptive_rms_threshold"] = int(self._adaptive.threshold_linear)
             elif "adaptive_rms_threshold" not in payload:
                 payload["adaptive_rms_threshold"] = int(self._adaptive.threshold_linear)
+            payload["adaptive_rms_enabled"] = bool(self._adaptive.enabled)
 
             if self._status_mode == "live":
                 if effective_capturing and event:
@@ -760,6 +785,7 @@ class TimelineRecorder:
                 "last_stop_reason",
                 "adaptive_rms_threshold",
                 "current_rms",
+                "adaptive_rms_enabled",
                 "service_running",
                 "event_duration_seconds",
                 "event_size_bytes",
@@ -891,6 +917,25 @@ class TimelineRecorder:
         reason = cached.get("last_stop_reason")
         self._update_capture_status(capturing, event=event, last_event=last_event, reason=reason)
 
+    def _log_adaptive_rms_observation(self, observation: AdaptiveRmsObservation) -> None:
+        payload = {
+            "component": "segmenter",
+            "event": "adaptive_rms_observation",
+            "enabled": bool(self._adaptive.enabled),
+            "update_interval_sec": self._adaptive.update_interval,
+            "updated": observation.updated,
+            "threshold": observation.threshold_linear,
+            "previous_threshold": observation.previous_threshold_linear,
+            "candidate_threshold": observation.candidate_threshold_linear,
+            "p95_norm": round(observation.p95_norm, 6),
+            "release_norm": round(observation.release_norm, 6),
+            "window_size": observation.buffer_size,
+            "rms_value": observation.rms_value,
+            "voiced": observation.voiced,
+            "timestamp": observation.timestamp,
+        }
+        print(json.dumps(payload), flush=True)
+
     @staticmethod
     def _apply_gain(buf: bytes) -> bytes:
         return pcm16_apply_gain(buf, GAIN)
@@ -968,8 +1013,10 @@ class TimelineRecorder:
         self._dbg_rms.append(rms_val)
         self._dbg_voiced.append(bool(voiced))
 
-        threshold_updated = self._adaptive.observe(rms_val, bool(voiced))
-        if threshold_updated:
+        self._adaptive.observe(rms_val, bool(voiced))
+        observation = self._adaptive.pop_observation()
+        if observation:
+            self._log_adaptive_rms_observation(observation)
             self._emit_threshold_update()
 
         self._maybe_update_live_metrics(rms_val)

--- a/lib/web_streamer.py
+++ b/lib/web_streamer.py
@@ -2579,6 +2579,22 @@ def build_app() -> web.Application:
             elif normalized in {"0", "false", "no", "off", "stopped"}:
                 status["service_running"] = False
 
+        adaptive_threshold = raw.get("adaptive_rms_threshold")
+        if isinstance(adaptive_threshold, (int, float)) and math.isfinite(adaptive_threshold):
+            status["adaptive_rms_threshold"] = int(adaptive_threshold)
+
+        adaptive_enabled_raw = raw.get("adaptive_rms_enabled")
+        if isinstance(adaptive_enabled_raw, bool):
+            status["adaptive_rms_enabled"] = adaptive_enabled_raw
+        elif isinstance(adaptive_enabled_raw, (int, float)):
+            status["adaptive_rms_enabled"] = bool(adaptive_enabled_raw)
+        elif isinstance(adaptive_enabled_raw, str):
+            normalized = adaptive_enabled_raw.strip().lower()
+            if normalized in {"1", "true", "yes", "on", "enabled"}:
+                status["adaptive_rms_enabled"] = True
+            elif normalized in {"0", "false", "no", "off", "disabled"}:
+                status["adaptive_rms_enabled"] = False
+
         duration_seconds = raw.get("event_duration_seconds")
         if isinstance(duration_seconds, (int, float)) and math.isfinite(duration_seconds):
             status["event_duration_seconds"] = max(0.0, float(duration_seconds))

--- a/lib/webui/static/js/dashboard.js
+++ b/lib/webui/static/js/dashboard.js
@@ -938,6 +938,7 @@ const captureIndicatorState = {
 const rmsIndicatorState = {
   visible: false,
   value: null,
+  threshold: null,
 };
 
 const recordingMetaState = {
@@ -1762,6 +1763,7 @@ function hideRmsIndicator() {
   dom.rmsIndicatorValue.textContent = "";
   rmsIndicatorState.visible = false;
   rmsIndicatorState.value = null;
+  rmsIndicatorState.threshold = null;
 }
 
 function updateRmsIndicator(rawStatus) {
@@ -1771,6 +1773,8 @@ function updateRmsIndicator(rawStatus) {
   const status = rawStatus && typeof rawStatus === "object" ? rawStatus : null;
   const running = status ? parseBoolean(status.service_running) : false;
   const rmsValue = status ? toFiniteOrNull(status.current_rms) : null;
+  const adaptiveThreshold = status ? toFiniteOrNull(status.adaptive_rms_threshold) : null;
+  const adaptiveEnabled = status ? parseBoolean(status.adaptive_rms_enabled) : false;
   if (!running || rmsValue === null) {
     hideRmsIndicator();
     return;
@@ -1780,14 +1784,27 @@ function updateRmsIndicator(rawStatus) {
     hideRmsIndicator();
     return;
   }
-  if (rmsIndicatorState.visible && rmsIndicatorState.value === whole) {
+  const thresholdWhole =
+    adaptiveEnabled && Number.isFinite(adaptiveThreshold)
+      ? Math.trunc(adaptiveThreshold)
+      : null;
+  if (
+    rmsIndicatorState.visible &&
+    rmsIndicatorState.value === whole &&
+    rmsIndicatorState.threshold === thresholdWhole
+  ) {
     return;
   }
-  dom.rmsIndicatorValue.textContent = String(whole);
+  if (thresholdWhole !== null && Number.isFinite(thresholdWhole)) {
+    dom.rmsIndicatorValue.textContent = `${whole}/${thresholdWhole}`;
+  } else {
+    dom.rmsIndicatorValue.textContent = String(whole);
+  }
   dom.rmsIndicator.dataset.visible = "true";
   dom.rmsIndicator.setAttribute("aria-hidden", "false");
   rmsIndicatorState.visible = true;
   rmsIndicatorState.value = whole;
+  rmsIndicatorState.threshold = Number.isFinite(thresholdWhole) ? thresholdWhole : null;
 }
 
 function handleFetchSuccess() {


### PR DESCRIPTION
## Summary
- include the adaptive RMS enable flag alongside the threshold in the live status payload
- expose adaptive RMS threshold/enabled fields through the web streamer status API
- render the dashboard RMS indicator as `value/threshold` when adaptive RMS is active while keeping the static display otherwise
- emit structured adaptive RMS observation logs on each update interval and refresh the capture status so the dashboard follows each change

## Testing
- DEV=1 pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68daa64292e88327a33aadd8cf127a29