### PR TITLE
Align preview actions with metadata row

### DIFF
--- a/lib/webui/static/css/dashboard.css
+++ b/lib/webui/static/css/dashboard.css
@@ -1043,7 +1043,30 @@ button.small {
 .player-meta {
   color: var(--text-muted);
   font-size: 0.9rem;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.75rem;
 }
+
+.player-meta-text {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.player-meta-actions {
+  margin-left: auto;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 0.4rem;
+}
+
+.player-meta-actions[hidden] {
+  display: none;
+}
+
 
 .live-stream-panel {
   overflow: hidden;

--- a/lib/webui/static/js/dashboard.js
+++ b/lib/webui/static/js/dashboard.js
@@ -155,6 +155,11 @@ const dom = {
   playerCard: document.getElementById("player-card"),
   player: document.getElementById("preview-player"),
   playerMeta: document.getElementById("player-meta"),
+  playerMetaText: document.getElementById("player-meta-text"),
+  playerMetaActions: document.getElementById("player-meta-actions"),
+  playerDownload: document.getElementById("player-download"),
+  playerRename: document.getElementById("player-rename"),
+  playerDelete: document.getElementById("player-delete"),
   configViewer: document.getElementById("config-viewer"),
   configOpen: document.getElementById("config-open"),
   configModal: document.getElementById("config-modal"),
@@ -2424,6 +2429,7 @@ function setRenameDialogPending(pending) {
     dom.renameCancel.disabled = pending === true;
   }
   updateSelectionUI();
+  updatePlayerActions(state.current);
 }
 
 function closeRenameDialog() {
@@ -2881,14 +2887,68 @@ function applyNowPlayingHighlight() {
   });
 }
 
-function updatePlayerMeta(record) {
-  if (!record) {
-    dom.playerMeta.textContent = "Select a recording to preview.";
+function updatePlayerActions(record) {
+  if (!dom.playerMetaActions) {
     return;
   }
+  const hasRecord = Boolean(
+    record && typeof record.path === "string" && record.path.trim() !== ""
+  );
+  if (!hasRecord) {
+    dom.playerMetaActions.hidden = true;
+    if (dom.playerDownload) {
+      dom.playerDownload.removeAttribute("href");
+      dom.playerDownload.removeAttribute("download");
+    }
+    if (dom.playerRename) {
+      dom.playerRename.disabled = true;
+    }
+    if (dom.playerDelete) {
+      dom.playerDelete.disabled = true;
+    }
+    return;
+  }
+
+  dom.playerMetaActions.hidden = false;
+  if (dom.playerDownload) {
+    dom.playerDownload.href = recordingUrl(record.path, { download: true });
+    const baseName =
+      typeof record.name === "string" && record.name ? record.name : record.path;
+    const extension =
+      typeof record.extension === "string" && record.extension
+        ? `.${record.extension}`
+        : "";
+    dom.playerDownload.setAttribute("download", `${baseName}${extension}`);
+  }
+  if (dom.playerRename) {
+    dom.playerRename.disabled = Boolean(renameDialogState.pending);
+  }
+  if (dom.playerDelete) {
+    dom.playerDelete.disabled = false;
+  }
+}
+
+function updatePlayerMeta(record) {
+  const metaTarget = dom.playerMetaText || dom.playerMeta;
+  if (!metaTarget) {
+    updatePlayerActions(record || null);
+    return;
+  }
+
+  const hasRecord = Boolean(
+    record && typeof record.path === "string" && record.path.trim() !== ""
+  );
+  if (!hasRecord) {
+    metaTarget.textContent = "Select a recording to preview.";
+    updatePlayerActions(null);
+    return;
+  }
+
   const details = [];
   const extText = record.extension ? `.${record.extension}` : "";
-  details.push(`${record.name}${extText}`);
+  const nameText =
+    typeof record.name === "string" && record.name ? record.name : record.path;
+  details.push(`${nameText}${extText}`);
   if (record.day) {
     details.push(record.day);
   }
@@ -2898,7 +2958,8 @@ function updatePlayerMeta(record) {
   if (Number.isFinite(record.duration_seconds) && record.duration_seconds > 0) {
     details.push(formatDuration(record.duration_seconds));
   }
-  dom.playerMeta.textContent = `Now playing: ${details.join(" • ")}`;
+  metaTarget.textContent = `Now playing: ${details.join(" • ")}`;
+  updatePlayerActions(record);
 }
 
 function ensurePreviewSectionOrder() {
@@ -10123,6 +10184,24 @@ function attachEventListeners() {
   if (dom.previewClose) {
     dom.previewClose.addEventListener("click", () => {
       setNowPlaying(null);
+    });
+  }
+
+  if (dom.playerRename) {
+    dom.playerRename.addEventListener("click", () => {
+      if (renameDialogState.pending || !state.current) {
+        return;
+      }
+      openRenameDialog(state.current);
+    });
+  }
+
+  if (dom.playerDelete) {
+    dom.playerDelete.addEventListener("click", async () => {
+      if (!state.current) {
+        return;
+      }
+      await requestRecordDeletion(state.current);
     });
   }
 

--- a/lib/webui/templates/dashboard.html
+++ b/lib/webui/templates/dashboard.html
@@ -368,7 +368,14 @@
             </div>
             <div class="waveform-empty" id="waveform-empty">Select a recording to render its waveform.</div>
           </div>
-          <div class="player-meta" id="player-meta">Select a recording to preview.</div>
+          <div class="player-meta" id="player-meta">
+            <div class="player-meta-text" id="player-meta-text">Select a recording to preview.</div>
+            <div class="player-meta-actions action-buttons" id="player-meta-actions" hidden>
+              <a id="player-download" class="ghost-button small" download>Download</a>
+              <button id="player-rename" class="ghost-button small" type="button">Rename</button>
+              <button id="player-delete" class="danger-button small" type="button">Delete</button>
+            </div>
+          </div>
           <div
             id="clipper-container"
             class="clipper-container"


### PR DESCRIPTION
## Summary
- embed dedicated containers in the preview card for metadata text and action buttons
- style the preview metadata row so the text and actions stay aligned and responsive
- wire up download, rename, and delete controls to the active recording, including dialog state updates

## Testing
- `export DEV=1 && pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68dbc9f230948327983558f81f9129d4