### PR TITLE
Fix live capture status updates and recycle bin scrolling

### DIFF
--- a/lib/segmenter.py
+++ b/lib/segmenter.py
@@ -1081,6 +1081,8 @@ class TimelineRecorder:
                 "service_running",
                 "event_duration_seconds",
                 "event_size_bytes",
+                "partial_recording_path",
+                "streaming_container_format",
                 "encoding",
             )
             if extra and self._status_mode == "live":

--- a/lib/webui/static/css/dashboard.css
+++ b/lib/webui/static/css/dashboard.css
@@ -2031,10 +2031,13 @@ body[data-scroll-locked="true"] {
   flex: 1 1 auto;
   gap: 1.5rem;
   margin-top: 1rem;
-  overflow: hidden;
+  overflow-x: hidden;
+  overflow-y: auto;
   flex-wrap: wrap;
   align-items: stretch;
   min-height: 0;
+  overscroll-behavior: contain;
+  -webkit-overflow-scrolling: touch;
 }
 
 .recycle-bin-list {
@@ -2054,6 +2057,9 @@ body[data-scroll-locked="true"] {
   flex: 1 1 auto;
   min-height: 0;
   padding: 0;
+  max-height: 100%;
+  overscroll-behavior: contain;
+  -webkit-overflow-scrolling: touch;
 }
 
 .recycle-bin-table {


### PR DESCRIPTION
## Summary
- ensure the segmenter writes status updates when the partial recording path or streaming container changes so the dashboard can surface the live recording entry
- adjust the recycle bin modal styling to allow scrolling long lists on both desktop and touch devices

## Testing
- export DEV=1 && pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68dd660dcdbc8327b5ff99c08922da33