### PR TITLE
Restore recycle bin modal scrolling

### DIFF
--- a/lib/webui/static/css/dashboard.css
+++ b/lib/webui/static/css/dashboard.css
@@ -1599,6 +1599,7 @@ button.small {
   opacity: 0;
   visibility: hidden;
   transition: opacity 0.2s ease, visibility 0.2s ease;
+  overflow-y: auto;
 }
 
 .recycle-bin-modal[hidden] {


### PR DESCRIPTION
## Summary
- allow the recycle bin modal overlay to scroll vertically when its contents exceed the viewport

## Testing
- DEV=1 pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68dd6154513883279ddc61f28b665847