### PR TITLE
Add recycle bin waveform preview support

### DIFF
--- a/lib/webui/static/css/dashboard.css
+++ b/lib/webui/static/css/dashboard.css
@@ -1032,6 +1032,10 @@ button.small {
   margin-top: 1rem;
 }
 
+.player-card[data-context="recycle-bin"] .clipper-container {
+  display: none !important;
+}
+
 .player-row {
   background: transparent;
 }
@@ -2028,21 +2032,20 @@ body[data-scroll-locked="true"] {
 
 .recycle-bin-body {
   display: flex;
+  flex-direction: column;
   flex: 1 1 auto;
   gap: 1.5rem;
   margin-top: 1rem;
   overflow-x: hidden;
   overflow-y: auto;
-  flex-wrap: wrap;
-  align-items: stretch;
   min-height: 0;
   overscroll-behavior: contain;
   -webkit-overflow-scrolling: touch;
 }
 
 .recycle-bin-list {
-  flex: 1 1 60%;
-  min-width: 340px;
+  flex: 1 1 auto;
+  min-width: 0;
   display: flex;
   flex-direction: column;
   gap: 0.75rem;
@@ -2097,6 +2100,30 @@ body[data-scroll-locked="true"] {
   background: rgba(56, 189, 248, 0.12);
 }
 
+.recycle-bin-table tbody tr[data-active="true"] {
+  background: rgba(56, 189, 248, 0.18);
+}
+
+.recycle-bin-table tbody tr.recycle-bin-player-row {
+  cursor: default;
+  background: transparent;
+}
+
+.recycle-bin-player-row > td {
+  padding: 1rem;
+  border-bottom: none;
+  background: var(--surface-soft);
+  border-radius: 0 0 1rem 1rem;
+}
+
+.recycle-bin-player-cell {
+  padding: 0 !important;
+}
+
+.recycle-bin-player-cell .player-card {
+  margin: 0;
+}
+
 .recycle-bin-table tbody tr[data-restorable="false"] {
   opacity: 0.65;
 }
@@ -2127,66 +2154,6 @@ body[data-scroll-locked="true"] {
   background: var(--surface-faint);
 }
 
-.recycle-bin-preview {
-  flex: 1 1 40%;
-  min-width: 320px;
-  background: var(--surface-soft);
-  border: 1px solid var(--table-border);
-  border-radius: 1rem;
-  padding: 1.25rem;
-  display: flex;
-  flex-direction: column;
-  gap: 0.75rem;
-  min-height: 0;
-  overflow: auto;
-}
-
-.recycle-bin-preview h3 {
-  margin: 0;
-  font-size: 1rem;
-}
-
-.recycle-bin-preview-path {
-  margin: 0;
-  font-family: "JetBrains Mono", "Fira Mono", "SFMono-Regular", "Consolas", monospace;
-  font-size: 0.8rem;
-  color: var(--text-muted);
-  word-break: break-word;
-}
-
-.recycle-bin-preview-meta {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
-  gap: 0.5rem;
-  margin: 0;
-}
-
-.recycle-bin-preview-meta div {
-  display: flex;
-  flex-direction: column;
-  gap: 0.15rem;
-}
-
-.recycle-bin-preview-meta dt {
-  font-size: 0.75rem;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
-  color: var(--text-muted);
-  margin: 0;
-}
-
-.recycle-bin-preview-meta dd {
-  margin: 0;
-  font-size: 0.95rem;
-  font-weight: 600;
-}
-
-.recycle-bin-audio {
-  width: 100%;
-  border-radius: 0.75rem;
-  background: var(--surface-faint);
-}
-
 .recycle-bin-conflict {
   display: inline-flex;
   align-items: center;
@@ -2200,14 +2167,8 @@ body[data-scroll-locked="true"] {
 }
 
 @media (max-width: 900px) {
-  .recycle-bin-body {
-    flex-direction: column;
-  }
-
-  .recycle-bin-list,
-  .recycle-bin-preview {
-    flex: 1 1 auto;
-    min-width: 100%;
+  .recycle-bin-table-wrapper {
+    max-height: none;
   }
 }
 

--- a/lib/webui/static/js/dashboard.js
+++ b/lib/webui/static/js/dashboard.js
@@ -205,7 +205,7 @@ const state = {
   partialRecord: null,
   lastUpdated: null,
   sort: { key: "modified", direction: "asc" },
-  storage: { recordings: 0, total: null, free: null, diskUsed: null },
+  storage: { recordings: 0, recycleBin: 0, total: null, free: null, diskUsed: null },
   recycleBin: {
     open: false,
     items: [],
@@ -325,12 +325,7 @@ const dom = {
   recycleBinToggleAll: document.getElementById("recycle-bin-toggle-all"),
   recycleBinTableBody: document.getElementById("recycle-bin-tbody"),
   recycleBinEmpty: document.getElementById("recycle-bin-empty"),
-  recycleBinAudio: document.getElementById("recycle-bin-audio"),
-  recycleBinPreviewTitle: document.getElementById("recycle-bin-preview-title"),
-  recycleBinPreviewPath: document.getElementById("recycle-bin-preview-path"),
-  recycleBinPreviewTime: document.getElementById("recycle-bin-preview-time"),
-  recycleBinPreviewSize: document.getElementById("recycle-bin-preview-size"),
-  recycleBinPreviewDuration: document.getElementById("recycle-bin-preview-duration"),
+  recycleBinTable: document.getElementById("recycle-bin-table"),
   liveToggle: document.getElementById("live-stream-toggle"),
   liveCard: document.getElementById("live-stream-card"),
   livePanel: document.getElementById("live-stream-panel"),
@@ -1004,6 +999,14 @@ function findInteractiveElement(target, event = null) {
   return null;
 }
 
+function escapeSelector(value) {
+  const text = String(value);
+  if (typeof CSS !== "undefined" && typeof CSS.escape === "function") {
+    return CSS.escape(text);
+  }
+  return text.replace(/[^a-zA-Z0-9_-]/g, (char) => `\\${char}`);
+}
+
 let pendingSelectionPath = null;
 const renameDialogState = {
   open: false,
@@ -1081,6 +1084,7 @@ const playerPlacement = {
   anchorPath: null,
   desktopRowElement: null,
   mobileCell: null,
+  recycleBinRowElement: null,
 };
 
 const playerCardHome = dom.playerCard ? dom.playerCard.parentElement : null;
@@ -1175,6 +1179,8 @@ const recycleBinDialogState = {
   open: false,
   previouslyFocused: null,
   keydownHandler: null,
+  previewing: false,
+  previousRecord: null,
 };
 
 
@@ -2888,6 +2894,36 @@ function recordingUrl(path, { download = false } = {}) {
   return apiPath(`/recordings/${encoded}${suffix}`);
 }
 
+function recordAudioUrl(record, { download = false } = {}) {
+  if (isRecycleBinRecord(record)) {
+    return recycleBinAudioUrl(record.recycleBinId, { download });
+  }
+  if (record && typeof record.path === "string" && record.path) {
+    return recordingUrl(record.path, { download });
+  }
+  return "";
+}
+
+function recordWaveformUrl(record) {
+  if (!record) {
+    return "";
+  }
+  if (isRecycleBinRecord(record)) {
+    if (!record.waveform_available) {
+      return "";
+    }
+    const identifier =
+      typeof record.waveform_path === "string" && record.waveform_path
+        ? record.waveform_path
+        : record.recycleBinId;
+    return recycleBinWaveformUrl(identifier);
+  }
+  if (typeof record.waveform_path === "string" && record.waveform_path) {
+    return recordingUrl(record.waveform_path);
+  }
+  return "";
+}
+
 function populateFilters() {
   if (dom.filterSearch) {
     dom.filterSearch.value = state.filters.search;
@@ -3256,13 +3292,22 @@ function updatePlayerActions(record) {
 
   dom.playerMetaActions.hidden = false;
   const isPartial = Boolean(record.isPartial);
+  const isRecycle = isRecycleBinRecord(record);
+  if (isRecycle) {
+    dom.playerMetaActions.hidden = true;
+  }
   if (dom.playerDownload) {
     if (isPartial) {
       dom.playerDownload.removeAttribute("href");
       dom.playerDownload.removeAttribute("download");
       dom.playerDownload.setAttribute("aria-disabled", "true");
     } else {
-      dom.playerDownload.href = recordingUrl(record.path, { download: true });
+      const downloadUrl = recordAudioUrl(record, { download: true });
+      if (downloadUrl) {
+        dom.playerDownload.href = downloadUrl;
+      } else {
+        dom.playerDownload.removeAttribute("href");
+      }
       const baseName =
         typeof record.name === "string" && record.name ? record.name : record.path;
       const extension =
@@ -3274,10 +3319,11 @@ function updatePlayerActions(record) {
     }
   }
   if (dom.playerRename) {
-    dom.playerRename.disabled = isPartial || Boolean(renameDialogState.pending);
+    dom.playerRename.disabled =
+      isPartial || isRecycle || Boolean(renameDialogState.pending);
   }
   if (dom.playerDelete) {
-    dom.playerDelete.disabled = isPartial;
+    dom.playerDelete.disabled = isPartial || isRecycle;
   }
 }
 
@@ -3298,6 +3344,7 @@ function updatePlayerMeta(record) {
   }
 
   const isPartial = Boolean(record.isPartial);
+  const isRecycle = isRecycleBinRecord(record);
   const details = [];
   if (isPartial) {
     details.push("Recording in progress");
@@ -3305,17 +3352,38 @@ function updatePlayerMeta(record) {
   const extText = record.extension ? `.${record.extension}` : "";
   const nameText =
     typeof record.name === "string" && record.name ? record.name : record.path;
-  details.push(`${nameText}${extText}`);
-  if (record.day) {
-    details.push(record.day);
+  if (isRecycle) {
+    const baseDetails = [];
+    const displayName = nameText || record.recycleBinId || "Recycle bin entry";
+    baseDetails.push(`${displayName}${extText}`);
+    if (record.original_path) {
+      baseDetails.push(`Original: ${record.original_path}`);
+    }
+    const deletedText = formatIsoDateTime(record.deleted_at) || formatDate(record.deleted_at_epoch);
+    if (deletedText) {
+      baseDetails.push(`Deleted ${deletedText}`);
+    }
+    baseDetails.push(formatBytes(record.size_bytes));
+    if (Number.isFinite(record.duration_seconds) && record.duration_seconds > 0) {
+      baseDetails.push(formatDuration(record.duration_seconds));
+    }
+    if (record.restorable === false) {
+      baseDetails.push("Destination in use");
+    }
+    metaTarget.textContent = `Recycle bin preview: ${baseDetails.join(" • ")}`;
+  } else {
+    details.push(`${nameText}${extText}`);
+    if (record.day) {
+      details.push(record.day);
+    }
+    const startSeconds = getRecordStartSeconds(record);
+    details.push(formatDate(startSeconds !== null ? startSeconds : record.modified));
+    details.push(formatBytes(record.size_bytes));
+    if (Number.isFinite(record.duration_seconds) && record.duration_seconds > 0) {
+      details.push(formatDuration(record.duration_seconds));
+    }
+    metaTarget.textContent = `Now playing: ${details.join(" • ")}`;
   }
-  const startSeconds = getRecordStartSeconds(record);
-  details.push(formatDate(startSeconds !== null ? startSeconds : record.modified));
-  details.push(formatBytes(record.size_bytes));
-  if (Number.isFinite(record.duration_seconds) && record.duration_seconds > 0) {
-    details.push(formatDuration(record.duration_seconds));
-  }
-  metaTarget.textContent = `Now playing: ${details.join(" • ")}`;
   updatePlayerActions(record);
 }
 
@@ -3341,6 +3409,22 @@ function getTableColumnCount() {
     return headerRow.children.length;
   }
   const sampleRow = dom.tableBody ? dom.tableBody.querySelector("tr[data-path]") : null;
+  if (sampleRow && sampleRow.children.length > 0) {
+    return sampleRow.children.length;
+  }
+  return 1;
+}
+
+function getRecycleBinColumnCount() {
+  if (dom.recycleBinTable && dom.recycleBinTable.tHead) {
+    const headerRow = dom.recycleBinTable.tHead.rows[0];
+    if (headerRow && headerRow.children.length > 0) {
+      return headerRow.children.length;
+    }
+  }
+  const sampleRow = dom.recycleBinTableBody
+    ? dom.recycleBinTableBody.querySelector("tr[data-id]")
+    : null;
   if (sampleRow && sampleRow.children.length > 0) {
     return sampleRow.children.length;
   }
@@ -3385,12 +3469,16 @@ function detachPlayerCard() {
   if (playerPlacement.mobileCell && playerPlacement.mobileCell.parentElement) {
     playerPlacement.mobileCell.parentElement.removeChild(playerPlacement.mobileCell);
   }
+  if (playerPlacement.recycleBinRowElement && playerPlacement.recycleBinRowElement.parentElement) {
+    playerPlacement.recycleBinRowElement.parentElement.removeChild(playerPlacement.recycleBinRowElement);
+  }
   dom.playerCard.hidden = true;
   dom.playerCard.dataset.active = "false";
   playerPlacement.mode = "hidden";
   playerPlacement.anchorPath = null;
   playerPlacement.desktopRowElement = null;
   playerPlacement.mobileCell = null;
+  playerPlacement.recycleBinRowElement = null;
 }
 
 function ensureDesktopRow() {
@@ -3415,15 +3503,69 @@ function ensureDesktopRow() {
   return playerPlacement.desktopRowElement;
 }
 
+function ensureRecycleBinRow() {
+  if (!dom.playerCard) {
+    return null;
+  }
+  if (!playerPlacement.recycleBinRowElement) {
+    const row = document.createElement("tr");
+    row.className = "player-row recycle-bin-player-row";
+    const cell = document.createElement("td");
+    cell.className = "player-cell recycle-bin-player-cell";
+    row.append(cell);
+    playerPlacement.recycleBinRowElement = row;
+  }
+  const cell = playerPlacement.recycleBinRowElement.firstElementChild;
+  if (cell instanceof HTMLTableCellElement) {
+    cell.colSpan = getRecycleBinColumnCount();
+    if (!cell.contains(dom.playerCard)) {
+      cell.append(dom.playerCard);
+    }
+  }
+  return playerPlacement.recycleBinRowElement;
+}
+
 function placePlayerCard(record, sourceRow = null) {
   if (!dom.playerCard || !record) {
     return;
   }
-  const targetRow = sourceRow ?? findRowForRecord(record);
+  const isRecycle = isRecycleBinRecord(record);
+  const targetRow = sourceRow ?? (isRecycle ? getRecycleBinRow(record.recycleBinId) : findRowForRecord(record));
   if (!targetRow || !targetRow.parentElement) {
     detachPlayerCard();
     return;
   }
+
+  if (isRecycle) {
+    const row = ensureRecycleBinRow();
+    if (!row) {
+      return;
+    }
+    if (playerPlacement.mobileCell && playerPlacement.mobileCell.parentElement) {
+      playerPlacement.mobileCell.parentElement.removeChild(playerPlacement.mobileCell);
+      playerPlacement.mobileCell = null;
+    }
+    if (playerPlacement.desktopRowElement && playerPlacement.desktopRowElement.parentElement) {
+      playerPlacement.desktopRowElement.parentElement.removeChild(playerPlacement.desktopRowElement);
+    }
+    const parent = targetRow.parentElement;
+    const nextSibling = targetRow.nextSibling;
+    if (nextSibling) {
+      parent.insertBefore(row, nextSibling);
+    } else {
+      parent.append(row);
+    }
+    dom.playerCard.hidden = false;
+    dom.playerCard.dataset.active = "true";
+    playerPlacement.mode = "recycle-bin";
+    playerPlacement.anchorPath = record.path;
+    return;
+  }
+
+  if (playerPlacement.recycleBinRowElement && playerPlacement.recycleBinRowElement.parentElement) {
+    playerPlacement.recycleBinRowElement.parentElement.removeChild(playerPlacement.recycleBinRowElement);
+  }
+  playerPlacement.recycleBinRowElement = null;
 
   const isMobileLayout = layoutIsMobile();
   if (isMobileLayout) {
@@ -3518,6 +3660,7 @@ function setNowPlaying(record, options = {}) {
   const { autoplay = true, resetToStart = true, sourceRow = null } = options;
   const previous = state.current;
   const sameRecord = Boolean(previous && record && previous.path === record.path);
+  const recordIsRecycle = isRecycleBinRecord(record);
 
   cancelKeyboardJog();
 
@@ -3548,9 +3691,15 @@ function setNowPlaying(record, options = {}) {
     dom.player.removeAttribute("src");
     resetWaveform();
     applyNowPlayingHighlight();
+    if (dom.playerCard) {
+      dom.playerCard.dataset.context = "recordings";
+    }
     return;
   }
 
+  if (dom.playerCard) {
+    dom.playerCard.dataset.context = recordIsRecycle ? "recycle-bin" : "recordings";
+  }
   ensurePreviewSectionOrder();
   updatePlayerMeta(record);
   if (!sameRecord) {
@@ -3586,8 +3735,12 @@ function setNowPlaying(record, options = {}) {
   playbackState.resetOnLoad = resetToStart;
   playbackState.enforcePauseOnLoad = !autoplay;
 
-  const url = recordingUrl(record.path);
-  dom.player.src = url;
+  const url = recordAudioUrl(record);
+  if (url) {
+    dom.player.src = url;
+  } else {
+    dom.player.removeAttribute("src");
+  }
   dom.player.load();
   if (resetToStart) {
     try {
@@ -3759,7 +3912,7 @@ function renderRecords() {
       actionWrapper.append(statusLabel);
     } else {
       const downloadLink = document.createElement("a");
-      downloadLink.href = recordingUrl(record.path, { download: true });
+      downloadLink.href = recordAudioUrl(record, { download: true });
       downloadLink.textContent = "Download";
       downloadLink.setAttribute(
         "download",
@@ -3837,6 +3990,10 @@ function updateStats() {
   const recordingsUsed = Number.isFinite(state.storage.recordings)
     ? state.storage.recordings
     : 0;
+  const recycleBinUsed = Number.isFinite(state.storage.recycleBin)
+    ? state.storage.recycleBin
+    : 0;
+  const totalUsed = recordingsUsed + recycleBinUsed;
   const diskTotal = Number.isFinite(state.storage.total) && state.storage.total > 0
     ? state.storage.total
     : null;
@@ -3849,14 +4006,14 @@ function updateStats() {
 
   const hasCapacity = diskTotal !== null || diskFree !== null;
   const effectiveTotal = hasCapacity
-    ? diskTotal ?? recordingsUsed + Math.max(diskFree ?? 0, 0)
+    ? diskTotal ?? totalUsed + Math.max(diskFree ?? 0, 0)
     : null;
   if (hasCapacity && Number.isFinite(effectiveTotal) && effectiveTotal > 0) {
-    dom.storageUsageText.textContent = `${formatBytes(recordingsUsed)} of ${formatBytes(effectiveTotal)} available`;
+    dom.storageUsageText.textContent = `${formatBytes(totalUsed)} of ${formatBytes(effectiveTotal)} available`;
   } else if (hasCapacity) {
-    dom.storageUsageText.textContent = `${formatBytes(recordingsUsed)} of ${formatBytes(Math.max(recordingsUsed, 0))} available`;
+    dom.storageUsageText.textContent = `${formatBytes(totalUsed)} of ${formatBytes(Math.max(totalUsed, 0))} available`;
   } else {
-    dom.storageUsageText.textContent = formatBytes(recordingsUsed);
+    dom.storageUsageText.textContent = formatBytes(totalUsed);
   }
 
   let freeHint = diskFree;
@@ -3864,17 +4021,21 @@ function updateStats() {
     if (diskUsed !== null) {
       freeHint = Math.max(diskTotal - diskUsed, 0);
     } else {
-      freeHint = Math.max(diskTotal - recordingsUsed, 0);
+      freeHint = Math.max(diskTotal - totalUsed, 0);
     }
   }
   if (Number.isFinite(freeHint)) {
-    dom.storageHint.textContent = `Free space: ${formatBytes(freeHint)}`;
+    const parts = [`Free space: ${formatBytes(freeHint)}`];
+    if (recycleBinUsed > 0) {
+      parts.push(`Recycle bin: ${formatBytes(recycleBinUsed)}`);
+    }
+    dom.storageHint.textContent = parts.join(" • ");
   } else {
     dom.storageHint.textContent = "Free space: --";
   }
 
   const progress = hasCapacity && Number.isFinite(effectiveTotal) && effectiveTotal > 0
-    ? clamp((recordingsUsed / effectiveTotal) * 100, 0, 100)
+    ? clamp((totalUsed / effectiveTotal) * 100, 0, 100)
     : 0;
   dom.storageProgress.style.width = `${progress}%`;
   if (state.lastUpdated) {
@@ -4530,6 +4691,23 @@ function updateClipperUI({ updateInputs = true, updateName = true } = {}) {
 }
 
 function initializeClipper(record) {
+  if (isRecycleBinRecord(record)) {
+    clipperState.durationSeconds = null;
+    clipperState.startSeconds = 0;
+    clipperState.endSeconds = 0;
+    clipperState.busy = false;
+    clipperState.status = "";
+    clipperState.statusState = "idle";
+    clipperState.nameDirty = false;
+    clipperState.lastRecordPath = null;
+    clipperState.overwriteExisting = true;
+    if (dom.clipperOverwriteToggle) {
+      dom.clipperOverwriteToggle.checked = true;
+    }
+    setClipperVisible(false);
+    updateClipperStatusElement();
+    return;
+  }
   const duration = record ? toFiniteOrNull(record.duration_seconds) : null;
   if (!Number.isFinite(duration) || duration === null || duration < MIN_CLIP_DURATION_SECONDS) {
     clipperState.durationSeconds = null;
@@ -4972,11 +5150,12 @@ async function loadWaveform(record) {
   if (!dom.waveformContainer || !dom.waveformEmpty) {
     return;
   }
-  if (!record || !record.path) {
+  if (!record) {
     resetWaveform();
     return;
   }
-  if (!record.waveform_path) {
+  const waveformUrl = recordWaveformUrl(record);
+  if (!waveformUrl) {
     resetWaveform();
     if (dom.waveformEmpty) {
       dom.waveformEmpty.textContent = "Waveform unavailable for this recording.";
@@ -5011,7 +5190,7 @@ async function loadWaveform(record) {
   hideWaveformRms();
 
   try {
-    const response = await fetch(recordingUrl(record.waveform_path), {
+    const response = await fetch(waveformUrl, {
       cache: "no-store",
       signal: controller.signal,
     });
@@ -5498,6 +5677,50 @@ function selectAdjacentRecord(offset) {
   return true;
 }
 
+function selectAdjacentRecycleBinItem(offset) {
+  if (!Number.isFinite(offset) || offset === 0) {
+    return false;
+  }
+  const items = state.recycleBin.items;
+  if (!Array.isArray(items) || items.length === 0) {
+    return false;
+  }
+
+  const currentId = state.recycleBin.activeId;
+  let index = -1;
+  if (typeof currentId === "string" && currentId) {
+    index = items.findIndex((entry) => entry && entry.id === currentId);
+  }
+
+  let nextIndex;
+  if (index === -1) {
+    nextIndex = offset > 0 ? 0 : items.length - 1;
+  } else {
+    nextIndex = clamp(index + offset, 0, items.length - 1);
+  }
+
+  if (nextIndex === index || nextIndex < 0 || nextIndex >= items.length) {
+    return false;
+  }
+
+  const nextItem = items[nextIndex];
+  if (!nextItem || typeof nextItem.id !== "string" || !nextItem.id) {
+    return false;
+  }
+  state.recycleBin.selected = new Set([nextItem.id]);
+  state.recycleBin.activeId = nextItem.id;
+  renderRecycleBinItems();
+  const row = getRecycleBinRow(nextItem.id);
+  if (row && typeof row.scrollIntoView === "function") {
+    try {
+      row.scrollIntoView({ block: "nearest" });
+    } catch (error) {
+      /* ignore scrolling errors */
+    }
+  }
+  return true;
+}
+
 function handlePreviewShortcutKeydown(event) {
   const isEscape =
     event.key === "Escape" || event.code === "Escape" || event.key === "Esc";
@@ -5572,6 +5795,13 @@ async function handleTransportKeydown(event) {
     return;
   }
 
+  if (state.recycleBin.open) {
+    const handled = handleRecycleBinTransportKeydown(event);
+    if (handled) {
+      return;
+    }
+  }
+
   if (handlePreviewShortcutKeydown(event)) {
     return;
   }
@@ -5622,6 +5852,26 @@ async function handleTransportKeydown(event) {
     }
     await requestRecordDeletion(state.current, { bypassConfirm: event.shiftKey });
   }
+}
+
+function handleRecycleBinTransportKeydown(event) {
+  if (event.defaultPrevented || event.ctrlKey || event.metaKey || event.altKey) {
+    return false;
+  }
+  const isUp = isArrowKey(event, "ArrowUp");
+  const isDown = isArrowKey(event, "ArrowDown");
+  if (!isUp && !isDown) {
+    return false;
+  }
+  if (shouldIgnoreSpacebarTarget(event.target)) {
+    return false;
+  }
+  const moved = selectAdjacentRecycleBinItem(isDown ? 1 : -1);
+  if (moved) {
+    event.preventDefault();
+    return true;
+  }
+  return false;
 }
 
 function handleTransportKeyup(event) {
@@ -5823,6 +6073,7 @@ async function fetchRecordings(options = {}) {
     state.total = total;
     state.filteredSize = totalSize;
     state.storage.recordings = numericValue(payload.recordings_total_bytes, totalSize);
+    state.storage.recycleBin = numericValue(payload.recycle_bin_total_bytes, 0);
     state.storage.total = toFiniteOrNull(payload.storage_total_bytes);
     state.storage.free = toFiniteOrNull(payload.storage_free_bytes);
     state.storage.diskUsed = toFiniteOrNull(payload.storage_used_bytes);
@@ -9333,6 +9584,8 @@ function openRecycleBinModal(options = {}) {
   }
   recycleBinDialogState.open = true;
   state.recycleBin.open = true;
+  recycleBinDialogState.previewing = false;
+  recycleBinDialogState.previousRecord = null;
   recycleBinDialogState.previouslyFocused =
     document.activeElement instanceof HTMLElement ? document.activeElement : null;
   setRecycleBinModalVisible(true);
@@ -9355,16 +9608,7 @@ function closeRecycleBinModal(options = {}) {
   if (dom.recycleBinOpen) {
     dom.recycleBinOpen.setAttribute("aria-expanded", "false");
   }
-  if (dom.recycleBinAudio) {
-    try {
-      dom.recycleBinAudio.pause();
-    } catch (error) {
-      console.warn("Unable to pause recycle bin audio", error);
-    }
-    dom.recycleBinAudio.removeAttribute("src");
-    dom.recycleBinAudio.load();
-    delete dom.recycleBinAudio.dataset.entryId;
-  }
+  restoreRecycleBinPreview();
   const previous = recycleBinDialogState.previouslyFocused;
   recycleBinDialogState.previouslyFocused = null;
   if (restoreFocus && previous && typeof previous.focus === "function") {
@@ -9382,6 +9626,97 @@ function getRecycleBinItem(id) {
     }
   }
   return null;
+}
+
+function isRecycleBinRecord(record) {
+  return Boolean(
+    record &&
+      typeof record === "object" &&
+      record.source === "recycle-bin" &&
+      typeof record.recycleBinId === "string" &&
+      record.recycleBinId
+  );
+}
+
+function recycleBinAudioUrl(id, { download = false } = {}) {
+  if (typeof id !== "string" || !id) {
+    return "";
+  }
+  const encoded = encodeURIComponent(id);
+  const suffix = download ? "?download=1" : "";
+  return apiPath(`/recycle-bin/${encoded}${suffix}`);
+}
+
+function recycleBinWaveformUrl(id) {
+  if (typeof id !== "string" || !id) {
+    return "";
+  }
+  const encoded = encodeURIComponent(id);
+  return apiPath(`/api/recycle-bin/${encoded}/waveform`);
+}
+
+function getRecycleBinRow(id) {
+  if (!dom.recycleBinTableBody || typeof id !== "string" || !id) {
+    return null;
+  }
+  const selector = `tr[data-id="${escapeSelector(id)}"]`;
+  return dom.recycleBinTableBody.querySelector(selector);
+}
+
+function recycleBinRecordFromItem(item) {
+  if (!item || typeof item !== "object") {
+    return null;
+  }
+  const id = typeof item.id === "string" ? item.id : "";
+  if (!id) {
+    return null;
+  }
+  const extension =
+    typeof item.extension === "string" && item.extension ? item.extension : "";
+  const name = typeof item.name === "string" && item.name ? item.name : "";
+  const sizeValue = Number(item.size_bytes);
+  const durationValue =
+    typeof item.duration_seconds === "number" && Number.isFinite(item.duration_seconds)
+      ? item.duration_seconds
+      : null;
+  const deletedEpoch = Number.isFinite(Number(item.deleted_at_epoch))
+    ? Number(item.deleted_at_epoch)
+    : null;
+  return {
+    path: `recycle-bin/${id}`,
+    name,
+    extension,
+    size_bytes: Number.isFinite(sizeValue) && sizeValue >= 0 ? sizeValue : 0,
+    duration_seconds: durationValue !== null && durationValue > 0 ? durationValue : null,
+    modified: deletedEpoch,
+    modified_iso: typeof item.deleted_at === "string" ? item.deleted_at : "",
+    start_epoch: deletedEpoch,
+    original_path: typeof item.original_path === "string" ? item.original_path : "",
+    deleted_at: typeof item.deleted_at === "string" ? item.deleted_at : "",
+    deleted_at_epoch: deletedEpoch,
+    recycleBinId: id,
+    recycleBinEntry: item,
+    waveform_path: item.waveform_available ? id : "",
+    waveform_available: Boolean(item.waveform_available),
+    source: "recycle-bin",
+    restorable: item.restorable !== false,
+  };
+}
+
+function restoreRecycleBinPreview() {
+  if (!recycleBinDialogState.previewing) {
+    return;
+  }
+  recycleBinDialogState.previewing = false;
+  const previous = recycleBinDialogState.previousRecord || null;
+  recycleBinDialogState.previousRecord = null;
+  if (isRecycleBinRecord(state.current)) {
+    if (previous) {
+      setNowPlaying(previous, { autoplay: false, resetToStart: false });
+    } else {
+      setNowPlaying(null, { autoplay: false, resetToStart: true });
+    }
+  }
 }
 
 function updateRecycleBinControls() {
@@ -9407,64 +9742,33 @@ function updateRecycleBinControls() {
 }
 
 function updateRecycleBinPreview() {
-  if (!dom.recycleBinPreviewTitle || !dom.recycleBinPreviewPath) {
+  if (!state.recycleBin.open) {
     return;
   }
   const item = getRecycleBinItem(state.recycleBin.activeId);
   if (!item) {
-    dom.recycleBinPreviewTitle.textContent = "Select a recording to preview";
-    dom.recycleBinPreviewPath.textContent = "";
-    if (dom.recycleBinPreviewTime) {
-      dom.recycleBinPreviewTime.textContent = "--";
-    }
-    if (dom.recycleBinPreviewSize) {
-      dom.recycleBinPreviewSize.textContent = "--";
-    }
-    if (dom.recycleBinPreviewDuration) {
-      dom.recycleBinPreviewDuration.textContent = "--";
-    }
-    if (dom.recycleBinAudio) {
-      try {
-        dom.recycleBinAudio.pause();
-      } catch (error) {
-        console.warn("Unable to pause recycle bin audio", error);
-      }
-      dom.recycleBinAudio.removeAttribute("src");
-      dom.recycleBinAudio.load();
-      delete dom.recycleBinAudio.dataset.entryId;
-    }
+    restoreRecycleBinPreview();
     return;
   }
-
-  const title = item.name && item.name.trim() ? item.name : item.original_path || item.id;
-  dom.recycleBinPreviewTitle.textContent = item.restorable === false ? `${title} (destination in use)` : title;
-  dom.recycleBinPreviewPath.textContent = item.original_path || "";
-  if (dom.recycleBinPreviewTime) {
-    const formatted = formatIsoDateTime(item.deleted_at) || "--";
-    dom.recycleBinPreviewTime.textContent = formatted || "--";
+  const row = getRecycleBinRow(item.id);
+  if (!row) {
+    return;
   }
-  if (dom.recycleBinPreviewSize) {
-    dom.recycleBinPreviewSize.textContent = formatBytes(Number(item.size_bytes) || 0);
+  if (!recycleBinDialogState.previewing) {
+    recycleBinDialogState.previousRecord = isRecycleBinRecord(state.current)
+      ? null
+      : state.current;
+    recycleBinDialogState.previewing = true;
   }
-  if (dom.recycleBinPreviewDuration) {
-    const duration = typeof item.duration_seconds === "number" ? item.duration_seconds : Number(item.duration_seconds);
-    dom.recycleBinPreviewDuration.textContent = formatDuration(duration);
+  if (isRecycleBinRecord(state.current) && state.current.recycleBinId === item.id) {
+    placePlayerCard(state.current, row);
+    return;
   }
-
-  if (dom.recycleBinAudio) {
-    const currentId = dom.recycleBinAudio.dataset.entryId || "";
-    if (currentId !== item.id) {
-      const previewUrl = apiPath(`/recycle-bin/${encodeURIComponent(item.id)}`);
-      try {
-        dom.recycleBinAudio.pause();
-      } catch (error) {
-        console.warn("Unable to pause recycle bin audio", error);
-      }
-      dom.recycleBinAudio.src = previewUrl;
-      dom.recycleBinAudio.dataset.entryId = item.id;
-      dom.recycleBinAudio.load();
-    }
+  const record = recycleBinRecordFromItem(item);
+  if (!record) {
+    return;
   }
+  setNowPlaying(record, { autoplay: false, resetToStart: true, sourceRow: row });
 }
 
 function renderRecycleBinItems() {
@@ -9481,8 +9785,16 @@ function renderRecycleBinItems() {
     row.dataset.id = item.id;
     row.dataset.restorable = item.restorable === false ? "false" : "true";
     const isSelected = state.recycleBin.selected.has(item.id);
+    const isActive = state.recycleBin.activeId === item.id;
     if (isSelected) {
       row.dataset.selected = "true";
+    } else {
+      delete row.dataset.selected;
+    }
+    if (isActive) {
+      row.dataset.active = "true";
+    } else {
+      delete row.dataset.active;
     }
 
     const checkboxCell = document.createElement("td");
@@ -9578,7 +9890,8 @@ async function fetchRecycleBin(options = {}) {
         continue;
       }
       const sizeValue = Number(entry.size_bytes);
-      const durationValue = Number(entry.duration_seconds);
+      const rawDuration = entry.duration_seconds;
+      const durationValue = typeof rawDuration === "number" ? rawDuration : null;
       normalized.push({
         id: idValue,
         name: typeof entry.name === "string" ? entry.name : "",
@@ -9587,9 +9900,15 @@ async function fetchRecycleBin(options = {}) {
         deleted_at_epoch: Number.isFinite(Number(entry.deleted_at_epoch))
           ? Number(entry.deleted_at_epoch)
           : null,
-        size_bytes: Number.isFinite(sizeValue) ? sizeValue : 0,
-        duration_seconds: Number.isFinite(durationValue) ? durationValue : null,
+        size_bytes: Number.isFinite(sizeValue) && sizeValue >= 0 ? sizeValue : 0,
+        duration_seconds:
+          typeof durationValue === "number" && Number.isFinite(durationValue) && durationValue > 0
+            ? durationValue
+            : null,
         restorable: entry.restorable !== false,
+        extension:
+          typeof entry.extension === "string" && entry.extension ? entry.extension : "",
+        waveform_available: entry.waveform_available !== false && Boolean(entry.waveform_available),
       });
     }
 

--- a/lib/webui/templates/dashboard.html
+++ b/lib/webui/templates/dashboard.html
@@ -315,7 +315,7 @@
           </div>
         </div>
         <div class="stat storage-stat stat-storage">
-          <span class="label">Storage</span>
+          <span class="label">Storage use</span>
           <span class="value" id="storage-usage-text">--</span>
           <div class="storage-progress">
             <div class="storage-progress-bar" id="storage-progress-bar"></div>
@@ -351,7 +351,7 @@
         </div>
       </section>
       <section class="main-grid">
-        <div id="player-card" class="card player-card" hidden data-active="false">
+        <div id="player-card" class="card player-card" hidden data-active="false" data-context="recordings">
           <div class="card-header">
             <div class="card-heading">
               <h2>Preview</h2>
@@ -769,30 +769,6 @@
             <div id="recycle-bin-empty" class="recycle-bin-empty" hidden>
               No recordings in the recycle bin.
             </div>
-          </div>
-          <div class="recycle-bin-preview" aria-live="polite">
-            <h3 id="recycle-bin-preview-title">Select a recording to preview</h3>
-            <p id="recycle-bin-preview-path" class="recycle-bin-preview-path"></p>
-            <dl class="recycle-bin-preview-meta">
-              <div>
-                <dt>Deleted</dt>
-                <dd id="recycle-bin-preview-time">--</dd>
-              </div>
-              <div>
-                <dt>Size</dt>
-                <dd id="recycle-bin-preview-size">--</dd>
-              </div>
-              <div>
-                <dt>Duration</dt>
-                <dd id="recycle-bin-preview-duration">--</dd>
-              </div>
-            </dl>
-            <audio
-              id="recycle-bin-audio"
-              class="recycle-bin-audio"
-              controls
-              preload="metadata"
-            ></audio>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- add an API route to serve recycle bin waveform JSON and wire it into the modal preview
- reuse the main preview player inside the recycle bin table, hiding clip editing controls for bin items
- include recycle bin usage in the storage widget and relabel it to “Storage use”

## Testing
- export DEV=1 && pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68dd6b7a4b40832789536570d740a418