### PR TITLE
TR-34 reorder preview metadata placement

### DIFF
--- a/lib/webui/static/css/dashboard.css
+++ b/lib/webui/static/css/dashboard.css
@@ -1015,6 +1015,10 @@ button.small {
   margin-top: 0.75rem;
 }
 
+.player-card .player-meta {
+  margin-top: 1rem;
+}
+
 .player-row {
   background: transparent;
 }

--- a/lib/webui/templates/dashboard.html
+++ b/lib/webui/templates/dashboard.html
@@ -331,7 +331,6 @@
           <div class="card-header">
             <div class="card-heading">
               <h2>Preview</h2>
-              <div class="player-meta" id="player-meta">Select a recording to preview.</div>
             </div>
             <button id="preview-close" class="ghost-button small" type="button">Hide</button>
           </div>
@@ -369,6 +368,7 @@
             </div>
             <div class="waveform-empty" id="waveform-empty">Select a recording to render its waveform.</div>
           </div>
+          <div class="player-meta" id="player-meta">Select a recording to preview.</div>
           <div
             id="clipper-container"
             class="clipper-container"


### PR DESCRIPTION
## Summary
- move the preview metadata block beneath the waveform so the recording details appear between the waveform and clip editor
- add spacing rules so the relocated metadata aligns with the card layout

## Testing
- pytest tests/test_37_web_dashboard.py -q
- pytest tests/test_25_web_streamer.py -q
- pytest -q *(fails: tests/test_10_segmenter.py::test_adaptive_rms_logs_and_status_update)*

------
https://chatgpt.com/codex/tasks/task_e_68db80e1c4b8832798e060e615025a16