### PR TITLE
TR-47 add adaptive RMS ceiling

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,6 +327,8 @@ Key configuration sections (see `config.yaml` for defaults and documentation):
 - `paths` – tmpfs, recordings, dropbox, ingest work directory, encoder script path.
 - `segmenter` – pre/post pads, RMS threshold, debounce windows, optional denoise toggles, filter chain timing budgets, custom event tags.
 - `adaptive_rms` – background noise follower for automatically raising/lowering thresholds.
+  - `max_rms` enforces a hard ceiling using linear RMS units (same scale as `segmenter.rms_threshold`).
+    For example, set `max_rms: 250` to allow adaptive increases up to 250 and no higher.
 - `ingest` – file stability checks, extension filters, ignore suffixes.
 - `logging` – developer-mode verbosity toggle.
 - `notifications` – optional webhook/email alerts when events finish recording.

--- a/config.yaml
+++ b/config.yaml
@@ -178,7 +178,12 @@ adaptive_rms:
   # Minimum normalized RMS threshold (0.0–1.0). For 16-bit PCM, 0.01 ≈ 328 linear RMS.
   min_thresh: 0.01
 
-  # Maximum normalized RMS threshold (0.0–1.0). Caps how high the adaptive gate can climb.
+  # Optional hard ceiling in linear RMS units (same scale as segmenter.rms_threshold).
+  # Example: 250 keeps the adaptive gate from exceeding an RMS of 250. Leave null to disable.
+  max_rms: null
+
+  # Maximum normalized RMS threshold (0.0–1.0). Serves as a secondary guard rail for
+  # advanced tuning; most installs can keep this at 1.0 and rely on max_rms for the ceiling.
   max_thresh: 1.0
 
   # Multiplier applied to the background P95 value when computing the candidate threshold.

--- a/config.yaml
+++ b/config.yaml
@@ -178,6 +178,9 @@ adaptive_rms:
   # Minimum normalized RMS threshold (0.0–1.0). For 16-bit PCM, 0.01 ≈ 328 linear RMS.
   min_thresh: 0.01
 
+  # Maximum normalized RMS threshold (0.0–1.0). Caps how high the adaptive gate can climb.
+  max_thresh: 1.0
+
   # Multiplier applied to the background P95 value when computing the candidate threshold.
   margin: 1.2
 

--- a/lib/config.py
+++ b/lib/config.py
@@ -115,6 +115,7 @@ _DEFAULTS: Dict[str, Any] = {
     "adaptive_rms": {
         "enabled": False,
         "min_thresh": 0.01,
+        "max_rms": None,
         "max_thresh": 1.0,
         "margin": 1.2,
         "update_interval_sec": 5.0,
@@ -342,6 +343,7 @@ def _apply_env_overrides(cfg: Dict[str, Any]) -> None:
     adaptive_env = {
         "ADAPTIVE_RMS_ENABLED": ("enabled", _parse_bool),
         "ADAPTIVE_RMS_MIN_THRESH": ("min_thresh", float),
+        "ADAPTIVE_RMS_MAX_RMS": ("max_rms", int),
         "ADAPTIVE_RMS_MAX_THRESH": ("max_thresh", float),
         "ADAPTIVE_RMS_MARGIN": ("margin", float),
         "ADAPTIVE_RMS_UPDATE_INTERVAL_SEC": ("update_interval_sec", float),

--- a/lib/config.py
+++ b/lib/config.py
@@ -115,6 +115,7 @@ _DEFAULTS: Dict[str, Any] = {
     "adaptive_rms": {
         "enabled": False,
         "min_thresh": 0.01,
+        "max_thresh": 1.0,
         "margin": 1.2,
         "update_interval_sec": 5.0,
         "window_sec": 10.0,
@@ -341,6 +342,7 @@ def _apply_env_overrides(cfg: Dict[str, Any]) -> None:
     adaptive_env = {
         "ADAPTIVE_RMS_ENABLED": ("enabled", _parse_bool),
         "ADAPTIVE_RMS_MIN_THRESH": ("min_thresh", float),
+        "ADAPTIVE_RMS_MAX_THRESH": ("max_thresh", float),
         "ADAPTIVE_RMS_MARGIN": ("margin", float),
         "ADAPTIVE_RMS_UPDATE_INTERVAL_SEC": ("update_interval_sec", float),
         "ADAPTIVE_RMS_WINDOW_SEC": ("window_sec", float),

--- a/lib/config_template.py
+++ b/lib/config_template.py
@@ -187,7 +187,12 @@ adaptive_rms:
   # Minimum normalized RMS threshold (0.0–1.0). For 16-bit PCM, 0.01 ≈ 328 linear RMS.
   min_thresh: 0.01
 
-  # Maximum normalized RMS threshold (0.0–1.0). Caps how high the adaptive gate can climb.
+  # Optional hard ceiling in linear RMS units (same scale as segmenter.rms_threshold).
+  # Example: 250 keeps the adaptive gate from exceeding an RMS of 250. Leave null to disable.
+  max_rms: null
+
+  # Maximum normalized RMS threshold (0.0–1.0). Serves as a secondary guard rail for
+  # advanced tuning; most installs can keep this at 1.0 and rely on max_rms for the ceiling.
   max_thresh: 1.0
 
   # Multiplier applied to the background P95 value when computing the candidate threshold.

--- a/lib/config_template.py
+++ b/lib/config_template.py
@@ -187,6 +187,9 @@ adaptive_rms:
   # Minimum normalized RMS threshold (0.0–1.0). For 16-bit PCM, 0.01 ≈ 328 linear RMS.
   min_thresh: 0.01
 
+  # Maximum normalized RMS threshold (0.0–1.0). Caps how high the adaptive gate can climb.
+  max_thresh: 1.0
+
   # Multiplier applied to the background P95 value when computing the candidate threshold.
   margin: 1.2
 

--- a/lib/webui/static/js/dashboard.js
+++ b/lib/webui/static/js/dashboard.js
@@ -439,6 +439,7 @@ const recorderDom = {
       form: document.getElementById("adaptive-form"),
       enabled: document.getElementById("adaptive-enabled"),
       minThresh: document.getElementById("adaptive-min-thresh"),
+      maxThresh: document.getElementById("adaptive-max-thresh"),
       margin: document.getElementById("adaptive-margin"),
       updateInterval: document.getElementById("adaptive-update-interval"),
       window: document.getElementById("adaptive-window"),
@@ -6120,6 +6121,7 @@ function adaptiveDefaults() {
   return {
     enabled: false,
     min_thresh: 0.01,
+    max_thresh: 1,
     margin: 1.2,
     update_interval_sec: 5.0,
     window_sec: 10.0,
@@ -6143,6 +6145,7 @@ function canonicalAdaptiveSettings(settings) {
   }
 
   defaults.min_thresh = clampFloat(source.min_thresh, defaults.min_thresh, 0, 1);
+  defaults.max_thresh = clampFloat(source.max_thresh, defaults.max_thresh, 0, 1);
   defaults.margin = clampFloat(source.margin, defaults.margin, 0.5, 10);
   defaults.update_interval_sec = clampFloat(
     source.update_interval_sec,
@@ -6163,6 +6166,10 @@ function canonicalAdaptiveSettings(settings) {
     0.05,
     1
   );
+
+  if (defaults.max_thresh < defaults.min_thresh) {
+    defaults.max_thresh = defaults.min_thresh;
+  }
 
   return defaults;
 }
@@ -7088,6 +7095,9 @@ function applyAdaptiveForm(data) {
   if (section.minThresh) {
     section.minThresh.value = String(data.min_thresh);
   }
+  if (section.maxThresh) {
+    section.maxThresh.value = String(data.max_thresh);
+  }
   if (section.margin) {
     section.margin.value = String(data.margin);
   }
@@ -7113,6 +7123,7 @@ function readAdaptiveForm() {
   const payload = {
     enabled: section.enabled ? section.enabled.checked : false,
     min_thresh: section.minThresh ? Number(section.minThresh.value) : undefined,
+    max_thresh: section.maxThresh ? Number(section.maxThresh.value) : undefined,
     margin: section.margin ? Number(section.margin.value) : undefined,
     update_interval_sec: section.updateInterval ? Number(section.updateInterval.value) : undefined,
     window_sec: section.window ? Number(section.window.value) : undefined,

--- a/lib/webui/static/js/dashboard.js
+++ b/lib/webui/static/js/dashboard.js
@@ -439,7 +439,7 @@ const recorderDom = {
       form: document.getElementById("adaptive-form"),
       enabled: document.getElementById("adaptive-enabled"),
       minThresh: document.getElementById("adaptive-min-thresh"),
-      maxThresh: document.getElementById("adaptive-max-thresh"),
+      maxRms: document.getElementById("adaptive-max-rms"),
       margin: document.getElementById("adaptive-margin"),
       updateInterval: document.getElementById("adaptive-update-interval"),
       window: document.getElementById("adaptive-window"),
@@ -6121,6 +6121,7 @@ function adaptiveDefaults() {
   return {
     enabled: false,
     min_thresh: 0.01,
+    max_rms: null,
     max_thresh: 1,
     margin: 1.2,
     update_interval_sec: 5.0,
@@ -6136,6 +6137,24 @@ function canonicalAdaptiveSettings(settings) {
 
   defaults.enabled = parseBoolean(source.enabled);
 
+  function parseOptionalRms(value, fallback) {
+    if (value === null || value === undefined) {
+      return null;
+    }
+    if (typeof value === "string" && value.trim() === "") {
+      return null;
+    }
+    const number = Number(value);
+    if (!Number.isFinite(number)) {
+      return fallback;
+    }
+    const rounded = Math.round(number);
+    if (rounded <= 0) {
+      return null;
+    }
+    return Math.min(32767, rounded);
+  }
+
   function clampFloat(value, fallback, min, max) {
     const number = Number(value);
     if (!Number.isFinite(number)) {
@@ -6146,6 +6165,7 @@ function canonicalAdaptiveSettings(settings) {
 
   defaults.min_thresh = clampFloat(source.min_thresh, defaults.min_thresh, 0, 1);
   defaults.max_thresh = clampFloat(source.max_thresh, defaults.max_thresh, 0, 1);
+  defaults.max_rms = parseOptionalRms(source.max_rms, defaults.max_rms);
   defaults.margin = clampFloat(source.margin, defaults.margin, 0.5, 10);
   defaults.update_interval_sec = clampFloat(
     source.update_interval_sec,
@@ -7095,8 +7115,10 @@ function applyAdaptiveForm(data) {
   if (section.minThresh) {
     section.minThresh.value = String(data.min_thresh);
   }
-  if (section.maxThresh) {
-    section.maxThresh.value = String(data.max_thresh);
+  section.maxThreshValue = typeof data.max_thresh === "number" ? data.max_thresh : undefined;
+  if (section.maxRms) {
+    section.maxRms.value =
+      data.max_rms === null || data.max_rms === undefined ? "" : String(data.max_rms);
   }
   if (section.margin) {
     section.margin.value = String(data.margin);
@@ -7123,7 +7145,13 @@ function readAdaptiveForm() {
   const payload = {
     enabled: section.enabled ? section.enabled.checked : false,
     min_thresh: section.minThresh ? Number(section.minThresh.value) : undefined,
-    max_thresh: section.maxThresh ? Number(section.maxThresh.value) : undefined,
+    max_thresh:
+      typeof section.maxThreshValue === "number" ? section.maxThreshValue : undefined,
+    max_rms: section.maxRms
+      ? section.maxRms.value.trim() === ""
+        ? null
+        : Number(section.maxRms.value)
+      : undefined,
     margin: section.margin ? Number(section.margin.value) : undefined,
     update_interval_sec: section.updateInterval ? Number(section.updateInterval.value) : undefined,
     window_sec: section.window ? Number(section.window.value) : undefined,

--- a/lib/webui/templates/dashboard.html
+++ b/lib/webui/templates/dashboard.html
@@ -1243,6 +1243,11 @@
                 <p class="field-description">Floor for the normalized RMS threshold (0–1 scale).</p>
               </div>
               <div class="settings-field">
+                <label for="adaptive-max-thresh">Maximum threshold</label>
+                <input id="adaptive-max-thresh" type="number" min="0" max="1" step="0.001" />
+                <p class="field-description">Ceiling that prevents the adaptive gate from climbing indefinitely.</p>
+              </div>
+              <div class="settings-field">
                 <label for="adaptive-margin">Noise margin</label>
                 <input id="adaptive-margin" type="number" min="0.5" max="10" step="0.05" />
                 <p class="field-description">Multiplier applied to the observed background noise floor.</p>

--- a/lib/webui/templates/dashboard.html
+++ b/lib/webui/templates/dashboard.html
@@ -1243,8 +1243,16 @@
                 <p class="field-description">Floor for the normalized RMS threshold (0–1 scale).</p>
               </div>
               <div class="settings-field">
-                <label for="adaptive-max-thresh">Maximum threshold</label>
-                <input id="adaptive-max-thresh" type="number" min="0" max="1" step="0.001" />
+                <label for="adaptive-max-rms">Hard RMS ceiling</label>
+                <input
+                  id="adaptive-max-rms"
+                  type="number"
+                  min="0"
+                  max="32767"
+                  step="1"
+                  inputmode="numeric"
+                  placeholder="(optional)"
+                />
                 <p class="field-description">Ceiling that prevents the adaptive gate from climbing indefinitely.</p>
               </div>
               <div class="settings-field">

--- a/tests/test_10_segmenter.py
+++ b/tests/test_10_segmenter.py
@@ -202,7 +202,7 @@ def test_adaptive_threshold_ceiling(monkeypatch):
         cfg_section={
             "enabled": True,
             "min_thresh": 0.001,
-            "max_thresh": 0.02,
+            "max_rms": 500,
             "margin": 1.2,
             "update_interval_sec": 0.05,
             "window_sec": 0.2,
@@ -212,7 +212,8 @@ def test_adaptive_threshold_ceiling(monkeypatch):
         debug=False,
     )
 
-    ceiling_linear = int(round(ctrl.max_thresh_norm * segmenter.AdaptiveRmsController._NORM))
+    ceiling_linear = ctrl.max_threshold_linear
+    assert ceiling_linear == 500
 
     for _ in range(12):
         ctrl.observe(2500, voiced=False)


### PR DESCRIPTION
## Summary
- add a configurable ceiling to the adaptive RMS controller so the threshold stops rising once the cap is reached
- expose the new max threshold in config defaults, environment overrides, and the dashboard UI
- extend unit tests to cover ceiling enforcement and ensure recovery logic respects the cap

## Testing
- DEV=1 pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68dd19ac00948327b845cd29a91263a2