### PR TITLE
Update dashboard header logo and hamburger styling

### DIFF
--- a/lib/webui/static/css/dashboard.css
+++ b/lib/webui/static/css/dashboard.css
@@ -259,7 +259,7 @@ body {
 .app-header {
   display: flex;
   justify-content: space-between;
-  align-items: center;
+  align-items: flex-start;
   gap: 1.5rem;
 }
 
@@ -289,30 +289,7 @@ body {
 
 .app-menu-toggle {
   position: relative;
-  overflow: hidden;
-  isolation: isolate;
-  color: rgba(243, 244, 246, 0.82);
-}
-
-.app-menu-toggle::before {
-  content: "";
-  position: absolute;
-  inset: 0.15rem;
-  border-radius: calc(0.75rem - 0.15rem);
-  background-image: url("../img/tricorder-logo.svg");
-  background-size: 175%;
-  background-position: center;
-  background-repeat: no-repeat;
-  opacity: 0.35;
-  filter: saturate(1.1);
-  transition: opacity 0.2s ease, transform 0.2s ease;
-  pointer-events: none;
-  z-index: 0;
-}
-
-.app-menu-toggle:hover::before {
-  opacity: 0.5;
-  transform: scale(1.03);
+  color: rgba(243, 244, 246, 0.85);
 }
 
 .icon-button:hover {
@@ -335,22 +312,22 @@ body {
   z-index: 1;
   display: flex;
   flex-direction: column;
-  gap: 0.35rem;
+  gap: 0.25rem;
 }
 
 .menu-icon span {
   display: block;
-  width: 1.1rem;
-  height: 0.28rem;
+  width: 1.35rem;
+  height: 0.18rem;
   border-radius: 999px;
-  background: transparent;
-  border: 1px solid currentColor;
-  opacity: 0.75;
+  background: currentColor;
+  opacity: 0.82;
+  transition: opacity 0.2s ease, transform 0.2s ease;
 }
 
 .app-menu-toggle:hover .menu-icon span,
 .app-menu-toggle:focus-visible .menu-icon span {
-  opacity: 0.9;
+  opacity: 1;
 }
 
 .app-menu-toggle:active .menu-icon span {
@@ -358,7 +335,7 @@ body {
 }
 
 body[data-theme="light"] .app-menu-toggle {
-  color: rgba(15, 23, 42, 0.72);
+  color: rgba(15, 23, 42, 0.82);
 }
 
 .app-menu {
@@ -453,13 +430,22 @@ body[data-theme="light"] .app-menu-toggle {
 .titles {
   display: flex;
   align-items: center;
-  gap: 0.75rem;
+  gap: 0.625rem;
 }
 
-.app-header h1 {
+.app-title {
   margin: 0;
+  display: inline-flex;
+  align-items: center;
   font-size: clamp(1.6rem, 2.4vw, 2.1rem);
   letter-spacing: -0.015em;
+  line-height: 1;
+}
+
+.app-title-logo {
+  display: block;
+  height: clamp(2.2rem, 2.8vw, 2.6rem);
+  width: auto;
 }
 
 .app-header p {

--- a/lib/webui/static/css/main.css
+++ b/lib/webui/static/css/main.css
@@ -25,17 +25,28 @@ header h1 {
 header nav a {
   display: inline-flex;
   align-items: center;
-  gap: 0.25rem;
-  padding: 0.4rem 0.75rem;
-  border-radius: 999px;
-  border: 1px solid #ccc;
-  text-decoration: none;
-  font-size: 0.9rem;
-  color: inherit;
+  justify-content: center;
+  padding: 0;
+  border-radius: 0.75rem;
+  border: none;
+  background: transparent;
+  transition: transform 0.2s ease;
 }
 
-header nav a:hover {
-  background: rgba(0, 0, 0, 0.05);
+header nav a img {
+  display: block;
+  height: 2.4rem;
+  width: auto;
+}
+
+header nav a:hover,
+header nav a:focus-visible {
+  transform: translateY(-1px);
+}
+
+header nav a:focus-visible {
+  outline: 2px solid rgba(14, 165, 233, 0.45);
+  outline-offset: 3px;
 }
 
 .stats {

--- a/lib/webui/static/img/dashboard-logo.svg
+++ b/lib/webui/static/img/dashboard-logo.svg
@@ -1,0 +1,36 @@
+<svg width="192" height="56" viewBox="0 0 192 56" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="logo-gradient" x1="11" y1="4" x2="44" y2="52" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#f97316" />
+      <stop offset="1" stop-color="#fbbf24" />
+    </linearGradient>
+  </defs>
+  <rect x="4" y="4" width="48" height="48" rx="14" fill="url(#logo-gradient)" />
+  <text
+    x="28"
+    y="38"
+    text-anchor="middle"
+    font-family="'Inter', 'Segoe UI', 'Roboto', 'Helvetica Neue', sans-serif"
+    font-size="30"
+    font-weight="700"
+    fill="#ffffff"
+  >3</text>
+  <text
+    x="68"
+    y="36"
+    font-family="'Inter', 'Segoe UI', 'Roboto', 'Helvetica Neue', sans-serif"
+    font-size="24"
+    font-weight="600"
+    letter-spacing="0.01em"
+    fill="#f8fafc"
+  >Corder</text>
+  <text
+    x="68"
+    y="48"
+    font-family="'Inter', 'Segoe UI', 'Roboto', 'Helvetica Neue', sans-serif"
+    font-size="11"
+    font-weight="500"
+    letter-spacing="0.28em"
+    fill="rgba(248, 250, 252, 0.85)"
+  >DASHBOARD</text>
+</svg>

--- a/lib/webui/templates/dashboard.html
+++ b/lib/webui/templates/dashboard.html
@@ -181,7 +181,15 @@
               </div>
             </div>
           </div>
-          <h1>Dashboard</h1>
+          <h1 class="app-title">
+            <span class="sr-only">Tricorder dashboard home</span>
+            <img
+              src="{{ static_url('img/dashboard-logo.svg') }}"
+              class="app-title-logo"
+              alt=""
+              role="presentation"
+            />
+          </h1>
         </div>
         <div class="header-actions">
           <div class="header-controls">

--- a/lib/webui/templates/hls_index.html
+++ b/lib/webui/templates/hls_index.html
@@ -10,7 +10,11 @@
   <body>
     <header>
       <h1>{{ heading }}</h1>
-      <nav><a href="/">Dashboard</a></nav>
+      <nav>
+        <a href="/" class="nav-logo" aria-label="Return to dashboard">
+          <img src="{{ static_url('img/dashboard-logo.svg') }}" alt="" role="presentation" />
+        </a>
+      </nav>
     </header>
     <div class="stats" id="status-bar">
       Active listeners: <span id="clients" class="badge">0</span>


### PR DESCRIPTION
## Summary
- replace the dashboard heading text with a reusable branded logo asset and reuse it on the HLS index nav
- simplify the hamburger toggle styling to remove the background image and align the header elements to the top edge
- reduce the spacing between the hamburger icon and dashboard title to tighten their alignment

## Testing
- `pytest tests/test_37_web_dashboard.py tests/test_25_web_streamer.py -q`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68dab90db3f0832783edc7edb5b88697