### PR TITLE
Add template-based config comment restoration

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,15 @@ Uploads run immediately after the encoder finishes so recordings land in the arc
 - JSON APIs (`/api/recordings`, `/api/config`, `/api/recordings/delete`, `/hls/stats` or `/webrtc/stats`, etc.) consumed by the dashboard and available for automation.
 - Legacy HLS status page at `/hls` retained for compatibility with earlier deployments.
 
+### Audio filter chain tuning
+
+Open the ☰ menu → **Recorder configuration** → **Filters** to adjust the capture-time filter chain. The controls map directly to `audio.filter_chain` in `config.yaml`; the UI saves changes back to the YAML file while preserving inline comments. Suggested workflow:
+
+- **High-pass filter** – Sweep the cutoff between 80–120&nbsp;Hz to remove HVAC/handling rumble. Stop once speech starts losing warmth; this keeps the VAD from chasing sub-bass energy.
+- **Notch filter** – Target persistent hums or whistles (50/60&nbsp;Hz and harmonics). Keep Q in the 20–40 range for surgical cuts and only enable the stages you need.
+- **Spectral noise gate** – This is the dashboard’s “noise gating” control. Start with sensitivity between 1.2–1.8 and reduction between −12 to −24&nbsp;dB; lower sensitivity numbers clamp harder. Use the **Noise update** slider (0.05–0.2) to decide how quickly the gate learns new noise and **Noise decay** (0.9–0.98) to smooth releases.
+- **Calibration helpers** – Enable the quick actions when you want the dashboard to capture a fresh noise profile or launch `room_tuner.py` for gain recalibration.
+
 Waveform JSON is loaded on demand and cached client-side. Missing or stale sidecars are regenerated via `lib.waveform_cache` (see `tests/test_waveform_cache.py`). Transcript JSON files live next to each recording; the dashboard automatically includes transcript excerpts in the listings and search covers both filenames and transcript text.
 
 ---
@@ -298,6 +307,8 @@ Environment variables override YAML values. Common overrides include:
 - `INGEST_STABLE_CHECKS`, `INGEST_STABLE_INTERVAL_SEC`, `INGEST_ALLOWED_EXT` — ingest tunables.
 - `ADAPTIVE_RMS_*` — detailed control of the adaptive RMS tracker.
 - `EVENT_TAG_HUMAN`, `EVENT_TAG_OTHER`, `EVENT_TAG_BOTH` — override event labels without editing YAML.
+- `TRICORDER_CONFIG_TEMPLATE` — optional absolute path to a commented template used to rehydrate inline guidance if the active
+  YAML lost its comments.
 
 Key configuration sections (see `config.yaml` for defaults and documentation):
 
@@ -309,6 +320,8 @@ Key configuration sections (see `config.yaml` for defaults and documentation):
 - `logging` – developer-mode verbosity toggle.
 - `notifications` – optional webhook/email alerts when events finish recording.
 - `streaming` – live stream transport configuration (HLS/WebRTC).
+
+The dashboard writes updates back to `config.yaml` using `ruamel.yaml` so inline documentation stays intact; the dependency ships in `requirements.txt` for both runtime and UI edits.
 
 ### Idle hum mitigation
 

--- a/lib/config.py
+++ b/lib/config.py
@@ -17,12 +17,37 @@ import copy
 import os
 import sys
 from pathlib import Path
-from typing import Any, Dict, Mapping
+from typing import Any, Dict, Mapping, MutableMapping, Sequence
+
+try:
+    from ruamel.yaml import YAML
+    from ruamel.yaml.comments import CommentedMap, CommentedSeq
+except Exception:
+    YAML = None  # type: ignore[assignment]
+    CommentedMap = None  # type: ignore[assignment]
+    CommentedSeq = None  # type: ignore[assignment]
+
+try:
+    from .config_template import CONFIG_TEMPLATE_YAML
+except Exception:
+    CONFIG_TEMPLATE_YAML = None  # type: ignore[assignment]
 
 try:
     import yaml
 except Exception:
     yaml = None  # pyyaml should be installed; if not, only defaults will be used.
+
+if YAML:
+    _ROUND_TRIP_YAML = YAML(typ="rt")
+    _ROUND_TRIP_YAML.indent(mapping=2, sequence=4, offset=2)
+    _ROUND_TRIP_YAML.default_flow_style = False
+    _ROUND_TRIP_YAML.allow_unicode = True
+    try:
+        _ROUND_TRIP_YAML.preserve_quotes = True  # type: ignore[attr-defined]
+    except AttributeError:
+        pass
+else:  # pragma: no cover - exercised when ruamel.yaml is not available.
+    _ROUND_TRIP_YAML = None
 
 EVENT_TAG_DEFAULTS: Dict[str, str] = {
     "human": "Human",
@@ -138,6 +163,7 @@ _warned_yaml_missing = False
 _search_paths: list[Path] = []
 _active_config_path: Path | None = None
 _primary_config_path: Path | None = None
+_template_cache: MutableMapping[str, Any] | None = None
 
 
 class ConfigPersistenceError(Exception):
@@ -466,6 +492,168 @@ def search_paths() -> list[Path]:
     return list(_search_paths)
 
 
+def _empty_mapping() -> MutableMapping[str, Any]:
+    if CommentedMap is not None:
+        return CommentedMap()
+    return {}
+
+
+def _file_has_comments(path: Path) -> bool:
+    if not path.exists():
+        return False
+    try:
+        text = path.read_text(encoding="utf-8")
+    except Exception:
+        return False
+    for line in text.splitlines():
+        stripped = line.lstrip()
+        if stripped.startswith("#"):
+            return True
+        idx = line.find("#")
+        if idx > 0 and line[idx - 1].isspace():
+            return True
+    return False
+
+
+def _load_comment_template() -> MutableMapping[str, Any] | None:
+    global _template_cache
+    if _ROUND_TRIP_YAML is None:
+        return None
+    if _template_cache is None:
+        candidates: list[Path] = []
+        template_env = os.getenv("TRICORDER_CONFIG_TEMPLATE")
+        if template_env:
+            try:
+                candidates.append(Path(template_env).expanduser())
+            except Exception:
+                candidates.append(Path(template_env))
+        candidates.extend(
+            [
+                Path("/etc/tricorder/config.template.yaml"),
+                Path("/apps/tricorder/config.template.yaml"),
+            ]
+        )
+        project_root = Path(__file__).resolve().parents[1]
+        candidates.extend(
+            [
+                project_root / "config.template.yaml",
+                project_root / "docs" / "config-template.yaml",
+            ]
+        )
+
+        for candidate in candidates:
+            try:
+                if candidate.exists():
+                    with candidate.open("r", encoding="utf-8") as handle:
+                        loaded = _ROUND_TRIP_YAML.load(handle)  # type: ignore[arg-type]
+                    if isinstance(loaded, MutableMapping):
+                        _template_cache = _convert_to_round_trip(loaded)
+                        break
+            except Exception:
+                continue
+
+        if _template_cache is None and CONFIG_TEMPLATE_YAML:
+            try:
+                loaded = _ROUND_TRIP_YAML.load(CONFIG_TEMPLATE_YAML)
+                if isinstance(loaded, MutableMapping):
+                    _template_cache = _convert_to_round_trip(loaded)
+            except Exception:
+                _template_cache = None
+
+    if _template_cache is None:
+        return None
+    return _convert_to_round_trip(_template_cache)
+
+
+def _template_with_values(values: Mapping[str, Any]) -> MutableMapping[str, Any] | None:
+    template = _load_comment_template()
+    if template is None:
+        return None
+    if isinstance(values, Mapping):
+        _replace_mapping(template, values, prune=False)
+    return template
+
+
+def _convert_to_round_trip(value: Any) -> Any:
+    if CommentedMap is not None:
+        if isinstance(value, CommentedMap) or isinstance(value, CommentedSeq):
+            return value
+        if isinstance(value, Mapping) and not isinstance(value, (str, bytes)):
+            converted = CommentedMap()
+            for key, sub_value in value.items():
+                converted[key] = _convert_to_round_trip(sub_value)
+            return converted
+        if isinstance(value, Sequence) and not isinstance(value, (str, bytes)):
+            converted_seq = CommentedSeq()
+            for item in value:
+                converted_seq.append(_convert_to_round_trip(item))
+            return converted_seq
+    return copy.deepcopy(value)
+
+
+def _ensure_mapping(container: MutableMapping[str, Any], key: str) -> MutableMapping[str, Any]:
+    existing = container.get(key)
+    if isinstance(existing, MutableMapping):
+        return existing
+    if isinstance(existing, Mapping):
+        converted = _convert_to_round_trip(existing)
+        if isinstance(converted, MutableMapping):
+            container[key] = converted
+            return converted
+    new_map = _convert_to_round_trip({})
+    assert isinstance(new_map, MutableMapping)
+    container[key] = new_map
+    return new_map
+
+
+def _replace_mapping(
+    target: MutableMapping[str, Any],
+    updates: Mapping[str, Any],
+    *,
+    prune: bool,
+) -> None:
+    if prune:
+        for existing_key in list(target.keys()):
+            if existing_key not in updates:
+                try:
+                    del target[existing_key]
+                except Exception:
+                    pass
+    for key, value in updates.items():
+        if isinstance(value, Mapping) and not isinstance(value, (str, bytes)):
+            nested: MutableMapping[str, Any]
+            existing = target.get(key)
+            if isinstance(existing, MutableMapping):
+                nested = existing
+            else:
+                converted = _convert_to_round_trip(value)
+                if isinstance(converted, MutableMapping):
+                    target[key] = converted
+                    nested = converted
+                    continue
+                nested = _empty_mapping()
+                target[key] = nested
+            _replace_mapping(nested, value, prune=prune)
+        elif isinstance(value, Sequence) and not isinstance(value, (str, bytes)):
+            target[key] = _convert_to_round_trip(value)
+        else:
+            target[key] = copy.deepcopy(value)
+
+
+def _load_yaml_for_update(path: Path) -> MutableMapping[str, Any]:
+    if _ROUND_TRIP_YAML is not None:
+        if path.exists():
+            try:
+                with path.open("r", encoding="utf-8") as handle:
+                    data = _ROUND_TRIP_YAML.load(handle)  # type: ignore[arg-type]
+            except Exception as exc:
+                raise ConfigPersistenceError(f"Unable to read configuration: {exc}") from exc
+            if isinstance(data, MutableMapping):
+                return data
+        return _empty_mapping()
+    return {}
+
+
 def _load_raw_yaml(path: Path) -> Dict[str, Any]:
     if not yaml:
         raise ConfigPersistenceError("PyYAML is required to update configuration files")
@@ -481,8 +669,8 @@ def _load_raw_yaml(path: Path) -> Dict[str, Any]:
     return {}
 
 
-def _dump_yaml(path: Path, payload: Dict[str, Any]) -> None:
-    if not yaml:
+def _dump_yaml(path: Path, payload: MutableMapping[str, Any] | Dict[str, Any]) -> None:
+    if _ROUND_TRIP_YAML is None and not yaml:
         raise ConfigPersistenceError("PyYAML is required to update configuration files")
     try:
         path.parent.mkdir(parents=True, exist_ok=True)
@@ -490,13 +678,16 @@ def _dump_yaml(path: Path, payload: Dict[str, Any]) -> None:
         raise ConfigPersistenceError(f"Unable to create configuration directory: {exc}") from exc
     try:
         with path.open("w", encoding="utf-8") as handle:
-            yaml.safe_dump(
-                payload,
-                handle,
-                default_flow_style=False,
-                sort_keys=False,
-                allow_unicode=True,
-            )
+            if _ROUND_TRIP_YAML is not None:
+                _ROUND_TRIP_YAML.dump(payload, handle)  # type: ignore[arg-type]
+            else:
+                yaml.safe_dump(  # type: ignore[union-attr]
+                    payload,
+                    handle,
+                    default_flow_style=False,
+                    sort_keys=False,
+                    allow_unicode=True,
+                )
     except Exception as exc:
         raise ConfigPersistenceError(f"Unable to write configuration: {exc}") from exc
 
@@ -509,18 +700,35 @@ def _persist_settings_section(
 
     primary_path = primary_config_path()
     current = _load_raw_yaml(primary_path)
-    updated = copy.deepcopy(current)
+
+    updated: MutableMapping[str, Any] | Any
+
+    if _ROUND_TRIP_YAML is not None:
+        template_candidate: MutableMapping[str, Any] | None = None
+        if not _file_has_comments(primary_path):
+            template_candidate = _template_with_values(current)
+        if template_candidate is not None:
+            updated = template_candidate
+        else:
+            updated = _load_yaml_for_update(primary_path)
+            if isinstance(updated, dict) and not isinstance(updated, MutableMapping):
+                updated = _convert_to_round_trip(updated)
+    else:
+        updated = _convert_to_round_trip(current)
+        if not isinstance(updated, MutableMapping):
+            updated = _convert_to_round_trip({})
+
+    if not isinstance(updated, MutableMapping):
+        raise ConfigPersistenceError("Configuration root must be a mapping")
+
+    target = _ensure_mapping(updated, section)
+    if not isinstance(target, MutableMapping):
+        raise ConfigPersistenceError(f"Configuration section {section!r} is not a mapping")
 
     if merge:
-        base: Dict[str, Any] = {}
-        existing = updated.get(section)
-        if isinstance(existing, dict):
-            base = copy.deepcopy(existing)
-        for key, value in settings.items():
-            base[key] = copy.deepcopy(value)
-        updated[section] = base
+        _replace_mapping(target, settings, prune=False)
     else:
-        updated[section] = copy.deepcopy(settings)
+        _replace_mapping(target, settings, prune=True)
 
     _dump_yaml(primary_path, updated)
     return reload_cfg().get(section, {})

--- a/lib/config_template.py
+++ b/lib/config_template.py
@@ -1,3 +1,12 @@
+#!/usr/bin/env python3
+"""Comment template for regenerating config.yaml inline docs.
+
+This blob mirrors the canonical `config.yaml` shipped with Tricorder and is
+used to rehydrate inline documentation for installs that previously lost the
+comments via legacy dashboard saves. Update this file whenever `config.yaml`
+changes to keep guidance synchronized.
+"""
+CONFIG_TEMPLATE_YAML = """
 # Tricorder configuration
 # Guidelines:
 # - This file is the single source of truth for tunables.
@@ -307,3 +316,5 @@ dashboard:
   # Unit that should be restarted automatically when stopped or reloaded through
   # the dashboard to keep the management interface reachable.
   web_service: "web-streamer.service"
+
+"""

--- a/lib/webui/templates/dashboard.html
+++ b/lib/webui/templates/dashboard.html
@@ -834,7 +834,8 @@
               </div>
               <h4 class="settings-subheading">Filter chain</h4>
               <p class="settings-subheading-description">
-                Enable lightweight filters to tame rumble, hiss, or bed noise before the segmenter sees the audio.
+                Enable lightweight filters to tame rumble, hiss, or bed noise before the segmenter sees the audio. Start with the
+                high-pass filter, then layer in narrow notches for hums, and finally add noise gating once the noise floor is steady.
               </p>
               <div class="settings-field filter-field">
                 <div class="filter-toggle field-control">
@@ -853,7 +854,10 @@
                   />
                   <span id="audio-filter-highpass-cutoff-value" class="filter-value" aria-live="off">90&nbsp;Hz</span>
                 </div>
-                <p class="field-description">Remove low-frequency rumble from HVAC systems, footsteps, or desk bumps.</p>
+                <p class="field-description">
+                  Roll off sub-bass rumble from HVAC, footsteps, or desk bumps. Sweep between 80–120&nbsp;Hz; stop just before the
+                  voices you care about start to thin out.
+                </p>
               </div>
               <div class="settings-field filter-field">
                 <div class="filter-toggle field-control">
@@ -884,12 +888,15 @@
                   />
                   <span id="audio-filter-notch-quality-value" class="filter-value" aria-live="off">Q&nbsp;30</span>
                 </div>
-                <p class="field-description">Carve out persistent hums (50/60&nbsp;Hz) or whistles without impacting the rest of the spectrum.</p>
+                <p class="field-description">
+                  Carve out persistent hums (50/60&nbsp;Hz) or whistles without touching everything else. Aim the frequency at the
+                  offending tone and keep Q in the 20–40 range for precise cuts.
+                </p>
               </div>
               <div class="settings-field filter-field">
                 <div class="filter-toggle field-control">
                   <input id="audio-filter-spectral-enabled" type="checkbox" />
-                  <label for="audio-filter-spectral-enabled">Spectral gate</label>
+                  <label for="audio-filter-spectral-enabled">Spectral noise gate</label>
                 </div>
                 <div class="filter-slider">
                   <label class="filter-slider-label" for="audio-filter-spectral-sensitivity">Sensitivity</label>
@@ -939,7 +946,10 @@
                   />
                   <span id="audio-filter-spectral-decay-value" class="filter-value" aria-live="off">0.95</span>
                 </div>
-                <p class="field-description">Adaptive gate tuned for constant ambient noise. Lower sensitivity reacts faster; adjust reduction to taste.</p>
+                <p class="field-description">
+                  Adaptive noise gate for steady ambient beds. Use 1.2–1.8 sensitivity for HVAC rumble, pull reduction into the
+                  −12 to −24&nbsp;dB window, then fine-tune update/decay to trade chatter for smooth releases.
+                </p>
               </div>
               <h4 class="settings-subheading">Calibration helpers</h4>
               <p class="settings-subheading-description">

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ setuptools==68.1.2
 wheel==0.42.0
 
 pyyaml==6.0.2
+ruamel.yaml==0.18.6
 webrtcvad==2.0.10
 noisereduce==3.0.3
 numpy==1.26.4

--- a/tests/test_37_web_dashboard.py
+++ b/tests/test_37_web_dashboard.py
@@ -511,6 +511,173 @@ def test_audio_settings_preserve_filter_stage_list(tmp_path, monkeypatch):
     asyncio.run(runner())
 
 
+def test_audio_settings_preserve_inline_comments(tmp_path, monkeypatch):
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(
+        (
+            "audio:\n"
+            "  device: hw:1,0  # usb device mapping\n"
+            "  sample_rate: 48000\n"
+            "  frame_ms: 20\n"
+            "  gain: 2.0  # front-end gain guidance\n"
+            "  vad_aggressiveness: 2\n"
+            "  filter_chain:\n"
+            "    highpass:\n"
+            "      enabled: false  # high-pass toggle\n"
+            "      cutoff_hz: 90.0  # high-pass cutoff\n"
+            "    spectral_gate:\n"
+            "      enabled: false  # spectral gate toggle\n"
+            "      sensitivity: 1.5\n"
+            "      reduction_db: -18.0  # gate reduction depth\n"
+            "      noise_update: 0.10  # gate update speed\n"
+            "      noise_decay: 0.95  # gate release smoothing\n"
+        ),
+        encoding="utf-8",
+    )
+
+    monkeypatch.setenv("TRICORDER_CONFIG", str(config_path))
+    monkeypatch.setattr(config, "_cfg_cache", None, raising=False)
+    monkeypatch.setattr(config, "_primary_config_path", None, raising=False)
+    monkeypatch.setattr(config, "_active_config_path", None, raising=False)
+    monkeypatch.setattr(config, "_search_paths", [], raising=False)
+
+    async def runner():
+        systemctl_calls: list[list[str]] = []
+
+        async def fake_systemctl(args):
+            systemctl_calls.append(list(args))
+            if args and args[0] == "is-active":
+                return 0, "active\n", ""
+            return 0, "", ""
+
+        monkeypatch.setattr(web_streamer, "_run_systemctl", fake_systemctl)
+
+        app = web_streamer.build_app()
+        client, server = await _start_client(app)
+
+        try:
+            update_payload = {
+                "device": "hw:CARD=Device,DEV=0",
+                "sample_rate": 48000,
+                "frame_ms": 20,
+                "gain": 3.0,
+                "vad_aggressiveness": 3,
+                "filter_chain": {
+                    "highpass": {"enabled": True, "cutoff_hz": 110.0},
+                    "spectral_gate": {
+                        "enabled": True,
+                        "sensitivity": 1.4,
+                        "reduction_db": -20.0,
+                        "noise_update": 0.15,
+                        "noise_decay": 0.92,
+                    },
+                },
+            }
+
+            resp = await client.post("/api/config/audio", json=update_payload)
+            assert resp.status == 200
+
+            persisted_text = config_path.read_text(encoding="utf-8")
+            assert "# front-end gain guidance" in persisted_text
+            assert "# high-pass toggle" in persisted_text
+            assert "# high-pass cutoff" in persisted_text
+            assert "# gate reduction depth" in persisted_text
+            assert "# gate update speed" in persisted_text
+            assert "# gate release smoothing" in persisted_text
+
+            lines = persisted_text.splitlines()
+            gain_line = next(line for line in lines if "gain:" in line and "front-end" in line)
+            assert "3.0" in gain_line or "3" in gain_line
+            cutoff_line = next(line for line in lines if "cutoff_hz" in line and "high-pass cutoff" in line)
+            assert "110" in cutoff_line
+            reduction_line = next(line for line in lines if "reduction_db" in line and "gate reduction depth" in line)
+            assert "-20" in reduction_line
+
+            assert systemctl_calls == [
+                ["is-active", "voice-recorder.service"],
+                ["restart", "voice-recorder.service"],
+            ]
+        finally:
+            await client.close()
+            await server.close()
+
+    asyncio.run(runner())
+
+
+def test_audio_settings_rehydrate_comments_when_missing(tmp_path, monkeypatch):
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(
+        (
+            "audio:\n"
+            "  device: hw:1,0\n"
+            "  gain: 1.8\n"
+            "  vad_aggressiveness: 1\n"
+            "  filter_chain:\n"
+            "    highpass:\n"
+            "      enabled: false\n"
+            "      cutoff_hz: 80.0\n"
+        ),
+        encoding="utf-8",
+    )
+
+    monkeypatch.setenv("TRICORDER_CONFIG", str(config_path))
+    monkeypatch.setattr(config, "_cfg_cache", None, raising=False)
+    monkeypatch.setattr(config, "_primary_config_path", None, raising=False)
+    monkeypatch.setattr(config, "_active_config_path", None, raising=False)
+    monkeypatch.setattr(config, "_search_paths", [], raising=False)
+    monkeypatch.setattr(config, "_template_cache", None, raising=False)
+
+    async def runner():
+        systemctl_calls: list[list[str]] = []
+
+        async def fake_systemctl(args):
+            systemctl_calls.append(list(args))
+            if args and args[0] == "is-active":
+                return 0, "active\n", ""
+            return 0, "", ""
+
+        monkeypatch.setattr(web_streamer, "_run_systemctl", fake_systemctl)
+
+        app = web_streamer.build_app()
+        client, server = await _start_client(app)
+
+        try:
+            update_payload = {
+                "device": "hw:CARD=Device,DEV=0",
+                "sample_rate": 48000,
+                "frame_ms": 20,
+                "gain": 2.6,
+                "vad_aggressiveness": 2,
+                "filter_chain": {
+                    "highpass": {"enabled": True, "cutoff_hz": 115.0},
+                },
+            }
+
+            resp = await client.post("/api/config/audio", json=update_payload)
+            assert resp.status == 200
+
+            persisted_text = config_path.read_text(encoding="utf-8")
+            assert "# ALSA device identifier" in persisted_text
+            assert "# Unified live/recording filter chain" in persisted_text
+            assert "gain:" in persisted_text
+
+            persisted = yaml.safe_load(persisted_text)
+            assert persisted["audio"]["gain"] == pytest.approx(2.6)
+            assert persisted["audio"]["device"] == "hw:CARD=Device,DEV=0"
+            assert persisted["audio"]["filter_chain"]["highpass"]["enabled"] is True
+            assert persisted["audio"]["filter_chain"]["highpass"]["cutoff_hz"] == pytest.approx(115.0)
+
+            assert systemctl_calls == [
+                ["is-active", "voice-recorder.service"],
+                ["restart", "voice-recorder.service"],
+            ]
+        finally:
+            await client.close()
+            await server.close()
+
+    asyncio.run(runner())
+
+
 def test_audio_settings_skip_restart_when_inactive(tmp_path, monkeypatch):
     config_path = tmp_path / "config.yaml"
     config_path.write_text(


### PR DESCRIPTION
## Summary
- layer dashboard saves onto a cached copy of the commented config template whenever the active YAML lacks inline docs, with optional overrides via TRICORDER_CONFIG_TEMPLATE
- ship the embedded template so prior installs can regain guidance without losing their values and document the new environment toggle
- cover the regression with a dashboard test that verifies comment rehydration when starting from a stripped config

## Testing
- export DEV=1 && pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68dbc887d8648327b473e62dd8d68edb