### PR TITLE
Add Winters documentation lint workflow test

### DIFF
--- a/tests/test_45_workflow_tooling.py
+++ b/tests/test_45_workflow_tooling.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import os
+import shlex
 import shutil
 import subprocess
 from pathlib import Path
@@ -26,3 +28,45 @@ def test_act_cli_available() -> None:
         pytest.skip("act is not installed; install it to exercise workflow jobs locally")
 
     subprocess.run([act, "--version"], cwd=REPO_ROOT, check=True)
+
+
+def _build_winters_command(executable: str, template: str, *, readme: Path, output: Path) -> list[str]:
+    formatted = template.format(
+        readme=readme,
+        output=output,
+    )
+    args = shlex.split(formatted)
+    return [executable, *args]
+
+
+@pytest.mark.workflow
+def test_readme_renders_with_winters(tmp_path: Path) -> None:
+    winters = shutil.which("winters")
+    if winters is None:
+        pytest.skip("winters is not installed; install it to lint mermaid diagrams")
+
+    readme = REPO_ROOT / "README.md"
+    if not readme.exists():
+        pytest.skip("README.md missing; cannot lint documentation")
+
+    output_path = tmp_path / "README.html"
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    lint_template = os.environ.get("TRICORDER_WINTERS_LINT", "lint {readme}")
+    render_template = os.environ.get(
+        "TRICORDER_WINTERS_RENDER", "render {readme} --output {output}"
+    )
+
+    subprocess.run(
+        _build_winters_command(winters, lint_template, readme=readme, output=output_path),
+        cwd=REPO_ROOT,
+        check=True,
+    )
+
+    subprocess.run(
+        _build_winters_command(winters, render_template, readme=readme, output=output_path),
+        cwd=REPO_ROOT,
+        check=True,
+    )
+
+    assert output_path.exists(), "winters render did not produce an output artifact"


### PR DESCRIPTION
## Summary
- update the README architecture diagram to trace USB capture through the filter pipeline and streaming backends
- clarify the README narrative with a step-by-step breakdown of how frames travel from capture through filtering, fan-out, and encoding
- add a Winters-based documentation workflow test that lints and renders the README mermaid diagram

## Testing
- export DEV=1 && pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68db5e88e5e083278cde84c571c2f0f5