### PR TITLE
Remove dashboard refresh indicator

### DIFF
--- a/lib/webui/static/css/dashboard.css
+++ b/lib/webui/static/css/dashboard.css
@@ -619,43 +619,6 @@ body[data-theme="light"] .app-menu-toggle {
   }
 }
 
-.refresh-indicator {
-  display: none;
-  align-items: center;
-  gap: 0.45rem;
-  min-height: 2rem;
-  pointer-events: none;
-  color: var(--text-muted);
-  font-size: 0.85rem;
-  opacity: 0;
-  visibility: hidden;
-  transition: opacity 0.2s ease, visibility 0.2s ease;
-  white-space: nowrap;
-  flex: 0 0 auto;
-}
-
-.refresh-indicator[data-visible="true"] {
-  display: inline-flex;
-  opacity: 1;
-  visibility: visible;
-}
-
-.refresh-indicator .refresh-spinner {
-  width: 1rem;
-  height: 1rem;
-  border-radius: 50%;
-  border: 2px solid var(--ghost-border);
-  border-top-color: var(--primary);
-  animation: refresh-spin 0.8s linear infinite;
-}
-
-.refresh-indicator .refresh-text {
-  letter-spacing: 0.04em;
-  text-transform: uppercase;
-  font-weight: 600;
-  font-size: 0.75rem;
-}
-
 .connection-status {
   display: none;
   align-items: center;
@@ -2801,8 +2764,3 @@ body[data-scroll-locked="true"] {
   }
 }
 
-@keyframes refresh-spin {
-  to {
-    transform: rotate(360deg);
-  }
-}

--- a/lib/webui/static/js/dashboard.js
+++ b/lib/webui/static/js/dashboard.js
@@ -60,7 +60,6 @@ function toFiniteOrNull(value) {
 
 const AUTO_REFRESH_INTERVAL_MS = 1000;
 const OFFLINE_REFRESH_INTERVAL_MS = 5000;
-const REFRESH_INDICATOR_DELAY_MS = 600;
 const MARKER_MIN_GAP_SECONDS = 0.05;
 const KEYBOARD_JOG_RATE_SECONDS_PER_SECOND = 4;
 const MIN_CLIP_DURATION_SECONDS = 0.05;
@@ -233,7 +232,6 @@ const dom = {
   downloadSelected: document.getElementById("download-selected"),
   renameSelected: document.getElementById("rename-selected"),
   deleteSelected: document.getElementById("delete-selected"),
-  refreshIndicator: document.getElementById("refresh-indicator"),
   themeToggle: document.getElementById("theme-toggle"),
   connectionStatus: document.getElementById("connection-status"),
   recordingIndicator: document.getElementById("recording-indicator"),
@@ -979,7 +977,6 @@ function findInteractiveElement(target, event = null) {
   return null;
 }
 
-let refreshIndicatorTimer = null;
 let pendingSelectionPath = null;
 const renameDialogState = {
   open: false,
@@ -2831,48 +2828,6 @@ if (dom.renameModal) {
       focusable[index].focus();
     }
   });
-}
-
-function clearRefreshIndicatorTimer() {
-  if (refreshIndicatorTimer) {
-    window.clearTimeout(refreshIndicatorTimer);
-    refreshIndicatorTimer = null;
-  }
-}
-
-function setRefreshIndicatorVisible(visible) {
-  if (!dom.refreshIndicator) {
-    return;
-  }
-  dom.refreshIndicator.dataset.visible = visible ? "true" : "false";
-  dom.refreshIndicator.setAttribute("aria-hidden", visible ? "false" : "true");
-}
-
-function scheduleRefreshIndicator() {
-  clearRefreshIndicatorTimer();
-  if (!dom.refreshIndicator) {
-    setRefreshIndicatorVisible(false);
-    return;
-  }
-  if (connectionState.offline) {
-    setRefreshIndicatorVisible(false);
-    return;
-  }
-  setRefreshIndicatorVisible(false);
-  refreshIndicatorTimer = window.setTimeout(() => {
-    if (connectionState.offline) {
-      setRefreshIndicatorVisible(false);
-      refreshIndicatorTimer = null;
-      return;
-    }
-    setRefreshIndicatorVisible(true);
-    refreshIndicatorTimer = null;
-  }, REFRESH_INDICATOR_DELAY_MS);
-}
-
-function hideRefreshIndicator() {
-  clearRefreshIndicatorTimer();
-  setRefreshIndicatorVisible(false);
 }
 
 function recordingUrl(path, { download = false } = {}) {
@@ -5554,8 +5509,6 @@ async function fetchRecordings(options = {}) {
   }
   fetchInFlight = true;
 
-  scheduleRefreshIndicator();
-
   const limit = clampLimitValue(state.filters.limit);
   if (limit !== state.filters.limit) {
     state.filters.limit = limit;
@@ -5737,7 +5690,6 @@ async function fetchRecordings(options = {}) {
     }
     fetchQueued = false;
   } finally {
-    hideRefreshIndicator();
     fetchInFlight = false;
     if (fetchQueued) {
       fetchQueued = false;
@@ -10706,7 +10658,6 @@ function initialize() {
   setClipperVisible(false);
   updateClipperStatusElement();
   setRecordingIndicatorUnknown("Loading status…");
-  setRefreshIndicatorVisible(false);
   setLiveButtonState(false);
   setLiveStatus("Idle");
   setLiveToggleDisabled(true, "Checking recorder service status…");

--- a/lib/webui/templates/dashboard.html
+++ b/lib/webui/templates/dashboard.html
@@ -206,17 +206,6 @@
               Toggle theme
             </button>
             <button id="live-stream-toggle" class="primary-button" type="button">Live Stream</button>
-            <div
-              id="refresh-indicator"
-              class="refresh-indicator"
-              role="status"
-              aria-live="polite"
-              aria-hidden="true"
-              data-visible="false"
-            >
-              <span class="refresh-spinner" aria-hidden="true"></span>
-              <span class="refresh-text">Refreshing…</span>
-            </div>
           </div>
           <div class="header-status-group">
             <div class="status-labels">


### PR DESCRIPTION
## Summary
- remove the dashboard refresh indicator markup and styling to keep the header controls stable
- delete the JavaScript that tracked refresh state now that the indicator is gone

## Risk
- Low, limited to dashboard header visuals and fetch bookkeeping

## Testing
- DEV=1 pytest tests/test_37_web_dashboard.py
- DEV=1 pytest tests/test_25_web_streamer.py
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68dcc1bc0b948327bc3393dd4da6a1a6