### PR TITLE
Adjust preview section ordering when previewing recordings

### DIFF
--- a/lib/webui/static/js/dashboard.js
+++ b/lib/webui/static/js/dashboard.js
@@ -3116,7 +3116,6 @@ function setNowPlaying(record, options = {}) {
   }
 
   state.current = record;
-  ensurePreviewSectionOrder();
   if (!record) {
     initializeClipper(null);
     updatePlayerMeta(null);
@@ -3134,6 +3133,7 @@ function setNowPlaying(record, options = {}) {
     return;
   }
 
+  ensurePreviewSectionOrder();
   updatePlayerMeta(record);
   if (!sameRecord) {
     initializeClipper(record);

--- a/lib/webui/static/js/dashboard.js
+++ b/lib/webui/static/js/dashboard.js
@@ -2901,6 +2901,15 @@ function updatePlayerMeta(record) {
   dom.playerMeta.textContent = `Now playing: ${details.join(" • ")}`;
 }
 
+function ensurePreviewSectionOrder() {
+  if (!dom.playerCard || !dom.playerMeta || !dom.clipperContainer) {
+    return;
+  }
+  if (dom.playerMeta.nextElementSibling !== dom.clipperContainer) {
+    dom.playerCard.insertBefore(dom.playerMeta, dom.clipperContainer);
+  }
+}
+
 function layoutIsMobile() {
   if (mobileLayoutQuery) {
     return mobileLayoutQuery.matches;
@@ -3107,6 +3116,7 @@ function setNowPlaying(record, options = {}) {
   }
 
   state.current = record;
+  ensurePreviewSectionOrder();
   if (!record) {
     initializeClipper(null);
     updatePlayerMeta(null);


### PR DESCRIPTION
## Summary
- ensure the preview metadata node is kept ahead of the clip editor inside the player card
- re-order the preview sections whenever the now-playing record is updated to maintain the 1 → 3 → 2 layout

## Testing
- export DEV=1 && pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68db8e393df08327af1c491391a237c3