### PR TITLE
TR-37 fix Firefox WebRTC ICE completion wait

### DIFF
--- a/lib/webui/static/js/dashboard.js
+++ b/lib/webui/static/js/dashboard.js
@@ -9472,21 +9472,54 @@ function attachLiveStreamSource() {
     });
 }
 
-function waitForIceGatheringComplete(pc) {
+function waitForIceGatheringComplete(pc, { timeoutMs = 2500 } = {}) {
   if (!pc) {
     return Promise.resolve();
   }
   if (pc.iceGatheringState === "complete") {
     return Promise.resolve();
   }
+
   return new Promise((resolve) => {
-    const checkState = () => {
-      if (pc.iceGatheringState === "complete") {
-        pc.removeEventListener("icegatheringstatechange", checkState);
-        resolve();
+    let settled = false;
+    let timeoutId = null;
+
+    const cleanup = () => {
+      pc.removeEventListener("icegatheringstatechange", onStateChange);
+      pc.removeEventListener("icecandidate", onCandidate);
+      if (timeoutId !== null) {
+        window.clearTimeout(timeoutId);
+        timeoutId = null;
       }
     };
-    pc.addEventListener("icegatheringstatechange", checkState);
+
+    const settle = () => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      cleanup();
+      resolve();
+    };
+
+    const onStateChange = () => {
+      if (pc.iceGatheringState === "complete") {
+        settle();
+      }
+    };
+
+    const onCandidate = (event) => {
+      if (!event.candidate) {
+        settle();
+      }
+    };
+
+    pc.addEventListener("icegatheringstatechange", onStateChange);
+    pc.addEventListener("icecandidate", onCandidate);
+
+    if (Number.isFinite(timeoutMs) && timeoutMs > 0) {
+      timeoutId = window.setTimeout(settle, timeoutMs);
+    }
   });
 }
 


### PR DESCRIPTION
## Summary
- resolve Firefox WebRTC negotiation stalling by waiting for icecandidate completion as well as icegatheringstatechange
- add timeout-based fallback and cleanup for the ICE wait helper to avoid hanging the session

## Testing
- DEV=1 pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68dbd536226c83278752c246c80efa5b