### PR TITLE
TR-49: Add streaming Opus pipeline groundwork

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,7 +331,7 @@ Key configuration sections (see `config.yaml` for defaults and documentation):
 
 - `audio` – device, sample rate, frame size, gain, VAD aggressiveness, optional filter chain for hum/rumble control.
 - `paths` – tmpfs, recordings, dropbox, ingest work directory, encoder script path.
-- `segmenter` – pre/post pads, RMS threshold, debounce windows, optional denoise toggles, filter chain timing budgets, custom event tags.
+- `segmenter` – pre/post pads, RMS threshold, debounce windows, optional denoise toggles, filter chain timing budgets, custom event tags. When `segmenter.streaming_encode` is enabled the recorder mirrors audio frames into a background ffmpeg process that writes a `.partial.opus` (or `.partial.webm`) beside the eventual recording so browsers can tail the file while waveform/transcription jobs run.
 - `adaptive_rms` – background noise follower for automatically raising/lowering thresholds.
   - `max_rms` enforces a hard ceiling using linear RMS units (same scale as `segmenter.rms_threshold`).
     For example, set `max_rms: 250` to allow adaptive increases up to 250 and no higher.

--- a/bin/encode_and_store.sh
+++ b/bin/encode_and_store.sh
@@ -13,12 +13,18 @@ DENOISE="${DENOISE:-1}"
 
 in_wav="$1"     # abs path in tmpfs
 base="$2"       # e.g. 08-57-34_Both_1
+existing_opus="${3:-}"
 VENV="/apps/tricorder/venv"
 day="$(date +%Y%m%d)"
 outdir="/apps/tricorder/recordings/$day"
 mkdir -p "$outdir"
 
-outfile="$outdir/${base}.opus"
+if [[ -n "$existing_opus" ]]; then
+  outfile="$existing_opus"
+else
+  outfile="$outdir/${base}.opus"
+fi
+mkdir -p "$(dirname "$outfile")"
 waveform_file="${outfile}.waveform.json"
 
 # Optional denoise filter chain
@@ -38,15 +44,19 @@ fi
 #   resample if the WAV header is off or if ALSA produced a surprise rate.
 # - Use application=audio (general content), 20ms frames, VBR on, 48 kbps.
 # - One thread to reduce CPU spikes on the Zero 2 W.
-if ! nice -n 15 ionice -c3 ffmpeg -hide_banner -loglevel error -y -threads 1 \
-  -i "$in_wav" \
-  "${FILTERS[@]}" \
-  -ac 1 -ar 48000 -sample_fmt s16 \
-  -c:a libopus -b:a 48k -vbr on -application audio -frame_duration 20 \
-  "$outfile"; then
-    echo "[encode] ffmpeg failed for $in_wav" | systemd-cat -t tricorder
-    "$VENV/bin/python" -m lib.fault_handler encode_failure "$in_wav" "$base"
-    exit 1
+if [[ -n "$existing_opus" && -f "$existing_opus" ]]; then
+  echo "[encode] Streaming encoder provided $existing_opus; skipping ffmpeg" | systemd-cat -t tricorder
+else
+  if ! nice -n 15 ionice -c3 ffmpeg -hide_banner -loglevel error -y -threads 1 \
+    -i "$in_wav" \
+    "${FILTERS[@]}" \
+    -ac 1 -ar 48000 -sample_fmt s16 \
+    -c:a libopus -b:a 48k -vbr on -application audio -frame_duration 20 \
+    "$outfile"; then
+      echo "[encode] ffmpeg failed for $in_wav" | systemd-cat -t tricorder
+      "$VENV/bin/python" -m lib.fault_handler encode_failure "$in_wav" "$base"
+      exit 1
+  fi
 fi
 
 if ! "$VENV/bin/python" -m lib.waveform_cache "$in_wav" "$waveform_file"; then

--- a/config.yaml
+++ b/config.yaml
@@ -159,6 +159,14 @@ segmenter:
   # Typical: 65536–262144 (64–256 KB).
   flush_threshold_bytes: 131072
 
+  # Enable experimental streaming Opus encoding that writes a .partial.opus file while
+  # recording is still in progress. The existing post-event encoder remains the fallback
+  # and still handles waveform/transcription generation. Requires libopus via ffmpeg.
+  streaming_encode: false
+
+  # Container format for streaming output. Supported values: "opus" (default) or "webm".
+  streaming_encode_container: "opus"
+
   # Max queued frames before backpressure/drop (safety). With 20ms @ 48k mono: 512 ≈ 10.24s of audio.
   # Keep modest to avoid memory spikes. Typical: 256–1024.
   max_queue_frames: 512

--- a/lib/segmenter.py
+++ b/lib/segmenter.py
@@ -135,6 +135,18 @@ TMP_DIR = cfg["paths"]["tmp_dir"]
 REC_DIR = cfg["paths"]["recordings_dir"]
 ENCODER = cfg["paths"]["encoder_script"]
 
+STREAMING_ENCODE_ENABLED = bool(
+    cfg["segmenter"].get("streaming_encode", False)
+)
+_STREAMING_FORMAT = str(
+    cfg["segmenter"].get("streaming_encode_container", "opus")
+).strip().lower()
+if _STREAMING_FORMAT not in {"opus", "webm"}:
+    _STREAMING_FORMAT = "opus"
+STREAMING_CONTAINER_FORMAT = _STREAMING_FORMAT
+STREAMING_EXTENSION = ".opus" if STREAMING_CONTAINER_FORMAT == "opus" else ".webm"
+STREAMING_PARTIAL_SUFFIX = f".partial{STREAMING_EXTENSION}"
+
 # PRE_PAD / POST_PAD
 PRE_PAD = int(cfg["segmenter"]["pre_pad_ms"])
 POST_PAD = int(cfg["segmenter"]["post_pad_ms"])
@@ -296,6 +308,186 @@ class _WriterWorker(threading.Thread):
             finally:
                 self.q.task_done()
 
+
+# ---------- Streaming Opus encoder helper ----------
+
+
+@dataclass
+class StreamingEncoderResult:
+    partial_path: str | None
+    success: bool
+    returncode: int | None
+    error: Exception | None
+    stderr: str | None
+    bytes_sent: int
+    dropped_chunks: int
+
+
+class StreamingOpusEncoder:
+    def __init__(self, partial_path: str, *, container_format: str = "opus") -> None:
+        if not partial_path:
+            raise ValueError("partial_path is required for StreamingOpusEncoder")
+        self.partial_path = partial_path
+        self.container_format = container_format if container_format in {"opus", "webm"} else "opus"
+        self._process: subprocess.Popen | None = None
+        self._queue: queue.Queue[bytes | None] = queue.Queue(maxsize=MAX_QUEUE_FRAMES)
+        self._thread: threading.Thread | None = None
+        self._bytes_sent = 0
+        self._dropped = 0
+        self._error: Exception | None = None
+        self._stderr: bytes | None = None
+        self._returncode: int | None = None
+        self._closed = threading.Event()
+
+    def _build_command(self) -> list[str]:
+        base_cmd = [
+            "ffmpeg",
+            "-hide_banner",
+            "-loglevel",
+            "error",
+            "-f",
+            "s16le",
+            "-ar",
+            str(SAMPLE_RATE),
+            "-ac",
+            "1",
+            "-i",
+            "pipe:0",
+            "-c:a",
+            "libopus",
+            "-b:a",
+            "48k",
+            "-vbr",
+            "on",
+            "-application",
+            "audio",
+            "-frame_duration",
+            "20",
+            "-f",
+            self.container_format,
+            self.partial_path,
+        ]
+        return base_cmd
+
+    def start(self, command: list[str] | None = None) -> None:
+        if self._process is not None:
+            raise RuntimeError("StreamingOpusEncoder already started")
+        os.makedirs(os.path.dirname(self.partial_path), exist_ok=True)
+        if command is None:
+            command = self._build_command()
+        try:
+            self._process = subprocess.Popen(
+                command,
+                stdin=subprocess.PIPE,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.PIPE,
+            )
+        except Exception as exc:  # noqa: BLE001 - surface failure upstream
+            self._error = exc
+            raise
+
+        self._thread = threading.Thread(target=self._pump, daemon=True)
+        self._thread.start()
+
+    def _pump(self) -> None:
+        proc = self._process
+        if proc is None:
+            self._closed.set()
+            return
+        try:
+            stdin = proc.stdin
+            if stdin is None:
+                raise RuntimeError("encoder stdin unavailable")
+            while True:
+                try:
+                    chunk = self._queue.get(timeout=0.5)
+                except queue.Empty:
+                    if proc.poll() is not None:
+                        break
+                    continue
+
+                if chunk is None:
+                    self._queue.task_done()
+                    break
+
+                try:
+                    stdin.write(chunk)
+                    if hasattr(stdin, "flush"):
+                        stdin.flush()
+                    self._bytes_sent += len(chunk)
+                except Exception as exc:  # noqa: BLE001 - propagate failure
+                    self._error = exc
+                    break
+                finally:
+                    self._queue.task_done()
+        finally:
+            try:
+                if proc.stdin:
+                    proc.stdin.close()
+            except Exception:
+                pass
+            try:
+                self._stderr = proc.stderr.read() if proc.stderr else None
+            except Exception:
+                self._stderr = None
+            self._returncode = proc.wait()
+            self._closed.set()
+
+    def feed(self, chunk: bytes) -> bool:
+        if not chunk or self._process is None:
+            return False
+        try:
+            self._queue.put_nowait(bytes(chunk))
+            return True
+        except queue.Full:
+            self._dropped += 1
+            return False
+
+    def close(self, *, timeout: float | None = None) -> StreamingEncoderResult:
+        if self._process is None:
+            return StreamingEncoderResult(
+                partial_path=self.partial_path,
+                success=False,
+                returncode=None,
+                error=self._error,
+                stderr=None,
+                bytes_sent=self._bytes_sent,
+                dropped_chunks=self._dropped,
+            )
+
+        try:
+            self._queue.put_nowait(None)
+        except queue.Full:
+            # Fall back to blocking put; ensures sentinel eventually delivered
+            self._queue.put(None)
+
+        if self._thread is not None:
+            self._thread.join(timeout)
+
+        if self._process and self._process.poll() is None:
+            try:
+                self._process.wait(timeout=timeout)
+            except subprocess.TimeoutExpired:
+                self._process.kill()
+                self._returncode = self._process.wait()
+
+        success = self._error is None and (self._returncode or 0) == 0
+        stderr_text = None
+        if self._stderr:
+            try:
+                stderr_text = self._stderr.decode("utf-8", errors="ignore")
+            except Exception:
+                stderr_text = None
+
+        return StreamingEncoderResult(
+            partial_path=self.partial_path,
+            success=success,
+            returncode=self._returncode,
+            error=self._error,
+            stderr=stderr_text,
+            bytes_sent=self._bytes_sent,
+            dropped_chunks=self._dropped,
+        )
 
 # ---------- Async encoder worker ----------
 ENCODE_QUEUE: queue.Queue = queue.Queue()
@@ -470,14 +662,25 @@ class _EncoderWorker(threading.Thread):
                 job_id: int | None
                 wav_path: str
                 base_name: str
-                if isinstance(item, tuple) and len(item) == 3:
+                existing_opus: str | None = None
+                if isinstance(item, tuple) and len(item) == 4:
+                    job_id, wav_path, base_name, existing_opus = item
+                elif isinstance(item, tuple) and len(item) == 3:
                     job_id, wav_path, base_name = item
                 else:
                     job_id = None
-                    wav_path, base_name = item
+                    if isinstance(item, tuple):
+                        wav_path = item[0]
+                        base_name = item[1]
+                        if len(item) >= 3:
+                            existing_opus = item[2]
+                    else:
+                        wav_path, base_name = item  # type: ignore[assignment]
                 if job_id is not None:
                     ENCODING_STATUS.mark_started(job_id, base_name)
                 cmd = [ENCODER, wav_path, base_name]
+                if existing_opus:
+                    cmd.append(existing_opus)
                 try:
                     subprocess.run(cmd, capture_output=True, text=True, check=True)
                 except subprocess.CalledProcessError as exc:
@@ -508,15 +711,17 @@ def _enqueue_encode_job(
     base_name: str,
     *,
     source: str = "live",
+    existing_opus_path: str | None = None,
 ) -> int | None:
     if not tmp_wav_path or not base_name:
         return None
     _ensure_encoder_worker()
     job_id = ENCODING_STATUS.enqueue(base_name, source=source)
+    payload = (job_id, tmp_wav_path, base_name, existing_opus_path)
     try:
-        ENCODE_QUEUE.put_nowait((job_id, tmp_wav_path, base_name))
+        ENCODE_QUEUE.put_nowait(payload)
     except queue.Full:
-        ENCODE_QUEUE.put((job_id, tmp_wav_path, base_name))
+        ENCODE_QUEUE.put(payload)
     print(f"[segmenter] queued encode job for {base_name}", flush=True)
     return job_id
 
@@ -714,6 +919,10 @@ class TimelineRecorder:
         self.writer = _WriterWorker(self.audio_q, self.done_q, FLUSH_THRESHOLD)
         self.writer.start()
 
+        self._streaming_enabled = STREAMING_ENCODE_ENABLED
+        self._streaming_encoder: StreamingOpusEncoder | None = None
+        self._streaming_day_dir: str | None = None
+
         self._adaptive = AdaptiveRmsController(
             frame_ms=FRAME_MS,
             initial_linear_threshold=STATIC_RMS_THRESH,
@@ -774,6 +983,8 @@ class TimelineRecorder:
                     "current_rms": 0,
                     "event_duration_seconds": None,
                     "event_size_bytes": None,
+                    "partial_recording_path": None,
+                    "streaming_container_format": None,
                 },
             )
 
@@ -913,7 +1124,11 @@ class TimelineRecorder:
         return capturing, event, last_event, reason
 
     def _current_event_size(self) -> int | None:
-        path = self.tmp_wav_path
+        path = None
+        if self._streaming_encoder:
+            path = self._streaming_encoder.partial_path
+        if not path:
+            path = self.tmp_wav_path
         if not path:
             return None
         try:
@@ -953,6 +1168,14 @@ class TimelineRecorder:
                     else None
                 ),
                 "event_size_bytes": self._current_event_size() if capturing else None,
+                "partial_recording_path": (
+                    self._streaming_encoder.partial_path
+                    if capturing and self._streaming_encoder
+                    else None
+                ),
+                "streaming_container_format": (
+                    STREAMING_CONTAINER_FORMAT if capturing and self._streaming_encoder else None
+                ),
                 "filter_chain_avg_ms": round(self._filter_avg_ms, 3),
                 "filter_chain_peak_ms": round(self._filter_peak_ms, 3),
                 "filter_chain_avg_budget_ms": FILTER_CHAIN_AVG_BUDGET_MS,
@@ -1153,9 +1376,34 @@ class TimelineRecorder:
 
                 self._q_send(('open', self.base_name, self.tmp_wav_path))
 
+                if self._streaming_enabled:
+                    try:
+                        day = time.strftime("%Y%m%d")
+                        day_dir = os.path.join(REC_DIR, day)
+                        os.makedirs(day_dir, exist_ok=True)
+                        partial_path = os.path.join(
+                            day_dir,
+                            f"{self.base_name}{STREAMING_PARTIAL_SUFFIX}",
+                        )
+                        self._streaming_day_dir = day_dir
+                        self._streaming_encoder = StreamingOpusEncoder(
+                            partial_path,
+                            container_format=STREAMING_CONTAINER_FORMAT,
+                        )
+                        self._streaming_encoder.start()
+                    except Exception as exc:
+                        print(
+                            f"[segmenter] WARN: failed to start streaming encoder: {exc!r}",
+                            flush=True,
+                        )
+                        self._streaming_encoder = None
+                        self._streaming_day_dir = None
+
                 if self.prebuf:
                     for f in self.prebuf:
                         self._q_send(bytes(f))
+                        if self._streaming_encoder and not self._streaming_encoder.feed(bytes(f)):
+                            self.queue_drops += 1
                         self.frames_written += 1
                         self.sum_rms += rms(f)
                 self.prebuf.clear()
@@ -1177,10 +1425,21 @@ class TimelineRecorder:
                     "trigger_rms": self.trigger_rms,
                 }
                 if self._status_mode == "live":
+                    if self._streaming_encoder:
+                        event_status = dict(event_status)
+                        event_status["in_progress"] = True
+                        event_status["partial_recording_path"] = (
+                            self._streaming_encoder.partial_path
+                        )
+                        event_status["streaming_container_format"] = (
+                            STREAMING_CONTAINER_FORMAT
+                        )
                     self._update_capture_status(True, event=event_status)
             return
 
         self._q_send(bytes(buf))
+        if self._streaming_encoder and not self._streaming_encoder.feed(bytes(buf)):
+            self.queue_drops += 1
         self.frames_written += 1
         self.sum_rms += rms(proc_for_analysis)
         self.saw_voiced = voiced or self.saw_voiced
@@ -1198,6 +1457,32 @@ class TimelineRecorder:
         if self.frames_written <= 0 or not self.base_name:
             self._reset_event_state()
             return
+
+        streaming_result: StreamingEncoderResult | None = None
+        partial_stream_path: str | None = None
+        final_stream_path: str | None = None
+        day_dir = self._streaming_day_dir
+        if self._streaming_encoder:
+            try:
+                streaming_result = self._streaming_encoder.close(timeout=5.0)
+            except Exception as exc:
+                print(
+                    f"[segmenter] WARN: streaming encoder close failed: {exc!r}",
+                    flush=True,
+                )
+                streaming_result = StreamingEncoderResult(
+                    partial_path=self._streaming_encoder.partial_path,
+                    success=False,
+                    returncode=None,
+                    error=exc,
+                    stderr=None,
+                    bytes_sent=0,
+                    dropped_chunks=0,
+                )
+            finally:
+                self._streaming_encoder = None
+        if streaming_result:
+            partial_stream_path = streaming_result.partial_path
 
         if self.saw_voiced and self.saw_loud:
             etype_label = EVENT_TAGS["both"]
@@ -1233,10 +1518,42 @@ class TimelineRecorder:
             event_count = str(self.event_counter) if self.event_counter is not None else base.rsplit("_", 1)[-1]
             safe_etype = _sanitize_event_tag(etype_label)
             final_base = f"{event_ts}_{safe_etype}_RMS-{trigger_rms}_{event_count}"
+            streaming_succeeded = False
+            target_day_dir = day_dir or os.path.join(REC_DIR, day)
+            os.makedirs(target_day_dir, exist_ok=True)
+            final_opus_path = os.path.join(target_day_dir, f"{final_base}{STREAMING_EXTENSION}")
+            if streaming_result and streaming_result.success and partial_stream_path and os.path.exists(partial_stream_path):
+                try:
+                    os.replace(partial_stream_path, final_opus_path)
+                    streaming_succeeded = True
+                    final_stream_path = final_opus_path
+                    print(
+                        f"[segmenter] Streaming encode finalized at {final_opus_path}",
+                        flush=True,
+                    )
+                except Exception as exc:
+                    print(
+                        f"[segmenter] WARN: failed to finalize streaming output: {exc!r}",
+                        flush=True,
+                    )
+                    streaming_succeeded = False
+            elif streaming_result and not streaming_result.success:
+                if streaming_result.stderr:
+                    print(
+                        f"[segmenter] WARN: streaming encoder stderr: {streaming_result.stderr.strip()}",
+                        flush=True,
+                    )
+            if not streaming_succeeded and partial_stream_path and os.path.exists(partial_stream_path):
+                try:
+                    os.unlink(partial_stream_path)
+                except OSError:
+                    pass
+
             job_id = _enqueue_encode_job(
                 tmp_wav_path,
                 final_base,
                 source=self._recording_source,
+                existing_opus_path=final_stream_path if streaming_succeeded else None,
             )
             if job_id is not None:
                 self._encode_jobs.append(job_id)
@@ -1250,7 +1567,9 @@ class TimelineRecorder:
                         ),
                         flush=True,
                     )
+        self._streaming_day_dir = None
 
+        if tmp_wav_path and base:
             last_event_status = {
                 "base_name": final_base,
                 "started_at": self.event_timestamp,
@@ -1274,12 +1593,21 @@ class TimelineRecorder:
             }
 
         last_event_status["end_reason"] = reason
+        last_event_status["in_progress"] = False
+        if final_stream_path:
+            last_event_status["recording_path"] = final_stream_path
+            last_event_status["streaming_container_format"] = STREAMING_CONTAINER_FORMAT
         if self._status_mode == "live":
             self._update_capture_status(
                 False,
                 last_event=last_event_status,
                 reason=reason,
-                extra={"event_duration_seconds": None, "event_size_bytes": None},
+                extra={
+                    "event_duration_seconds": None,
+                    "event_size_bytes": None,
+                    "partial_recording_path": None,
+                    "streaming_container_format": None,
+                },
             )
         if NOTIFIER:
             try:
@@ -1292,6 +1620,27 @@ class TimelineRecorder:
         self._reset_event_state()
 
     def _reset_event_state(self):
+        if self._streaming_encoder:
+            result: StreamingEncoderResult | None = None
+            try:
+                result = self._streaming_encoder.close(timeout=1.0)
+            except Exception:
+                result = StreamingEncoderResult(
+                    partial_path=self._streaming_encoder.partial_path,
+                    success=False,
+                    returncode=None,
+                    error=None,
+                    stderr=None,
+                    bytes_sent=0,
+                    dropped_chunks=0,
+                )
+            if result and result.partial_path and os.path.exists(result.partial_path):
+                try:
+                    os.unlink(result.partial_path)
+                except OSError:
+                    pass
+        self._streaming_encoder = None
+        self._streaming_day_dir = None
         self.active = False
         self.post_count = 0
         self.recent_active.clear()
@@ -1335,6 +1684,8 @@ class TimelineRecorder:
                     "current_rms": 0,
                     "event_duration_seconds": None,
                     "event_size_bytes": None,
+                    "partial_recording_path": None,
+                    "streaming_container_format": None,
                 },
             )
 

--- a/lib/web_streamer.py
+++ b/lib/web_streamer.py
@@ -2871,6 +2871,15 @@ def build_app() -> web.Application:
             trigger_rms = event_payload.get("trigger_rms")
             if isinstance(trigger_rms, (int, float)):
                 event["trigger_rms"] = float(trigger_rms)
+            partial_path = event_payload.get("partial_recording_path")
+            if isinstance(partial_path, str) and partial_path:
+                event["partial_recording_path"] = partial_path
+            in_progress = event_payload.get("in_progress")
+            if isinstance(in_progress, bool):
+                event["in_progress"] = in_progress
+            streaming_format = event_payload.get("streaming_container_format")
+            if isinstance(streaming_format, str) and streaming_format:
+                event["streaming_container_format"] = streaming_format
             if event:
                 status["event"] = event
 
@@ -2901,6 +2910,15 @@ def build_app() -> web.Application:
             etype = last_payload.get("etype")
             if isinstance(etype, str) and etype:
                 last_event["etype"] = etype
+            recording_path = last_payload.get("recording_path")
+            if isinstance(recording_path, str) and recording_path:
+                last_event["recording_path"] = recording_path
+            last_in_progress = last_payload.get("in_progress")
+            if isinstance(last_in_progress, bool):
+                last_event["in_progress"] = last_in_progress
+            last_streaming_format = last_payload.get("streaming_container_format")
+            if isinstance(last_streaming_format, str) and last_streaming_format:
+                last_event["streaming_container_format"] = last_streaming_format
             if last_event:
                 status["last_event"] = last_event
 
@@ -2947,6 +2965,14 @@ def build_app() -> web.Application:
         event_size_bytes = raw.get("event_size_bytes")
         if isinstance(event_size_bytes, (int, float)) and math.isfinite(event_size_bytes):
             status["event_size_bytes"] = max(0, int(event_size_bytes))
+
+        partial_recording_path = raw.get("partial_recording_path")
+        if isinstance(partial_recording_path, str) and partial_recording_path:
+            status["partial_recording_path"] = partial_recording_path
+
+        streaming_format = raw.get("streaming_container_format")
+        if isinstance(streaming_format, str) and streaming_format:
+            status["streaming_container_format"] = streaming_format
 
         avg_ms = raw.get("filter_chain_avg_ms")
         if isinstance(avg_ms, (int, float)) and math.isfinite(avg_ms):

--- a/tests/test_streaming_encoder.py
+++ b/tests/test_streaming_encoder.py
@@ -1,0 +1,34 @@
+import sys
+from pathlib import Path
+
+from lib.segmenter import StreamingOpusEncoder
+
+
+def test_streaming_encoder_writes_chunks(tmp_path: Path):
+    partial_path = tmp_path / "stream.partial.opus"
+    encoder = StreamingOpusEncoder(str(partial_path))
+    command = [
+        sys.executable,
+        "-c",
+        (
+            "import pathlib, sys; "
+            "dest = pathlib.Path(sys.argv[1]); "
+            "data = sys.stdin.buffer.read(); "
+            "dest.write_bytes(data)"
+        ),
+        str(partial_path),
+    ]
+    encoder.start(command=command)
+
+    assert encoder.feed(b"abc") is True
+    assert encoder.feed(b"123") is True
+
+    result = encoder.close(timeout=2.0)
+    assert result.success
+    assert result.partial_path == str(partial_path)
+    assert result.bytes_sent == 6
+    assert result.dropped_chunks == 0
+    assert partial_path.exists()
+    with open(partial_path, "rb") as handle:
+        assert handle.read() == b"abc123"
+


### PR DESCRIPTION
## Summary
- add a StreamingOpusEncoder helper and route live frames through it when the new segmenter.streaming_encode flag is enabled
- reuse existing encode workflow by skipping ffmpeg when a streaming .partial.opus is finalized and expose the metadata via segmenter_status.json and the web API
- document the configuration toggle and cover the helper with a unit test

## Testing
- DEV=1 pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68dd316f83608327a2711cbbc5601f65