### PR TITLE
Shift dashboard logo left by 10px

### DIFF
--- a/lib/webui/static/css/dashboard.css
+++ b/lib/webui/static/css/dashboard.css
@@ -435,6 +435,7 @@ body[data-theme="light"] .app-menu-toggle {
 
 .app-title {
   margin: 0;
+  margin-left: -10px;
   display: inline-flex;
   align-items: center;
   font-size: clamp(1.6rem, 2.4vw, 2.1rem);


### PR DESCRIPTION
## Summary
- move the dashboard title logo 10px to the left to tighten its spacing with the menu button

## Testing
- export DEV=1 && pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68dacb443260832782965f8b2f1d9a69