### PR TITLE
Restore config helpers for dashboard tests

### DIFF
--- a/lib/config.py
+++ b/lib/config.py
@@ -169,9 +169,328 @@ _template_cache: MutableMapping[str, Any] | None = None
 class ConfigPersistenceError(Exception):
     """Raised when configuration changes cannot be persisted."""
 
+def _load_yaml_if_exists(path: Path) -> Dict[str, Any]:
+    global _warned_yaml_missing
+    if not path.exists():
+        return {}
+    if not yaml:
+        if not _warned_yaml_missing:
+            _warned_yaml_missing = True
+            print("[config] WARNING: PyYAML not available; using defaults only (no file parsing).", flush=True)
+        return {}
+    try:
+        with path.open("r") as f:
+            data = yaml.safe_load(f) or {}
+            if isinstance(data, dict):
+                return data
+    except Exception:
+        # Ignore parse errors and continue with other locations/defaults
+        pass
+    return {}
 
-# (file continues unchanged until conflicts)
-# ...
+
+def _candidate_search_paths(project_root: Path, script_dir: Path) -> list[Path]:
+    search: list[Path] = []
+    env_cfg = os.getenv("TRICORDER_CONFIG")
+    if env_cfg:
+        try:
+            search.append(Path(env_cfg).expanduser().resolve())
+        except Exception:
+            search.append(Path(env_cfg).expanduser())
+    search.extend(
+        [
+            Path("/etc/tricorder/config.yaml"),
+            Path("/apps/tricorder/config.yaml"),
+            project_root / "config.yaml",
+            script_dir / "config.yaml",
+            Path.cwd() / "config.yaml",
+        ]
+    )
+    seen: set[Path] = set()
+    ordered: list[Path] = []
+    for candidate in search:
+        try:
+            resolved = candidate.resolve()
+        except Exception:
+            resolved = candidate
+        if resolved in seen:
+            continue
+        seen.add(resolved)
+        ordered.append(resolved)
+    return ordered
+
+
+def _resolve_primary_path(search: list[Path], active: Path | None) -> Path:
+    env_cfg = os.getenv("TRICORDER_CONFIG")
+    if env_cfg:
+        try:
+            return Path(env_cfg).expanduser().resolve()
+        except Exception:
+            return Path(env_cfg).expanduser()
+
+    try:
+        etc_path = Path("/etc/tricorder/config.yaml").resolve()
+    except Exception:
+        etc_path = Path("/etc/tricorder/config.yaml")
+
+    if active is not None:
+        try:
+            active_resolved = active.resolve()
+        except Exception:
+            active_resolved = active
+        if active_resolved != etc_path:
+            return active_resolved
+
+    base_path = Path("/apps/tricorder/config.yaml")
+    fallback: Path | None = None
+    for candidate in search:
+        try:
+            resolved = candidate.resolve()
+        except Exception:
+            resolved = candidate
+        if resolved == base_path:
+            return resolved
+        if str(resolved).startswith("/etc/"):
+            continue
+        if fallback is None:
+            fallback = resolved
+    if fallback is not None:
+        return fallback
+    return base_path
+
+def _deep_merge(base: Dict[str, Any], extra: Dict[str, Any]) -> Dict[str, Any]:
+    out = dict(base)
+    for k, v in extra.items():
+        if isinstance(v, dict) and isinstance(out.get(k), dict):
+            out[k] = _deep_merge(out[k], v)
+        else:
+            out[k] = v
+    return out
+
+def _apply_env_overrides(cfg: Dict[str, Any]) -> None:
+    # DEV mode
+    if os.getenv("DEV") == "1":
+        cfg.setdefault("logging", {})["dev_mode"] = True
+    # Audio device and sample rate/gain
+    if "AUDIO_DEV" in os.environ:
+        cfg.setdefault("audio", {})["device"] = os.environ["AUDIO_DEV"]
+    if "GAIN" in os.environ:
+        try:
+            cfg.setdefault("audio", {})["gain"] = float(os.environ["GAIN"])
+        except ValueError:
+            pass
+    # Paths
+    if "REC_DIR" in os.environ:
+        cfg.setdefault("paths", {})["recordings_dir"] = os.environ["REC_DIR"]
+    if "TMP_DIR" in os.environ:
+        cfg.setdefault("paths", {})["tmp_dir"] = os.environ["TMP_DIR"]
+    if "DROPBOX_DIR" in os.environ:
+        cfg.setdefault("paths", {})["dropbox_dir"] = os.environ["DROPBOX_DIR"]
+    if "VOSK_MODEL_PATH" in os.environ:
+        value = os.environ["VOSK_MODEL_PATH"].strip()
+        if value:
+            cfg.setdefault("transcription", {})["vosk_model_path"] = value
+    # Ingest tuning
+    env_map = {
+        "INGEST_STABLE_CHECKS": ("ingest", "stable_checks", int),
+        "INGEST_STABLE_INTERVAL_SEC": ("ingest", "stable_interval_sec", float),
+        "INGEST_ALLOWED_EXT": ("ingest", "allowed_ext", lambda s: [x.strip().lower() for x in s.split(",") if x.strip()]),
+    }
+    for env_key, (section, key, cast) in env_map.items():
+        if env_key in os.environ:
+            try:
+                cfg.setdefault(section, {})[key] = cast(os.environ[env_key])
+            except Exception:
+                pass
+
+    def _parse_bool(value: str) -> bool:
+        return value.strip().lower() in {"1", "true", "yes", "on"}
+
+    transcription_env = {
+        "TRANSCRIPTION_ENABLED": ("enabled", _parse_bool),
+        "TRANSCRIPTION_ENGINE": ("engine", str),
+        "TRANSCRIPTION_TYPES": (
+            "types",
+            lambda s: [token.strip() for token in s.split(",") if token.strip()],
+        ),
+        "TRANSCRIPTION_TARGET_RATE": ("target_sample_rate", int),
+        "TRANSCRIPTION_INCLUDE_WORDS": ("include_words", _parse_bool),
+        "TRANSCRIPTION_MAX_ALTERNATIVES": ("max_alternatives", int),
+    }
+
+    for env_key, (key, caster) in transcription_env.items():
+        if env_key in os.environ:
+            try:
+                cfg.setdefault("transcription", {})[key] = caster(os.environ[env_key])
+            except Exception:
+                pass
+
+    tag_env = {
+        "EVENT_TAG_HUMAN": "human",
+        "EVENT_TAG_OTHER": "other",
+        "EVENT_TAG_BOTH": "both",
+    }
+    for env_key, tag_key in tag_env.items():
+        if env_key in os.environ:
+            value = os.environ[env_key].strip()
+            if value:
+                segmenter = cfg.setdefault("segmenter", {})
+                tags = segmenter.setdefault("event_tags", {})
+                tags[tag_key] = value
+
+    adaptive_env = {
+        "ADAPTIVE_RMS_ENABLED": ("enabled", _parse_bool),
+        "ADAPTIVE_RMS_MIN_THRESH": ("min_thresh", float),
+        "ADAPTIVE_RMS_MARGIN": ("margin", float),
+        "ADAPTIVE_RMS_UPDATE_INTERVAL_SEC": ("update_interval_sec", float),
+        "ADAPTIVE_RMS_WINDOW_SEC": ("window_sec", float),
+        "ADAPTIVE_RMS_HYSTERESIS_TOLERANCE": ("hysteresis_tolerance", float),
+        "ADAPTIVE_RMS_RELEASE_PERCENTILE": ("release_percentile", float),
+    }
+    for env_key, (key, caster) in adaptive_env.items():
+        if env_key in os.environ:
+            try:
+                cfg.setdefault("adaptive_rms", {})[key] = caster(os.environ[env_key])
+            except Exception:
+                pass
+
+    def _service_label_from_unit(unit: str) -> str:
+        base = unit.split(".", 1)[0]
+        tokens = [segment for segment in base.replace("_", "-").split("-") if segment]
+        if not tokens:
+            return unit
+        return " ".join(token.capitalize() for token in tokens)
+
+    if "DASHBOARD_SERVICES" in os.environ:
+        raw = os.environ["DASHBOARD_SERVICES"]
+        entries = []
+        for chunk in raw.split(";"):
+            piece = chunk.strip()
+            if not piece:
+                continue
+            parts = [p.strip() for p in piece.split("|", 2)]
+            unit = parts[0]
+            if not unit:
+                continue
+            label = parts[1] if len(parts) > 1 and parts[1] else _service_label_from_unit(unit)
+            description = parts[2] if len(parts) > 2 and parts[2] else ""
+            entry: Dict[str, Any] = {"unit": unit}
+            if label:
+                entry["label"] = label
+            if description:
+                entry["description"] = description
+            entries.append(entry)
+        if entries:
+            cfg.setdefault("dashboard", {})["services"] = entries
+
+    if "DASHBOARD_WEB_SERVICE" in os.environ:
+        value = os.environ["DASHBOARD_WEB_SERVICE"].strip()
+        if value:
+            cfg.setdefault("dashboard", {})["web_service"] = value
+
+
+def resolve_event_tags(cfg: Mapping[str, Any]) -> Dict[str, str]:
+    segmenter_section = cfg.get("segmenter") if isinstance(cfg, Mapping) else None
+    raw_tags = {}
+    if isinstance(segmenter_section, Mapping):
+        maybe_tags = segmenter_section.get("event_tags")
+        if isinstance(maybe_tags, Mapping):
+            raw_tags = maybe_tags
+
+    resolved: Dict[str, str] = {}
+    for key, default in EVENT_TAG_DEFAULTS.items():
+        value: str | None = None
+        if raw_tags:
+            for alias in {key, key.lower(), key.upper(), key.capitalize(), default}:
+                candidate = raw_tags.get(alias)
+                if isinstance(candidate, str) and candidate.strip():
+                    value = candidate.strip()
+                    break
+        resolved[key] = value or default
+    return resolved
+
+
+def event_type_aliases(cfg: Mapping[str, Any]) -> Dict[str, str]:
+    tags = resolve_event_tags(cfg)
+    aliases: Dict[str, str] = {}
+    for key, label in tags.items():
+        aliases[key.lower()] = label
+        aliases[label.lower()] = label
+    for key, default in EVENT_TAG_DEFAULTS.items():
+        aliases.setdefault(default.lower(), tags[key])
+    return aliases
+
+
+def get_cfg() -> Dict[str, Any]:
+    global _cfg_cache, _search_paths, _active_config_path, _primary_config_path
+    if _cfg_cache is not None:
+        return _cfg_cache
+
+    cfg = copy.deepcopy(_DEFAULTS)
+
+    # Derive project root relative to this file (lib/ -> project root)
+    try:
+        this_dir = Path(__file__).resolve().parent
+        project_root = this_dir.parent  # <root>/lib -> <root>
+    except Exception:
+        project_root = Path.cwd()
+
+    # Derive script directory (useful for tools run as ./tool.py)
+    try:
+        script_dir = Path(sys.argv[0]).resolve().parent
+    except Exception:
+        script_dir = Path.cwd()
+
+    search = _candidate_search_paths(project_root, script_dir)
+    _search_paths = list(search)
+
+    active: Path | None = None
+    for candidate in search:
+        if active is None:
+            try:
+                if candidate.exists():
+                    active = candidate
+            except OSError:
+                pass
+
+    for candidate in reversed(search):
+        cfg = _deep_merge(cfg, _load_yaml_if_exists(candidate))
+
+    _active_config_path = active
+    _primary_config_path = _resolve_primary_path(search, active)
+
+    _apply_env_overrides(cfg)
+    _cfg_cache = cfg
+    return cfg
+
+
+def reload_cfg() -> Dict[str, Any]:
+    global _cfg_cache
+    _cfg_cache = None
+    return get_cfg()
+
+
+def primary_config_path() -> Path:
+    global _primary_config_path
+    if _primary_config_path is None:
+        get_cfg()
+    assert _primary_config_path is not None
+    return _primary_config_path
+
+
+def active_config_path() -> Path | None:
+    global _active_config_path
+    if _active_config_path is None:
+        get_cfg()
+    return _active_config_path
+
+
+def search_paths() -> list[Path]:
+    global _search_paths
+    if not _search_paths:
+        get_cfg()
+    return list(_search_paths)
+
 
 def _empty_mapping() -> MutableMapping[str, Any]:
     if CommentedMap is not None:
@@ -255,8 +574,123 @@ def _template_with_values(values: Mapping[str, Any]) -> MutableMapping[str, Any]
     return template
 
 
-# (file continues unchanged until the last conflict area)
-# ...
+def _convert_to_round_trip(value: Any) -> Any:
+    if CommentedMap is not None:
+        if isinstance(value, CommentedMap) or isinstance(value, CommentedSeq):
+            return value
+        if isinstance(value, Mapping) and not isinstance(value, (str, bytes)):
+            converted = CommentedMap()
+            for key, sub_value in value.items():
+                converted[key] = _convert_to_round_trip(sub_value)
+            return converted
+        if isinstance(value, Sequence) and not isinstance(value, (str, bytes)):
+            converted_seq = CommentedSeq()
+            for item in value:
+                converted_seq.append(_convert_to_round_trip(item))
+            return converted_seq
+    return copy.deepcopy(value)
+
+
+def _ensure_mapping(container: MutableMapping[str, Any], key: str) -> MutableMapping[str, Any]:
+    existing = container.get(key)
+    if isinstance(existing, MutableMapping):
+        return existing
+    if isinstance(existing, Mapping):
+        converted = _convert_to_round_trip(existing)
+        if isinstance(converted, MutableMapping):
+            container[key] = converted
+            return converted
+    new_map = _convert_to_round_trip({})
+    assert isinstance(new_map, MutableMapping)
+    container[key] = new_map
+    return new_map
+
+
+def _replace_mapping(
+    target: MutableMapping[str, Any],
+    updates: Mapping[str, Any],
+    *,
+    prune: bool,
+) -> None:
+    if prune:
+        for existing_key in list(target.keys()):
+            if existing_key not in updates:
+                try:
+                    del target[existing_key]
+                except Exception:
+                    pass
+    for key, value in updates.items():
+        if isinstance(value, Mapping) and not isinstance(value, (str, bytes)):
+            nested: MutableMapping[str, Any]
+            existing = target.get(key)
+            if isinstance(existing, MutableMapping):
+                nested = existing
+            else:
+                converted = _convert_to_round_trip(value)
+                if isinstance(converted, MutableMapping):
+                    target[key] = converted
+                    nested = converted
+                    continue
+                nested = _empty_mapping()
+                target[key] = nested
+            _replace_mapping(nested, value, prune=prune)
+        elif isinstance(value, Sequence) and not isinstance(value, (str, bytes)):
+            target[key] = _convert_to_round_trip(value)
+        else:
+            target[key] = copy.deepcopy(value)
+
+
+def _load_yaml_for_update(path: Path) -> MutableMapping[str, Any]:
+    if _ROUND_TRIP_YAML is not None:
+        if path.exists():
+            try:
+                with path.open("r", encoding="utf-8") as handle:
+                    data = _ROUND_TRIP_YAML.load(handle)  # type: ignore[arg-type]
+            except Exception as exc:
+                raise ConfigPersistenceError(f"Unable to read configuration: {exc}") from exc
+            if isinstance(data, MutableMapping):
+                return data
+        return _empty_mapping()
+    return {}
+
+
+def _load_raw_yaml(path: Path) -> Dict[str, Any]:
+    if not yaml:
+        raise ConfigPersistenceError("PyYAML is required to update configuration files")
+    if not path.exists():
+        return {}
+    try:
+        with path.open("r", encoding="utf-8") as handle:
+            payload = yaml.safe_load(handle) or {}
+            if isinstance(payload, dict):
+                return payload
+    except Exception as exc:
+        raise ConfigPersistenceError(f"Unable to read configuration: {exc}") from exc
+    return {}
+
+
+def _dump_yaml(path: Path, payload: MutableMapping[str, Any] | Dict[str, Any]) -> None:
+    if _ROUND_TRIP_YAML is None and not yaml:
+        raise ConfigPersistenceError("PyYAML is required to update configuration files")
+    try:
+        path.parent.mkdir(parents=True, exist_ok=True)
+    except Exception as exc:
+        raise ConfigPersistenceError(f"Unable to create configuration directory: {exc}") from exc
+    try:
+        with path.open("w", encoding="utf-8") as handle:
+            if _ROUND_TRIP_YAML is not None:
+                _ROUND_TRIP_YAML.dump(payload, handle)  # type: ignore[arg-type]
+            else:
+                yaml.safe_dump(  # type: ignore[union-attr]
+                    payload,
+                    handle,
+                    default_flow_style=False,
+                    sort_keys=False,
+                    allow_unicode=True,
+                )
+    except Exception as exc:
+        raise ConfigPersistenceError(f"Unable to write configuration: {exc}") from exc
+
 
 def _persist_settings_section(
     section: str, settings: Dict[str, Any], *, merge: bool = True

--- a/tests/test_37_web_dashboard.py
+++ b/tests/test_37_web_dashboard.py
@@ -675,11 +675,6 @@ def test_audio_settings_preserve_inline_comments(tmp_path, monkeypatch):
     asyncio.run(runner())
 
 
-def test_audio_settings_preserve_inline_comments(tmp_path, monkeypatch):
-    # existing body unchanged…
-    asyncio.run(runner())
-
-
 def test_audio_settings_rehydrate_comments_when_missing(tmp_path, monkeypatch):
     config_path = tmp_path / "config.yaml"
     config_path.write_text(


### PR DESCRIPTION
## Summary
- restore the configuration loader utilities that were dropped during the merge so runtime modules can import `get_cfg` and related helpers again
- remove the placeholder dashboard audio settings test stub so the full inline comment regression test executes

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68dbe769d8288327ba17aca6d3ab0098