### PR TITLE
TR-30 Add resource usage metrics to dashboard

### DIFF
--- a/lib/web_streamer.py
+++ b/lib/web_streamer.py
@@ -3557,8 +3557,8 @@ def build_app() -> web.Application:
         if not values:
             return None
 
-        idle = values[3] if len(values) > 3 else 0
-        iowait = values[4] if len(values) > 4 else 0
+        idle = values[3] if len(values) >= 4 else 0
+        iowait = values[4] if len(values) >= 5 else 0
         total = sum(values)
         return total, idle + iowait
 

--- a/lib/webui/static/css/dashboard.css
+++ b/lib/webui/static/css/dashboard.css
@@ -673,9 +673,10 @@ body[data-theme="light"] .app-menu-toggle {
   display: inline-flex;
 }
 
+
 .status-bar {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
   gap: 1rem;
 }
 
@@ -702,22 +703,38 @@ body[data-theme="light"] .app-menu-toggle {
   font-weight: 600;
 }
 
-.status-bar .stat-selection-combined {
-  display: none;
+.status-bar .stat-counts {
   gap: 0.75rem;
 }
 
-.stat-combined-row {
+.stat-count-row {
   display: flex;
   align-items: baseline;
   justify-content: space-between;
   gap: 0.75rem;
 }
 
-.stat-combined-row + .stat-combined-row {
-  border-top: 1px solid var(--table-border);
-  padding-top: 0.75rem;
-  margin-top: 0.75rem;
+.status-bar .stat-counts .value,
+.status-bar .stat-resource .value {
+  font-size: 1.3rem;
+}
+
+.stat-resource {
+  gap: 0.6rem;
+}
+
+.stat-resource-values {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.stat-resource-detail {
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: var(--text-muted);
 }
 
 .storage-progress {
@@ -2569,17 +2586,6 @@ body[data-scroll-locked="true"] {
     display: flex;
     flex-direction: column;
     gap: 0.75rem;
-  }
-
-  .status-bar .stat-recordings,
-  .status-bar .stat-selected {
-    display: none;
-  }
-
-  .status-bar .stat-selection-combined {
-    display: flex;
-    flex-direction: column;
-    order: 0;
   }
 
   .status-bar .stat-storage {

--- a/lib/webui/static/js/dashboard.js
+++ b/lib/webui/static/js/dashboard.js
@@ -47,6 +47,17 @@ function nowMilliseconds() {
   return Date.now();
 }
 
+function toFiniteOrNull(value) {
+  if (typeof value === "number") {
+    return Number.isFinite(value) ? value : null;
+  }
+  if (typeof value === "string" && value.trim() !== "") {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+  return null;
+}
+
 const AUTO_REFRESH_INTERVAL_MS = 1000;
 const OFFLINE_REFRESH_INTERVAL_MS = 5000;
 const REFRESH_INDICATOR_DELAY_MS = 600;
@@ -2208,17 +2219,6 @@ function clamp(value, min, max) {
 function numericValue(value, fallback = 0) {
   const num = Number(value);
   return Number.isFinite(num) ? num : fallback;
-}
-
-function toFiniteOrNull(value) {
-  if (typeof value === "number") {
-    return Number.isFinite(value) ? value : null;
-  }
-  if (typeof value === "string" && value.trim() !== "") {
-    const parsed = Number(value);
-    return Number.isFinite(parsed) ? parsed : null;
-  }
-  return null;
 }
 
 function getRecordStartSeconds(record) {

--- a/lib/webui/static/js/dashboard.js
+++ b/lib/webui/static/js/dashboard.js
@@ -106,6 +106,10 @@ const state = {
 const healthState = {
   sdCard: null,
   lastUpdated: null,
+  resources: {
+    cpu: null,
+    memory: null,
+  },
 };
 
 const dom = {
@@ -113,9 +117,7 @@ const dom = {
   systemBannerMessage: document.getElementById("system-banner-message"),
   systemBannerDetail: document.getElementById("system-banner-detail"),
   recordingCount: document.getElementById("recording-count"),
-  recordingCountMobile: document.getElementById("recording-count-mobile"),
   selectedCount: document.getElementById("selected-count"),
-  selectedCountMobile: document.getElementById("selected-count-mobile"),
   storageUsageText: document.getElementById("storage-usage-text"),
   storageHint: document.getElementById("storage-hint"),
   storageProgress: document.getElementById("storage-progress-bar"),
@@ -138,6 +140,10 @@ const dom = {
   rmsIndicatorValue: document.getElementById("rms-indicator-value"),
   encodingStatus: document.getElementById("encoding-status"),
   encodingStatusText: document.getElementById("encoding-status-text"),
+  cpuUsage: document.getElementById("cpu-usage-value"),
+  cpuLoadAverage: document.getElementById("cpu-load-average"),
+  memoryUsage: document.getElementById("memory-usage-value"),
+  memoryDetail: document.getElementById("memory-usage-detail"),
   applyFilters: document.getElementById("apply-filters"),
   clearFilters: document.getElementById("clear-filters"),
   filterSearch: document.getElementById("filter-search"),
@@ -599,11 +605,64 @@ function renderSdCardBanner() {
   dom.systemBannerDetail.textContent = parts.join(" — ");
 }
 
+function renderResourceStats() {
+  const resources = healthState.resources || {};
+  const cpu = resources.cpu ?? null;
+  if (dom.cpuUsage) {
+    if (cpu && Number.isFinite(cpu.percent)) {
+      const clamped = clamp(cpu.percent, 0, 100);
+      dom.cpuUsage.textContent = `${clamped.toFixed(clamped >= 100 ? 0 : 1)}%`;
+    } else {
+      dom.cpuUsage.textContent = "--";
+    }
+  }
+  if (dom.cpuLoadAverage) {
+    if (cpu && Number.isFinite(cpu.load1m)) {
+      const loadParts = [`load ${cpu.load1m.toFixed(2)}`];
+      if (Number.isFinite(cpu.cores) && cpu.cores > 0) {
+        const cores = Math.round(cpu.cores);
+        loadParts.push(`${cores} ${cores === 1 ? "core" : "cores"}`);
+      }
+      dom.cpuLoadAverage.textContent = loadParts.join(" • ");
+    } else {
+      dom.cpuLoadAverage.textContent = "--";
+    }
+  }
+  const memory = resources.memory ?? null;
+  if (dom.memoryUsage) {
+    if (memory && Number.isFinite(memory.percent)) {
+      const percent = clamp(memory.percent, 0, 100);
+      dom.memoryUsage.textContent = `${percent.toFixed(percent >= 100 ? 0 : 1)}%`;
+    } else {
+      dom.memoryUsage.textContent = "--";
+    }
+  }
+  if (dom.memoryDetail) {
+    if (memory) {
+      const parts = [];
+      if (Number.isFinite(memory.usedBytes) && Number.isFinite(memory.totalBytes)) {
+        parts.push(`${formatBytes(memory.usedBytes)} / ${formatBytes(memory.totalBytes)}`);
+      } else if (Number.isFinite(memory.totalBytes)) {
+        parts.push(`${formatBytes(memory.totalBytes)} total`);
+      }
+      if (Number.isFinite(memory.availableBytes)) {
+        parts.push(`${formatBytes(memory.availableBytes)} free`);
+      }
+      dom.memoryDetail.textContent = parts.length ? parts.join(" • ") : "--";
+    } else {
+      dom.memoryDetail.textContent = "--";
+    }
+  }
+}
+
 function applyHealthPayload(payload) {
   if (!payload || typeof payload !== "object") {
     healthState.sdCard = null;
     healthState.lastUpdated = null;
+    healthState.resources.cpu = null;
+    healthState.resources.memory = null;
     renderSdCardBanner();
+    renderResourceStats();
     return;
   }
 
@@ -636,7 +695,37 @@ function applyHealthPayload(payload) {
     healthState.sdCard = null;
   }
 
+  const resources = payload.resources;
+  if (resources && typeof resources === "object") {
+    const cpu = resources.cpu;
+    if (cpu && typeof cpu === "object") {
+      healthState.resources.cpu = {
+        percent: toFiniteOrNull(cpu.percent),
+        load1m: toFiniteOrNull(cpu.load_1m ?? cpu.load1m),
+        cores: Number.isFinite(cpu.cores) ? cpu.cores : null,
+      };
+    } else {
+      healthState.resources.cpu = null;
+    }
+
+    const memory = resources.memory;
+    if (memory && typeof memory === "object") {
+      healthState.resources.memory = {
+        percent: toFiniteOrNull(memory.percent),
+        totalBytes: toFiniteOrNull(memory.total_bytes),
+        usedBytes: toFiniteOrNull(memory.used_bytes),
+        availableBytes: toFiniteOrNull(memory.available_bytes),
+      };
+    } else {
+      healthState.resources.memory = null;
+    }
+  } else {
+    healthState.resources.cpu = null;
+    healthState.resources.memory = null;
+  }
+
   renderSdCardBanner();
+  renderResourceStats();
 }
 
 async function fetchSystemHealth() {
@@ -2822,9 +2911,8 @@ function updateSelectionUI(records = null) {
     }
   }
   const selectedText = state.selections.size.toString();
-  dom.selectedCount.textContent = selectedText;
-  if (dom.selectedCountMobile) {
-    dom.selectedCountMobile.textContent = selectedText;
+  if (dom.selectedCount) {
+    dom.selectedCount.textContent = selectedText;
   }
   dom.deleteSelected.disabled = state.selections.size === 0;
   if (dom.downloadSelected) {
@@ -3385,9 +3473,8 @@ function renderRecords() {
 
 function updateStats() {
   const recordingsText = state.total.toString();
-  dom.recordingCount.textContent = recordingsText;
-  if (dom.recordingCountMobile) {
-    dom.recordingCountMobile.textContent = recordingsText;
+  if (dom.recordingCount) {
+    dom.recordingCount.textContent = recordingsText;
   }
   const recordingsUsed = Number.isFinite(state.storage.recordings)
     ? state.storage.recordings

--- a/lib/webui/templates/dashboard.html
+++ b/lib/webui/templates/dashboard.html
@@ -272,22 +272,28 @@
         </div>
       </header>
       <section class="status-bar">
-        <div class="stat stat-recordings">
-          <span class="label">Recordings</span>
-          <span class="value" id="recording-count">0</span>
-        </div>
-        <div class="stat stat-selected">
-          <span class="label">Selected</span>
-          <span class="value" id="selected-count">0</span>
-        </div>
-        <div class="stat stat-selection-combined">
-          <div class="stat-combined-row">
+        <div class="stat stat-counts">
+          <div class="stat-count-row">
             <span class="label">Recordings</span>
-            <span class="value" id="recording-count-mobile">0</span>
+            <span class="value" id="recording-count">0</span>
           </div>
-          <div class="stat-combined-row">
+          <div class="stat-count-row">
             <span class="label">Selected</span>
-            <span class="value" id="selected-count-mobile">0</span>
+            <span class="value" id="selected-count">0</span>
+          </div>
+        </div>
+        <div class="stat stat-resource stat-cpu">
+          <span class="label">CPU</span>
+          <div class="stat-resource-values">
+            <span class="value" id="cpu-usage-value">--</span>
+            <span class="stat-resource-detail" id="cpu-load-average">--</span>
+          </div>
+        </div>
+        <div class="stat stat-resource stat-memory">
+          <span class="label">Memory</span>
+          <div class="stat-resource-values">
+            <span class="value" id="memory-usage-value">--</span>
+            <span class="stat-resource-detail" id="memory-usage-detail">--</span>
           </div>
         </div>
         <div class="stat storage-stat stat-storage">


### PR DESCRIPTION
## Summary
- extend `/api/system-health` to report CPU and memory usage details
- surface CPU/RAM status cards on the dashboard and compact the recordings/selected widget
- cover the new telemetry with a dashboard test

## Risk
- Low. The change only reads procfs data on refresh and updates existing UI layouts.

## Testing
- `export DEV=1 && pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68dbcc7ba7d083278de719e0f74a36e5