### PR TITLE
Skip auto-update tests when git is unavailable

### DIFF
--- a/tests/test_auto_update.py
+++ b/tests/test_auto_update.py
@@ -1,10 +1,19 @@
 import os
+import shutil
 import subprocess
 from pathlib import Path
+
+import pytest
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 SCRIPT_PATH = REPO_ROOT / "bin" / "tricorder_auto_update.sh"
+
+
+pytestmark = pytest.mark.skipif(
+    shutil.which("git") is None,
+    reason="git command unavailable; auto-update integration tests require git",
+)
 
 
 GIT_ENV = {


### PR DESCRIPTION
## Summary
- skip the auto-update integration tests when the git executable is not present in PATH
- ensure pytest imports git detection helpers needed for the skip condition

## Testing
- export DEV=1 && pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68db76ae2ed0832781f8f3913bf3149a