### PR TITLE
TR-53 Fix recycle bin preview timecode

### DIFF
--- a/lib/webui/static/js/dashboard.js
+++ b/lib/webui/static/js/dashboard.js
@@ -9910,6 +9910,21 @@ function recycleBinRecordFromItem(item) {
   const deletedEpoch = Number.isFinite(Number(item.deleted_at_epoch))
     ? Number(item.deleted_at_epoch)
     : null;
+  const startEpochCandidate = Number(item.start_epoch);
+  const fallbackStartEpoch = Number(item.started_epoch);
+  const startEpoch = Number.isFinite(startEpochCandidate)
+    ? startEpochCandidate
+    : Number.isFinite(fallbackStartEpoch)
+    ? fallbackStartEpoch
+    : null;
+  let startedAt = typeof item.started_at === "string" ? item.started_at : "";
+  if (!startedAt && Number.isFinite(startEpoch)) {
+    try {
+      startedAt = new Date(Number(startEpoch) * 1000).toISOString();
+    } catch (error) {
+      startedAt = "";
+    }
+  }
   return {
     path: `recycle-bin/${id}`,
     name,
@@ -9918,7 +9933,9 @@ function recycleBinRecordFromItem(item) {
     duration_seconds: durationValue !== null && durationValue > 0 ? durationValue : null,
     modified: deletedEpoch,
     modified_iso: typeof item.deleted_at === "string" ? item.deleted_at : "",
-    start_epoch: deletedEpoch,
+    start_epoch: Number.isFinite(startEpoch) ? Number(startEpoch) : null,
+    started_epoch: Number.isFinite(startEpoch) ? Number(startEpoch) : null,
+    started_at: startedAt,
     original_path: typeof item.original_path === "string" ? item.original_path : "",
     deleted_at: typeof item.deleted_at === "string" ? item.deleted_at : "",
     deleted_at_epoch: deletedEpoch,


### PR DESCRIPTION
## Summary
- persist the original recording start timestamps when moving files into the recycle bin and include them in the API payload
- teach the dashboard recycle bin preview to respect the preserved start metadata instead of the deletion time
- extend dashboard tests and helpers to cover recycle bin start timestamp handling

## Testing
- export DEV=1 && pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68dd8dbbf0808327a86efe3599b66827