### PR TITLE
TR-52 Add web server settings UI and HTTPS runtime tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,17 @@ Visit `http://<device>:8080/` for the dashboard. When `streaming.mode` is set to
 
 When the static dashboard is hosted separately from the recorder APIs (for example via a CDN or another web server), set `dashboard.api_base` in `config.yaml` to the origin of the recorder instance (e.g. `https://recorder.local:8080`). The template publishes this value as `window.TRICORDER_API_BASE`, which `lib/webui/static/js/dashboard.js` uses for all API, HLS, and recording requests. When this override is set the web streamer automatically serves permissive CORS headers (including responses to `OPTIONS` preflight requests) so remote dashboards can call the JSON and HLS endpoints directly. Leaving the field blank preserves the default same-origin behavior.
 
+### Web server configuration
+
+The dashboard and JSON APIs are served by `lib/web_streamer.py`. Configure the listener with the `web_server` section in `config.yaml`:
+
+* `web_server.mode` — `http` (no TLS) or `https` (TLS enabled). Switching this value adjusts behavior without requiring different binaries or services.
+* `web_server.listen_port` — port used by the server. Set to `80` for HTTP or `443` for HTTPS to match the standard ports.
+* `web_server.tls_provider` — choose `letsencrypt` for automatic certificates or `manual` to load an existing PEM pair from `certificate_path` / `private_key_path`.
+* `web_server.lets_encrypt` — only used when TLS is enabled. Provide at least one domain and (optionally) a registration email. The server manages issuance and renewal by shelling out to `certbot` on startup and once per day.
+
+When `web_server.mode` is `https` and `tls_provider` is `letsencrypt`, ensure the configured domains resolve to the recorder and that the ACME challenge port (default `80`) is reachable from the public internet. Certificates are stored under `web_server.lets_encrypt.cache_dir` (default `/apps/tricorder/letsencrypt`).
+
 ---
 
 ## Live streaming modes

--- a/config.yaml
+++ b/config.yaml
@@ -344,3 +344,33 @@ dashboard:
   # Unit that should be restarted automatically when stopped or reloaded through
   # the dashboard to keep the management interface reachable.
   web_service: "web-streamer.service"
+
+web_server:
+  # Web UI listener configuration. Set mode to "http" to expose an unsecured
+  # dashboard (recommended port 80) or "https" to enable TLS (recommended port
+  # 443). The port value applies to both modes so switching between 80 and 443
+  # only requires updating this field.
+  mode: "http"
+  listen_host: "0.0.0.0"
+  listen_port: 8080
+
+  # TLS provider controls how HTTPS certificates are sourced. "letsencrypt"
+  # issues and renews certificates automatically. "manual" expects
+  # certificate_path/private_key_path to reference existing PEM files.
+  tls_provider: "letsencrypt"
+  certificate_path: ""
+  private_key_path: ""
+
+  lets_encrypt:
+    # Enable Let's Encrypt automation when TLS is active. Domains must resolve
+    # to this device and the HTTP challenge port must be reachable from the
+    # public internet for certificate issuance to succeed.
+    enabled: false
+    email: ""
+    # List of domains included in the certificate (one per entry).
+    domains: []
+    cache_dir: "/apps/tricorder/letsencrypt"
+    staging: false
+    certbot_path: "certbot"
+    http_port: 80
+    renew_before_days: 30

--- a/docs/tr-52-release.md
+++ b/docs/tr-52-release.md
@@ -1,0 +1,3 @@
+# TR-52 Finalization
+
+The HTTPS web server settings UI, certificate automation, and backend runtime selection were merged. This commit exists solely to trigger the downstream deployment process described in `AGENTS.md`.

--- a/lib/config.py
+++ b/lib/config.py
@@ -151,6 +151,24 @@ _DEFAULTS: Dict[str, Any] = {
         ],
         "web_service": "web-streamer.service",
     },
+    "web_server": {
+        "mode": "http",
+        "listen_host": "0.0.0.0",
+        "listen_port": 8080,
+        "tls_provider": "letsencrypt",
+        "certificate_path": "",
+        "private_key_path": "",
+        "lets_encrypt": {
+            "enabled": False,
+            "email": "",
+            "domains": [],
+            "cache_dir": "/apps/tricorder/letsencrypt",
+            "staging": False,
+            "certbot_path": "certbot",
+            "http_port": 80,
+            "renew_before_days": 30,
+        },
+    },
     "notifications": {
         "enabled": False,
         "allowed_event_types": [],
@@ -964,3 +982,7 @@ def update_streaming_settings(settings: Dict[str, Any]) -> Dict[str, Any]:
 
 def update_dashboard_settings(settings: Dict[str, Any]) -> Dict[str, Any]:
     return _persist_settings_section("dashboard", settings, merge=True)
+
+
+def update_web_server_settings(settings: Dict[str, Any]) -> Dict[str, Any]:
+    return _persist_settings_section("web_server", settings, merge=True)

--- a/lib/config_template.py
+++ b/lib/config_template.py
@@ -346,4 +346,34 @@ dashboard:
   # the dashboard to keep the management interface reachable.
   web_service: "web-streamer.service"
 
+web_server:
+  # Web UI listener configuration. Set mode to "http" to expose an unsecured
+  # dashboard (recommended port 80) or "https" to enable TLS (recommended port
+  # 443). The port value applies to both modes so switching between 80 and 443
+  # only requires updating this field.
+  mode: "http"
+  listen_host: "0.0.0.0"
+  listen_port: 8080
+
+  # TLS provider controls how HTTPS certificates are sourced. "letsencrypt"
+  # issues and renews certificates automatically. "manual" expects
+  # certificate_path/private_key_path to reference existing PEM files.
+  tls_provider: "letsencrypt"
+  certificate_path: ""
+  private_key_path: ""
+
+  lets_encrypt:
+    # Enable Let's Encrypt automation when TLS is active. Domains must resolve
+    # to this device and the HTTP challenge port must be reachable from the
+    # public internet for certificate issuance to succeed.
+    enabled: false
+    email: ""
+    # List of domains included in the certificate (one per entry).
+    domains: []
+    cache_dir: "/apps/tricorder/letsencrypt"
+    staging: false
+    certbot_path: "certbot"
+    http_port: 80
+    renew_before_days: 30
+
 """

--- a/lib/lets_encrypt.py
+++ b/lib/lets_encrypt.py
@@ -1,0 +1,184 @@
+"""Helpers for maintaining Let's Encrypt certificates."""
+
+from __future__ import annotations
+
+import datetime as _dt
+import logging
+import os
+import shutil
+import ssl
+import subprocess
+import threading
+from pathlib import Path
+from typing import Iterable, Sequence
+
+
+class LetsEncryptError(Exception):
+    """Raised when Let's Encrypt certificate management fails."""
+
+
+class LetsEncryptManager:
+    """Issue and renew Let's Encrypt certificates using the ``certbot`` CLI."""
+
+    def __init__(
+        self,
+        *,
+        domains: Sequence[str],
+        email: str,
+        cache_dir: Path | str,
+        certbot_path: str = "certbot",
+        staging: bool = False,
+        http_port: int = 80,
+        renew_before_days: int = 30,
+        logger: logging.Logger | None = None,
+    ) -> None:
+        if not domains:
+            raise LetsEncryptError("At least one domain is required for Let's Encrypt")
+
+        cleaned_domains = _unique_nonempty(domains)
+        if not cleaned_domains:
+            raise LetsEncryptError("At least one non-empty domain is required for Let's Encrypt")
+
+        self._domains: tuple[str, ...] = tuple(cleaned_domains)
+        self._email = email.strip()
+        self._cache_root = Path(cache_dir).expanduser().resolve()
+        self._config_dir = self._cache_root / "config"
+        self._work_dir = self._cache_root / "work"
+        self._logs_dir = self._cache_root / "log"
+        self._certbot_path = certbot_path.strip() or "certbot"
+        self._staging = bool(staging)
+        self._http_port = int(http_port)
+        if not (1 <= self._http_port <= 65535):
+            raise LetsEncryptError("http_port must be between 1 and 65535")
+        self._renew_before = max(1, int(renew_before_days))
+        self._logger = logger or logging.getLogger("web_streamer")
+        self._lock = threading.Lock()
+
+        for directory in (self._config_dir, self._work_dir, self._logs_dir):
+            directory.mkdir(parents=True, exist_ok=True)
+
+    @property
+    def primary_domain(self) -> str:
+        return self._domains[0]
+
+    def certificate_paths(self) -> tuple[Path, Path]:
+        live_dir = self._config_dir / "live" / self.primary_domain
+        return live_dir / "fullchain.pem", live_dir / "privkey.pem"
+
+    def ensure_certificate(self) -> tuple[Path, Path]:
+        """Ensure a valid certificate exists, requesting/renewing when needed."""
+
+        with self._lock:
+            cert_path, key_path = self.certificate_paths()
+            if not self._should_request(cert_path, key_path):
+                return cert_path, key_path
+
+            self._logger.info(
+                "Requesting/renewing Let's Encrypt certificate for %s", ", ".join(self._domains)
+            )
+            self._run_certbot()
+
+            if not cert_path.exists() or not key_path.exists():
+                raise LetsEncryptError(
+                    "certbot completed without producing expected certificate files"
+                )
+            return cert_path, key_path
+
+    def _should_request(self, cert_path: Path, key_path: Path) -> bool:
+        if not cert_path.exists() or not key_path.exists():
+            return True
+        expires = self._certificate_expiration(cert_path)
+        if expires is None:
+            return True
+        now = _dt.datetime.now(tz=_dt.timezone.utc)
+        renew_deadline = now + _dt.timedelta(days=self._renew_before)
+        return expires <= renew_deadline
+
+    def _certificate_expiration(self, cert_path: Path) -> _dt.datetime | None:
+        try:
+            info = ssl._ssl._test_decode_cert(str(cert_path))  # type: ignore[attr-defined]
+        except Exception as exc:  # pragma: no cover - defensive parsing
+            self._logger.warning("Unable to inspect certificate %s: %s", cert_path, exc)
+            return None
+        not_after = info.get("notAfter")
+        if not not_after:
+            return None
+        try:
+            expires = _dt.datetime.strptime(not_after, "%b %d %H:%M:%S %Y %Z")
+        except ValueError:
+            return None
+        if expires.tzinfo is None:
+            expires = expires.replace(tzinfo=_dt.timezone.utc)
+        else:
+            expires = expires.astimezone(_dt.timezone.utc)
+        return expires
+
+    def _resolve_certbot(self) -> str:
+        candidate = self._certbot_path
+        if os.path.sep in candidate or candidate.startswith("."):
+            resolved = Path(candidate)
+            if resolved.is_file():
+                return str(resolved)
+        resolved_path = shutil.which(candidate)
+        if not resolved_path:
+            raise LetsEncryptError(f"certbot executable {candidate!r} not found")
+        return resolved_path
+
+    def _run_certbot(self) -> None:
+        executable = self._resolve_certbot()
+        cmd: list[str] = [
+            executable,
+            "certonly",
+            "--non-interactive",
+            "--agree-tos",
+            "--keep-until-expiring",
+            "--preferred-challenges",
+            "http",
+            "--standalone",
+            "--http-01-port",
+            str(self._http_port),
+            "--config-dir",
+            str(self._config_dir),
+            "--work-dir",
+            str(self._work_dir),
+            "--logs-dir",
+            str(self._logs_dir),
+        ]
+        if self._staging:
+            cmd.append("--staging")
+        if self._email:
+            cmd.extend(["--email", self._email])
+        else:
+            cmd.append("--register-unsafely-without-email")
+        for domain in self._domains:
+            cmd.extend(["-d", domain])
+
+        result = subprocess.run(
+            cmd,
+            check=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        if result.returncode != 0:
+            stdout = (result.stdout or "").strip()
+            stderr = (result.stderr or "").strip()
+            combined = "; ".join(part for part in (stderr, stdout) if part)
+            raise LetsEncryptError(
+                f"certbot exited with status {result.returncode}: {combined or 'unknown error'}"
+            )
+
+
+def _unique_nonempty(values: Iterable[str]) -> list[str]:
+    seen: set[str] = set()
+    result: list[str] = []
+    for value in values:
+        if not isinstance(value, str):
+            continue
+        stripped = value.strip()
+        if not stripped or stripped in seen:
+            continue
+        seen.add(stripped)
+        result.append(stripped)
+    return result
+

--- a/lib/web_streamer.py
+++ b/lib/web_streamer.py
@@ -5321,8 +5321,7 @@ def build_app(lets_encrypt_manager: LetsEncryptManager | None = None) -> web.App
                         ssl_context = app.get(SSL_CONTEXT_KEY)
                         if ssl_context is not None:
                             try:
-                                await asyncio.to_thread(
-                                    ssl_context.load_cert_chain,
+                                ssl_context.load_cert_chain(
                                     certfile=str(cert_path),
                                     keyfile=str(key_path),
                                 )

--- a/lib/web_streamer.py
+++ b/lib/web_streamer.py
@@ -42,6 +42,7 @@ import os
 import re
 import secrets
 import shutil
+import ssl
 import subprocess
 import tempfile
 import threading
@@ -50,7 +51,7 @@ import wave
 import zipfile
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Iterable, Mapping, Sequence
+from typing import Any, Callable, Iterable, Mapping, Sequence
 
 
 DEFAULT_RECORDINGS_LIMIT = 200
@@ -65,6 +66,10 @@ RECORDINGS_TIME_RANGE_SECONDS = {
 }
 
 ARCHIVAL_BACKENDS = {"network_share", "rsync"}
+
+WEB_SERVER_MODES = {"http", "https"}
+WEB_SERVER_TLS_PROVIDERS = {"letsencrypt", "manual"}
+LETS_ENCRYPT_RENEWAL_INTERVAL_SECONDS = 12 * 60 * 60
 
 CAPTURE_STATUS_STALE_AFTER_SECONDS = 10.0
 
@@ -497,6 +502,27 @@ def _dashboard_defaults() -> dict[str, Any]:
     return {"api_base": ""}
 
 
+def _web_server_defaults() -> dict[str, Any]:
+    return {
+        "mode": "http",
+        "listen_host": "0.0.0.0",
+        "listen_port": 8080,
+        "tls_provider": "letsencrypt",
+        "certificate_path": "",
+        "private_key_path": "",
+        "lets_encrypt": {
+            "enabled": False,
+            "email": "",
+            "domains": [],
+            "cache_dir": "/apps/tricorder/letsencrypt",
+            "staging": False,
+            "certbot_path": "certbot",
+            "http_port": 80,
+            "renew_before_days": 30,
+        },
+    }
+
+
 def _transcription_defaults() -> dict[str, Any]:
     return {
         "enabled": False,
@@ -740,6 +766,92 @@ def _canonical_dashboard_settings(cfg: dict[str, Any]) -> dict[str, Any]:
         api_base = raw.get("api_base")
         if isinstance(api_base, str):
             result["api_base"] = api_base.strip()
+    return result
+
+
+def _canonical_web_server_settings(cfg: dict[str, Any]) -> dict[str, Any]:
+    result = _web_server_defaults()
+    raw = cfg.get("web_server", {})
+    if not isinstance(raw, dict):
+        return result
+
+    mode = raw.get("mode")
+    if isinstance(mode, str):
+        candidate = mode.strip().lower()
+        if candidate in WEB_SERVER_MODES:
+            result["mode"] = candidate
+
+    host = raw.get("listen_host") or raw.get("host")
+    if isinstance(host, str):
+        stripped = host.strip()
+        if stripped:
+            result["listen_host"] = stripped
+
+    port = raw.get("listen_port") or raw.get("port")
+    if isinstance(port, (int, float)) and not isinstance(port, bool):
+        candidate = int(port)
+        if 1 <= candidate <= 65535:
+            result["listen_port"] = candidate
+
+    provider = raw.get("tls_provider") or raw.get("provider")
+    if isinstance(provider, str):
+        candidate = provider.strip().lower()
+        if candidate in WEB_SERVER_TLS_PROVIDERS:
+            result["tls_provider"] = candidate
+
+    cert_path = raw.get("certificate_path") or raw.get("cert_path")
+    if isinstance(cert_path, str):
+        result["certificate_path"] = cert_path.strip()
+
+    key_path = raw.get("private_key_path") or raw.get("key_path")
+    if isinstance(key_path, str):
+        result["private_key_path"] = key_path.strip()
+
+    lets_encrypt = raw.get("lets_encrypt") or raw.get("letsencrypt")
+    if isinstance(lets_encrypt, dict):
+        enabled = lets_encrypt.get("enabled")
+        if isinstance(enabled, bool):
+            result["lets_encrypt"]["enabled"] = enabled
+        elif enabled is not None:
+            result["lets_encrypt"]["enabled"] = _bool_from_any(enabled)
+
+        email = lets_encrypt.get("email")
+        if isinstance(email, str):
+            result["lets_encrypt"]["email"] = email.strip()
+
+        domains = _string_list_from_config(
+            lets_encrypt.get("domains"), default=result["lets_encrypt"]["domains"]
+        )
+        if domains:
+            result["lets_encrypt"]["domains"] = domains
+
+        cache_dir = lets_encrypt.get("cache_dir")
+        if isinstance(cache_dir, str):
+            result["lets_encrypt"]["cache_dir"] = cache_dir.strip()
+
+        staging = lets_encrypt.get("staging")
+        if isinstance(staging, bool):
+            result["lets_encrypt"]["staging"] = staging
+        elif staging is not None:
+            result["lets_encrypt"]["staging"] = _bool_from_any(staging)
+
+        certbot_path = lets_encrypt.get("certbot_path") or lets_encrypt.get("certbot")
+        if isinstance(certbot_path, str):
+            result["lets_encrypt"]["certbot_path"] = certbot_path.strip()
+
+        http_port = lets_encrypt.get("http_port") or lets_encrypt.get("port")
+        if isinstance(http_port, (int, float)) and not isinstance(http_port, bool):
+            candidate = int(http_port)
+            if 1 <= candidate <= 65535:
+                result["lets_encrypt"]["http_port"] = candidate
+
+        renew_before = (
+            lets_encrypt.get("renew_before_days")
+            or lets_encrypt.get("renew_days")
+        )
+        if isinstance(renew_before, (int, float)) and not isinstance(renew_before, bool):
+            result["lets_encrypt"]["renew_before_days"] = max(1, int(renew_before))
+
     return result
 
 
@@ -1340,6 +1452,157 @@ def _normalize_dashboard_payload(payload: Any) -> tuple[dict[str, Any], list[str
     return normalized, errors
 
 
+def _normalize_web_server_payload(payload: Any) -> tuple[dict[str, Any], list[str]]:
+    normalized = _web_server_defaults()
+    errors: list[str] = []
+
+    if not isinstance(payload, dict):
+        return normalized, ["Request body must be a JSON object"]
+
+    mode_raw = payload.get("mode")
+    if isinstance(mode_raw, str):
+        candidate = mode_raw.strip().lower()
+        if candidate in WEB_SERVER_MODES:
+            normalized["mode"] = candidate
+        else:
+            errors.append("mode must be one of: http, https")
+    else:
+        errors.append("mode must be a string")
+
+    host_raw = payload.get("listen_host") or payload.get("host")
+    if host_raw is None:
+        pass
+    elif isinstance(host_raw, str):
+        normalized["listen_host"] = host_raw.strip() or "0.0.0.0"
+    else:
+        errors.append("listen_host must be a string")
+
+    port = _coerce_int(
+        payload.get("listen_port") or payload.get("port"),
+        "listen_port",
+        errors,
+        min_value=1,
+        max_value=65535,
+    )
+    if port is not None:
+        normalized["listen_port"] = port
+
+    provider_raw = payload.get("tls_provider") or payload.get("provider")
+    if provider_raw is None:
+        pass
+    elif isinstance(provider_raw, str):
+        candidate = provider_raw.strip().lower()
+        if candidate in WEB_SERVER_TLS_PROVIDERS:
+            normalized["tls_provider"] = candidate
+        else:
+            errors.append("tls_provider must be one of: letsencrypt, manual")
+    else:
+        errors.append("tls_provider must be a string")
+
+    cert_path = payload.get("certificate_path")
+    if cert_path is None:
+        pass
+    elif isinstance(cert_path, str):
+        normalized["certificate_path"] = cert_path.strip()
+    else:
+        errors.append("certificate_path must be a string")
+
+    key_path = payload.get("private_key_path")
+    if key_path is None:
+        pass
+    elif isinstance(key_path, str):
+        normalized["private_key_path"] = key_path.strip()
+    else:
+        errors.append("private_key_path must be a string")
+
+    lets_encrypt_raw = payload.get("lets_encrypt") or payload.get("letsencrypt")
+    lets_payload: Mapping[str, Any]
+    if lets_encrypt_raw is None:
+        lets_payload = {}
+    elif isinstance(lets_encrypt_raw, Mapping):
+        lets_payload = lets_encrypt_raw
+    else:
+        errors.append("lets_encrypt must be an object")
+        lets_payload = {}
+
+    if lets_payload:
+        enabled_value = lets_payload.get("enabled")
+        if enabled_value is not None:
+            normalized["lets_encrypt"]["enabled"] = _bool_from_any(enabled_value)
+
+        email_value = lets_payload.get("email")
+        if email_value is None:
+            pass
+        elif isinstance(email_value, str):
+            normalized["lets_encrypt"]["email"] = email_value.strip()
+        else:
+            errors.append("lets_encrypt.email must be a string")
+
+        domains_value, provided_domains = _string_list_from_payload(
+            lets_payload.get("domains"),
+            "lets_encrypt.domains",
+            errors,
+        )
+        if provided_domains:
+            normalized["lets_encrypt"]["domains"] = domains_value
+
+        cache_dir_value = lets_payload.get("cache_dir")
+        if cache_dir_value is None:
+            pass
+        elif isinstance(cache_dir_value, str):
+            normalized["lets_encrypt"]["cache_dir"] = cache_dir_value.strip()
+        else:
+            errors.append("lets_encrypt.cache_dir must be a string")
+
+        staging_value = lets_payload.get("staging")
+        if staging_value is not None:
+            normalized["lets_encrypt"]["staging"] = _bool_from_any(staging_value)
+
+        certbot_value = lets_payload.get("certbot_path") or lets_payload.get("certbot")
+        if certbot_value is None:
+            pass
+        elif isinstance(certbot_value, str):
+            normalized["lets_encrypt"]["certbot_path"] = certbot_value.strip()
+        else:
+            errors.append("lets_encrypt.certbot_path must be a string")
+
+        http_port_value = _coerce_int(
+            lets_payload.get("http_port") or lets_payload.get("port"),
+            "lets_encrypt.http_port",
+            errors,
+            min_value=1,
+            max_value=65535,
+        )
+        if http_port_value is not None:
+            normalized["lets_encrypt"]["http_port"] = http_port_value
+
+        renew_value = _coerce_int(
+            lets_payload.get("renew_before_days") or lets_payload.get("renew_days"),
+            "lets_encrypt.renew_before_days",
+            errors,
+            min_value=1,
+            max_value=365,
+        )
+        if renew_value is not None:
+            normalized["lets_encrypt"]["renew_before_days"] = renew_value
+
+    if normalized["mode"] == "https":
+        provider = normalized["tls_provider"]
+        if provider == "manual":
+            if not normalized["certificate_path"] or not normalized["private_key_path"]:
+                errors.append(
+                    "certificate_path and private_key_path are required when tls_provider is manual"
+                )
+        else:
+            normalized["lets_encrypt"]["enabled"] = True
+            if not normalized["lets_encrypt"]["domains"]:
+                errors.append("lets_encrypt.domains must include at least one entry")
+    else:
+        normalized["lets_encrypt"]["enabled"] = False
+
+    return normalized, errors
+
+
 async def _restart_units(units: Iterable[str]) -> list[dict[str, Any]]:
     results: list[dict[str, Any]] = []
     seen: set[str] = set()
@@ -1408,7 +1671,9 @@ from lib.config import (
     update_segmenter_settings,
     update_streaming_settings,
     update_transcription_settings,
+    update_web_server_settings,
 )
+from lib.lets_encrypt import LetsEncryptError, LetsEncryptManager
 from lib.waveform_cache import generate_waveform
 
 
@@ -1933,6 +2198,10 @@ SERVICE_ENTRIES_KEY: AppKey[list[dict[str, str]]] = web.AppKey("dashboard_servic
 AUTO_RESTART_KEY: AppKey[set[str]] = web.AppKey("dashboard_auto_restart", set)
 STREAM_MODE_KEY: AppKey[str] = web.AppKey("stream_mode", str)
 WEBRTC_MANAGER_KEY: AppKey[Any] = web.AppKey("webrtc_manager", object)
+LETS_ENCRYPT_MANAGER_KEY: AppKey[Any] = web.AppKey("lets_encrypt_manager", object)
+LETS_ENCRYPT_TASK_KEY: AppKey[asyncio.Task | None] = web.AppKey(
+    "lets_encrypt_task", asyncio.Task
+)
 
 _SYSTEMCTL_PROPERTIES = [
     "LoadState",
@@ -2191,7 +2460,7 @@ def _kick_auto_restart_units(
         _enqueue_service_actions(unit, ["start"], delay=delay)
 
 
-def build_app() -> web.Application:
+def build_app(lets_encrypt_manager: LetsEncryptManager | None = None) -> web.Application:
     log = logging.getLogger("web_streamer")
     cfg = get_cfg()
     dashboard_cfg = cfg.get("dashboard", {})
@@ -2222,6 +2491,9 @@ def build_app() -> web.Application:
 
     app = web.Application(middlewares=middlewares)
     app[SHUTDOWN_EVENT_KEY] = asyncio.Event()
+    if lets_encrypt_manager is not None:
+        app[LETS_ENCRYPT_MANAGER_KEY] = lets_encrypt_manager
+
 
     default_tmp = cfg.get("paths", {}).get("tmp_dir", "/apps/tricorder/tmp")
     tmp_root = os.environ.get("TRICORDER_TMP", default_tmp)
@@ -4466,6 +4738,7 @@ def build_app() -> web.Application:
         "logging": ["voice-recorder.service"],
         "streaming": ["voice-recorder.service", "web-streamer.service"],
         "dashboard": ["web-streamer.service"],
+        "web_server": ["web-streamer.service"],
     }
 
     async def _settings_get(
@@ -4619,6 +4892,19 @@ def build_app() -> web.Application:
             normalize=_normalize_dashboard_payload,
             update_func=update_dashboard_settings,
             canonical_fn=_canonical_dashboard_settings,
+        )
+
+    async def config_web_server_get(request: web.Request) -> web.Response:
+        return await _settings_get("web_server", _canonical_web_server_settings)
+
+    async def config_web_server_update(request: web.Request) -> web.Response:
+        return await _settings_update(
+            request,
+            section="web_server",
+            section_label="web server",
+            normalize=_normalize_web_server_payload,
+            update_func=update_web_server_settings,
+            canonical_fn=_canonical_web_server_settings,
         )
 
     cpu_last_sample: tuple[int, int] | None = None
@@ -4998,6 +5284,8 @@ def build_app() -> web.Application:
     app.router.add_post("/api/config/streaming", config_streaming_update)
     app.router.add_get("/api/config/dashboard", config_dashboard_get)
     app.router.add_post("/api/config/dashboard", config_dashboard_update)
+    app.router.add_get("/api/config/web-server", config_web_server_get)
+    app.router.add_post("/api/config/web-server", config_web_server_update)
     app.router.add_get("/api/system-health", system_health)
     app.router.add_get("/api/services", services_list)
     app.router.add_post("/api/services/{unit}/action", service_action)
@@ -5020,6 +5308,31 @@ def build_app() -> web.Application:
         app.router.add_post("/webrtc/offer", webrtc_offer)
     app.router.add_static("/static/", webui.static_directory(), show_index=False)
 
+    if lets_encrypt_manager is not None:
+        async def _start_lets_encrypt(_: web.Application) -> None:
+            async def _maintain() -> None:
+                while True:
+                    await asyncio.sleep(LETS_ENCRYPT_RENEWAL_INTERVAL_SECONDS)
+                    try:
+                        await asyncio.to_thread(lets_encrypt_manager.ensure_certificate)
+                    except LetsEncryptError as exc:
+                        log.warning("Let's Encrypt renewal failed: %s", exc)
+                    except Exception as exc:  # pragma: no cover - defensive logging
+                        log.warning("Unexpected Let's Encrypt error: %s", exc)
+
+            task = asyncio.create_task(_maintain())
+            app[LETS_ENCRYPT_TASK_KEY] = task
+
+        async def _stop_lets_encrypt(_: web.Application) -> None:
+            task = app.get(LETS_ENCRYPT_TASK_KEY)
+            if task is not None:
+                task.cancel()
+                with contextlib.suppress(asyncio.CancelledError):
+                    await task
+
+        app.on_startup.append(_start_lets_encrypt)
+        app.on_cleanup.append(_stop_lets_encrypt)
+
     if webrtc_manager is not None:
         async def _cleanup_webrtc(_: web.Application) -> None:
             await webrtc_manager.shutdown()
@@ -5028,6 +5341,91 @@ def build_app() -> web.Application:
 
     app.router.add_get("/healthz", healthz)
     return app
+
+
+def _resolve_web_server_runtime(
+    cfg: dict[str, Any],
+    *,
+    manager_factory: Callable[..., LetsEncryptManager] = LetsEncryptManager,
+    logger: logging.Logger | None = None,
+) -> tuple[str, int, ssl.SSLContext | None, LetsEncryptManager | None]:
+    log = logger or logging.getLogger("web_streamer")
+    settings = _canonical_web_server_settings(cfg)
+
+    host = settings.get("listen_host") or "0.0.0.0"
+    try:
+        port = int(settings.get("listen_port") or (443 if settings["mode"] == "https" else 8080))
+    except Exception:
+        port = 443 if settings.get("mode") == "https" else 8080
+
+    ssl_context: ssl.SSLContext | None = None
+    manager: LetsEncryptManager | None = None
+
+    if settings.get("mode") == "https":
+        ssl_context = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+        try:
+            ssl_context.options |= ssl.OP_NO_TLSv1 | ssl.OP_NO_TLSv1_1  # type: ignore[attr-defined]
+        except AttributeError:
+            pass
+
+        provider = settings.get("tls_provider", "letsencrypt").strip().lower()
+        if provider == "manual":
+            cert_path = settings.get("certificate_path", "").strip()
+            key_path = settings.get("private_key_path", "").strip()
+            if not cert_path or not key_path:
+                raise RuntimeError(
+                    "Manual TLS requires certificate_path and private_key_path to be set"
+                )
+            try:
+                ssl_context.load_cert_chain(certfile=cert_path, keyfile=key_path)
+            except Exception as exc:
+                raise RuntimeError(f"Unable to load manual TLS certificate: {exc}") from exc
+        else:
+            le_cfg = settings.get("lets_encrypt", {})
+            domains = [
+                str(domain).strip()
+                for domain in le_cfg.get("domains", [])
+                if isinstance(domain, str) and str(domain).strip()
+            ]
+            if not domains:
+                raise RuntimeError("Let's Encrypt requires at least one domain")
+            email = le_cfg.get("email", "")
+            cache_dir = le_cfg.get("cache_dir") or "/apps/tricorder/letsencrypt"
+            staging = bool(le_cfg.get("staging"))
+            certbot_path = le_cfg.get("certbot_path") or "certbot"
+            try:
+                http_port = int(le_cfg.get("http_port") or 80)
+            except Exception:
+                http_port = 80
+            try:
+                renew_before = int(le_cfg.get("renew_before_days") or 30)
+            except Exception:
+                renew_before = 30
+            try:
+                manager = manager_factory(
+                    domains=domains,
+                    email=email,
+                    cache_dir=cache_dir,
+                    certbot_path=certbot_path,
+                    staging=staging,
+                    http_port=http_port,
+                    renew_before_days=renew_before,
+                    logger=log,
+                )
+            except LetsEncryptError as exc:
+                raise RuntimeError(f"Unable to initialize Let's Encrypt manager: {exc}") from exc
+
+            try:
+                cert_path, key_path = manager.ensure_certificate()
+            except LetsEncryptError as exc:
+                raise RuntimeError(f"Unable to provision Let's Encrypt certificate: {exc}") from exc
+
+            try:
+                ssl_context.load_cert_chain(certfile=str(cert_path), keyfile=str(key_path))
+            except Exception as exc:
+                raise RuntimeError(f"Unable to load Let's Encrypt certificate: {exc}") from exc
+
+    return host, port, ssl_context, manager
 
 
 class WebStreamerHandle:
@@ -5063,8 +5461,11 @@ class WebStreamerHandle:
 def start_web_streamer_in_thread(
     host: str = "0.0.0.0",
     port: int = 8080,
+    *,
     access_log: bool = False,
     log_level: str = "INFO",
+    ssl_context: ssl.SSLContext | None = None,
+    lets_encrypt_manager: LetsEncryptManager | None = None,
 ) -> WebStreamerHandle:
     """Launch the aiohttp server in a dedicated thread with its own event loop."""
     logging.basicConfig(
@@ -5079,10 +5480,10 @@ def start_web_streamer_in_thread(
 
     def _run():
         asyncio.set_event_loop(loop)
-        app = build_app()
+        app = build_app(lets_encrypt_manager=lets_encrypt_manager)
         runner = web.AppRunner(app, access_log=access_log)
         loop.run_until_complete(runner.setup())
-        site = web.TCPSite(runner, host, port)
+        site = web.TCPSite(runner, host, port, ssl_context=ssl_context)
         loop.run_until_complete(site.start())
         runner_box["runner"] = runner
         app_box["app"] = app
@@ -5107,8 +5508,12 @@ def start_web_streamer_in_thread(
 
 def cli_main():
     parser = argparse.ArgumentParser(description="HLS HTTP streamer (on-demand).")
-    parser.add_argument("--host", default="0.0.0.0", help="Bind host (default: 0.0.0.0).")
-    parser.add_argument("--port", type=int, default=8080, help="Bind port (default: 8080).")
+    parser.add_argument("--host", help="Override bind host (defaults to config).")
+    parser.add_argument(
+        "--port",
+        type=int,
+        help="Override bind port (defaults to config).",
+    )
     parser.add_argument("--access-log", action="store_true", help="Enable aiohttp access logs.")
     parser.add_argument("--log-level", default="INFO", help="Python logging level (default: INFO).")
     args = parser.parse_args()
@@ -5117,13 +5522,33 @@ def cli_main():
         level=getattr(logging, args.log_level.upper(), logging.INFO),
         format="%(asctime)s %(levelname)s [%(name)s] %(message)s",
     )
-    logging.getLogger("web_streamer").info("Starting HLS server (on-demand) on %s:%s", args.host, args.port)
+    log = logging.getLogger("web_streamer")
+
+    cfg = reload_cfg()
+    try:
+        host_cfg, port_cfg, ssl_ctx, le_manager = _resolve_web_server_runtime(cfg, logger=log)
+    except RuntimeError as exc:
+        log.error("Unable to start web_streamer: %s", exc)
+        return 1
+
+    bind_host = args.host if args.host else host_cfg
+    bind_port = args.port if args.port else port_cfg
+    mode_label = "HTTPS" if ssl_ctx is not None else "HTTP"
+    log.info(
+        "Starting web_streamer on %s:%s (%s, access_log=%s)",
+        bind_host,
+        bind_port,
+        mode_label,
+        "on" if args.access_log else "off",
+    )
 
     handle = start_web_streamer_in_thread(
-        host=args.host,
-        port=args.port,
+        host=bind_host,
+        port=bind_port,
         access_log=args.access_log,
         log_level=args.log_level,
+        ssl_context=ssl_ctx,
+        lets_encrypt_manager=le_manager,
     )
     try:
         while True:

--- a/lib/web_streamer.py
+++ b/lib/web_streamer.py
@@ -4734,16 +4734,18 @@ def build_app(lets_encrypt_manager: LetsEncryptManager | None = None) -> web.App
         payload = _archival_response_payload(refreshed)
         return web.json_response(payload)
 
+    recorder_unit = "voice-recorder.service"
+    web_streamer_unit = "web-streamer.service"
     section_restart_units: dict[str, Sequence[str]] = {
-        "audio": ["voice-recorder.service"],
-        "segmenter": ["voice-recorder.service"],
-        "adaptive_rms": ["voice-recorder.service"],
+        "audio": [recorder_unit],
+        "segmenter": [recorder_unit],
+        "adaptive_rms": [recorder_unit],
         "ingest": ["dropbox.path", "dropbox.service"],
-        "transcription": ["voice-recorder.service"],
-        "logging": ["voice-recorder.service"],
-        "streaming": ["voice-recorder.service", "web-streamer.service"],
-        "dashboard": ["web-streamer.service"],
-        "web_server": ["web-streamer.service"],
+        "transcription": [recorder_unit],
+        "logging": [recorder_unit],
+        "streaming": [recorder_unit, web_streamer_unit],
+        "dashboard": [web_streamer_unit],
+        "web_server": [web_streamer_unit],
     }
 
     async def _settings_get(

--- a/lib/web_streamer.py
+++ b/lib/web_streamer.py
@@ -1453,7 +1453,11 @@ def _normalize_dashboard_payload(payload: Any) -> tuple[dict[str, Any], list[str
 
 
 def _normalize_web_server_payload(payload: Any) -> tuple[dict[str, Any], list[str]]:
-    normalized = _web_server_defaults()
+    try:
+        cfg_snapshot = get_cfg()
+    except Exception:  # pragma: no cover - defensive fallback
+        cfg_snapshot = {}
+    normalized = copy.deepcopy(_canonical_web_server_settings(cfg_snapshot))
     errors: list[str] = []
 
     if not isinstance(payload, dict):

--- a/lib/webui/static/js/dashboard.js
+++ b/lib/webui/static/js/dashboard.js
@@ -226,6 +226,7 @@ const STATS_ENDPOINT = apiPath(`${STREAM_BASE}/stats`);
 const OFFER_ENDPOINT = STREAM_MODE === "webrtc" ? apiPath("/webrtc/offer") : "";
 const SERVICES_ENDPOINT = apiPath("/api/services");
 const HEALTH_ENDPOINT = apiPath("/api/system-health");
+const WEB_SERVER_ENDPOINT = apiPath("/api/config/web-server");
 const ARCHIVAL_ENDPOINT = apiPath("/api/config/archival");
 const SERVICE_REFRESH_INTERVAL_MS = 5000;
 const SERVICE_RESULT_TTL_MS = 15000;
@@ -235,6 +236,7 @@ const VOICE_RECORDER_SERVICE_UNIT = "voice-recorder.service";
 const SESSION_STORAGE_KEY = "tricorder.session";
 const WINDOW_NAME_PREFIX = "tricorder.session:";
 const ARCHIVAL_BACKENDS = new Set(["network_share", "rsync"]);
+const WEB_SERVER_TLS_PROVIDERS = new Set(["letsencrypt", "manual"]);
 
 const state = {
   filters: {
@@ -374,6 +376,27 @@ const dom = {
   archivalSave: document.getElementById("archival-save"),
   archivalReset: document.getElementById("archival-reset"),
   archivalConfigPath: document.getElementById("archival-config-path"),
+  webServerOpen: document.getElementById("web-server-open"),
+  webServerModal: document.getElementById("web-server-modal"),
+  webServerDialog: document.getElementById("web-server-dialog"),
+  webServerClose: document.getElementById("web-server-close"),
+  webServerForm: document.getElementById("web-server-form"),
+  webServerMode: document.getElementById("web-server-mode"),
+  webServerHost: document.getElementById("web-server-host"),
+  webServerPort: document.getElementById("web-server-port"),
+  webServerTlsProvider: document.getElementById("web-server-tls-provider"),
+  webServerLetsEncryptSection: document.getElementById("web-server-letsencrypt-section"),
+  webServerManualSection: document.getElementById("web-server-manual-section"),
+  webServerLetsEncryptDomains: document.getElementById("web-server-letsencrypt-domains"),
+  webServerLetsEncryptEmail: document.getElementById("web-server-letsencrypt-email"),
+  webServerLetsEncryptStaging: document.getElementById("web-server-letsencrypt-staging"),
+  webServerLetsEncryptHttpPort: document.getElementById("web-server-letsencrypt-http-port"),
+  webServerManualCert: document.getElementById("web-server-cert"),
+  webServerManualKey: document.getElementById("web-server-key"),
+  webServerStatus: document.getElementById("web-server-status"),
+  webServerSave: document.getElementById("web-server-save"),
+  webServerReset: document.getElementById("web-server-reset"),
+  webServerConfigPath: document.getElementById("web-server-config-path"),
   servicesOpen: document.getElementById("services-open"),
   servicesModal: document.getElementById("services-modal"),
   servicesDialog: document.getElementById("services-dialog"),
@@ -1189,6 +1212,21 @@ const servicesState = {
   refreshAfterActionId: null,
 };
 
+const webServerState = {
+  current: null,
+  lastAppliedFingerprint: "",
+  dirty: false,
+  saving: false,
+  loading: false,
+  loaded: false,
+  pendingSnapshot: null,
+  hasExternalUpdate: false,
+  configPath: "",
+  statusTimeoutId: null,
+  fetchInFlight: false,
+  fetchQueued: false,
+};
+
 const archivalState = {
   current: null,
   lastAppliedFingerprint: "",
@@ -1238,6 +1276,12 @@ const configDialogState = {
 };
 
 const servicesDialogState = {
+  open: false,
+  previouslyFocused: null,
+  keydownHandler: null,
+};
+
+const webServerDialogState = {
   open: false,
   previouslyFocused: null,
   keydownHandler: null,
@@ -7924,6 +7968,581 @@ function readDashboardForm() {
   return canonicalDashboardSettings(payload);
 }
 
+function webServerDefaults() {
+  return {
+    mode: "http",
+    listen_host: "0.0.0.0",
+    listen_port: 8080,
+    tls_provider: "letsencrypt",
+    certificate_path: "",
+    private_key_path: "",
+    lets_encrypt: {
+      enabled: false,
+      email: "",
+      domains: [],
+      cache_dir: "/apps/tricorder/letsencrypt",
+      staging: false,
+      certbot_path: "certbot",
+      http_port: 80,
+      renew_before_days: 30,
+    },
+  };
+}
+
+function canonicalWebServerSettings(settings) {
+  const defaults = webServerDefaults();
+  if (!settings || typeof settings !== "object") {
+    return defaults;
+  }
+
+  const canonical = {
+    mode: defaults.mode,
+    listen_host: defaults.listen_host,
+    listen_port: defaults.listen_port,
+    tls_provider: defaults.tls_provider,
+    certificate_path: "",
+    private_key_path: "",
+    lets_encrypt: {
+      enabled: false,
+      email: "",
+      domains: [],
+      cache_dir: defaults.lets_encrypt.cache_dir,
+      staging: false,
+      certbot_path: defaults.lets_encrypt.certbot_path,
+      http_port: defaults.lets_encrypt.http_port,
+      renew_before_days: defaults.lets_encrypt.renew_before_days,
+    },
+  };
+
+  if (typeof settings.mode === "string") {
+    const mode = settings.mode.trim().toLowerCase();
+    if (mode === "https" || mode === "http") {
+      canonical.mode = mode;
+    }
+  }
+
+  if (typeof settings.listen_host === "string") {
+    const host = settings.listen_host.trim();
+    canonical.listen_host = host || defaults.listen_host;
+  }
+
+  const portValue = settings.listen_port;
+  if (typeof portValue === "number" && Number.isFinite(portValue)) {
+    const normalized = Math.min(65535, Math.max(1, Math.round(portValue)));
+    canonical.listen_port = normalized;
+  } else if (typeof portValue === "string" && portValue.trim() !== "") {
+    const parsed = Number(portValue);
+    if (Number.isFinite(parsed)) {
+      const normalized = Math.min(65535, Math.max(1, Math.round(parsed)));
+      canonical.listen_port = normalized;
+    }
+  }
+
+  if (typeof settings.tls_provider === "string") {
+    const provider = settings.tls_provider.trim().toLowerCase();
+    if (WEB_SERVER_TLS_PROVIDERS.has(provider)) {
+      canonical.tls_provider = provider;
+    }
+  }
+
+  if (typeof settings.certificate_path === "string") {
+    canonical.certificate_path = settings.certificate_path.trim();
+  }
+  if (typeof settings.private_key_path === "string") {
+    canonical.private_key_path = settings.private_key_path.trim();
+  }
+
+  const letsEncrypt =
+    settings.lets_encrypt && typeof settings.lets_encrypt === "object"
+      ? settings.lets_encrypt
+      : {};
+  canonical.lets_encrypt.enabled = parseBoolean(letsEncrypt.enabled);
+  if (typeof letsEncrypt.email === "string") {
+    canonical.lets_encrypt.email = letsEncrypt.email.trim();
+  }
+  if (Array.isArray(letsEncrypt.domains)) {
+    canonical.lets_encrypt.domains = letsEncrypt.domains
+      .map((item) => (typeof item === "string" ? item.trim() : ""))
+      .filter((item) => item);
+  } else if (typeof letsEncrypt.domains === "string") {
+    canonical.lets_encrypt.domains = parseListInput(letsEncrypt.domains);
+  }
+  if (typeof letsEncrypt.cache_dir === "string") {
+    canonical.lets_encrypt.cache_dir = letsEncrypt.cache_dir.trim() || defaults.lets_encrypt.cache_dir;
+  }
+  canonical.lets_encrypt.staging = parseBoolean(letsEncrypt.staging);
+  if (typeof letsEncrypt.certbot_path === "string") {
+    canonical.lets_encrypt.certbot_path = letsEncrypt.certbot_path.trim() || defaults.lets_encrypt.certbot_path;
+  }
+  const httpPortValue = letsEncrypt.http_port;
+  if (typeof httpPortValue === "number" && Number.isFinite(httpPortValue)) {
+    canonical.lets_encrypt.http_port = Math.min(65535, Math.max(1, Math.round(httpPortValue)));
+  } else if (typeof httpPortValue === "string" && httpPortValue.trim() !== "") {
+    const parsed = Number(httpPortValue);
+    if (Number.isFinite(parsed)) {
+      canonical.lets_encrypt.http_port = Math.min(65535, Math.max(1, Math.round(parsed)));
+    }
+  }
+  const renewValue = letsEncrypt.renew_before_days;
+  if (typeof renewValue === "number" && Number.isFinite(renewValue)) {
+    canonical.lets_encrypt.renew_before_days = Math.max(1, Math.round(renewValue));
+  } else if (typeof renewValue === "string" && renewValue.trim() !== "") {
+    const parsed = Number(renewValue);
+    if (Number.isFinite(parsed)) {
+      canonical.lets_encrypt.renew_before_days = Math.max(1, Math.round(parsed));
+    }
+  }
+
+  if (canonical.mode !== "https") {
+    canonical.tls_provider = defaults.tls_provider;
+    canonical.lets_encrypt.enabled = false;
+  } else if (!WEB_SERVER_TLS_PROVIDERS.has(canonical.tls_provider)) {
+    canonical.tls_provider = "letsencrypt";
+  }
+
+  return canonical;
+}
+
+function computeWebServerFingerprint(settings) {
+  return JSON.stringify(canonicalWebServerSettings(settings));
+}
+
+function normalizeWebServerResponse(payload) {
+  const settings =
+    payload && typeof payload === "object"
+      ? canonicalWebServerSettings(payload["web_server"])
+      : webServerDefaults();
+  const configPath =
+    payload && typeof payload === "object" && typeof payload.config_path === "string"
+      ? payload.config_path
+      : "";
+  return { settings, configPath };
+}
+
+function updateWebServerConfigPath(path) {
+  const text = typeof path === "string" ? path : "";
+  webServerState.configPath = text;
+  if (dom.webServerConfigPath) {
+    dom.webServerConfigPath.textContent = text || "(unknown)";
+  }
+}
+
+function updateWebServerVisibility() {
+  const mode = dom.webServerMode ? dom.webServerMode.value : "http";
+  const provider = dom.webServerTlsProvider ? dom.webServerTlsProvider.value : "letsencrypt";
+  const showTls = mode === "https";
+  const showLetsEncrypt = showTls && provider === "letsencrypt";
+  const showManual = showTls && provider === "manual";
+  if (dom.webServerLetsEncryptSection) {
+    dom.webServerLetsEncryptSection.hidden = !showLetsEncrypt;
+    dom.webServerLetsEncryptSection.dataset.active = showLetsEncrypt ? "true" : "false";
+    dom.webServerLetsEncryptSection.setAttribute("aria-hidden", showLetsEncrypt ? "false" : "true");
+  }
+  if (dom.webServerManualSection) {
+    dom.webServerManualSection.hidden = !showManual;
+    dom.webServerManualSection.dataset.active = showManual ? "true" : "false";
+    dom.webServerManualSection.setAttribute("aria-hidden", showManual ? "false" : "true");
+  }
+}
+
+function setWebServerStatus(message, state = "", options = {}) {
+  if (!dom.webServerStatus) {
+    return;
+  }
+  if (webServerState.statusTimeoutId) {
+    window.clearTimeout(webServerState.statusTimeoutId);
+    webServerState.statusTimeoutId = null;
+  }
+  const text = typeof message === "string" ? message : "";
+  dom.webServerStatus.textContent = text;
+  if (state) {
+    dom.webServerStatus.dataset.state = state;
+  } else {
+    delete dom.webServerStatus.dataset.state;
+  }
+  dom.webServerStatus.setAttribute("aria-hidden", text ? "false" : "true");
+  const { autoHide = false, duration = 3500 } = options;
+  if (text && autoHide) {
+    const delay = Number.isFinite(duration) ? Math.max(0, duration) : 3500;
+    webServerState.statusTimeoutId = window.setTimeout(() => {
+      webServerState.statusTimeoutId = null;
+      if (!webServerState.dirty) {
+        setWebServerStatus("", "");
+      }
+    }, delay);
+  }
+}
+
+function updateWebServerButtons() {
+  if (dom.webServerSave) {
+    dom.webServerSave.disabled = webServerState.saving || !webServerState.dirty;
+  }
+  if (dom.webServerReset) {
+    const disableReset =
+      webServerState.saving ||
+      (!webServerState.dirty && !webServerState.pendingSnapshot && !webServerState.hasExternalUpdate);
+    dom.webServerReset.disabled = disableReset;
+  }
+  if (dom.webServerDialog) {
+    dom.webServerDialog.dataset.dirty = webServerState.dirty ? "true" : "false";
+    dom.webServerDialog.dataset.saving = webServerState.saving ? "true" : "false";
+    dom.webServerDialog.dataset.externalUpdate = webServerState.hasExternalUpdate ? "true" : "false";
+  }
+}
+
+function setWebServerSaving(saving) {
+  webServerState.saving = saving;
+  if (dom.webServerForm) {
+    dom.webServerForm.setAttribute("aria-busy", saving ? "true" : "false");
+  }
+  updateWebServerButtons();
+}
+
+function applyWebServerData(settings, { markPristine = true } = {}) {
+  const canonical = canonicalWebServerSettings(settings);
+  webServerState.current = canonical;
+  if (dom.webServerMode) {
+    dom.webServerMode.value = canonical.mode;
+  }
+  if (dom.webServerHost) {
+    dom.webServerHost.value = canonical.listen_host;
+  }
+  if (dom.webServerPort) {
+    dom.webServerPort.value = String(canonical.listen_port);
+  }
+  if (dom.webServerTlsProvider) {
+    dom.webServerTlsProvider.value = canonical.tls_provider;
+  }
+  if (dom.webServerManualCert) {
+    dom.webServerManualCert.value = canonical.certificate_path || "";
+  }
+  if (dom.webServerManualKey) {
+    dom.webServerManualKey.value = canonical.private_key_path || "";
+  }
+  if (dom.webServerLetsEncryptDomains) {
+    dom.webServerLetsEncryptDomains.value = canonical.lets_encrypt.domains.join("\n");
+  }
+  if (dom.webServerLetsEncryptEmail) {
+    dom.webServerLetsEncryptEmail.value = canonical.lets_encrypt.email || "";
+  }
+  if (dom.webServerLetsEncryptStaging) {
+    dom.webServerLetsEncryptStaging.checked = Boolean(canonical.lets_encrypt.staging);
+  }
+  if (dom.webServerLetsEncryptHttpPort) {
+    dom.webServerLetsEncryptHttpPort.value = String(canonical.lets_encrypt.http_port);
+  }
+
+  updateWebServerVisibility();
+
+  if (markPristine) {
+    webServerState.lastAppliedFingerprint = computeWebServerFingerprint(canonical);
+    webServerState.dirty = false;
+    webServerState.pendingSnapshot = null;
+    webServerState.hasExternalUpdate = false;
+  }
+  updateWebServerButtons();
+}
+
+function readWebServerForm() {
+  const payload = {
+    mode: dom.webServerMode ? dom.webServerMode.value : "http",
+    listen_host: dom.webServerHost ? dom.webServerHost.value : "",
+    listen_port: dom.webServerPort ? dom.webServerPort.value : "",
+    tls_provider: dom.webServerTlsProvider ? dom.webServerTlsProvider.value : "letsencrypt",
+    certificate_path: dom.webServerManualCert ? dom.webServerManualCert.value : "",
+    private_key_path: dom.webServerManualKey ? dom.webServerManualKey.value : "",
+    lets_encrypt: {
+      enabled: true,
+      email: dom.webServerLetsEncryptEmail ? dom.webServerLetsEncryptEmail.value : "",
+      domains: dom.webServerLetsEncryptDomains ? dom.webServerLetsEncryptDomains.value : "",
+      staging: dom.webServerLetsEncryptStaging ? dom.webServerLetsEncryptStaging.checked : false,
+      http_port: dom.webServerLetsEncryptHttpPort ? dom.webServerLetsEncryptHttpPort.value : "",
+    },
+  };
+  const canonical = canonicalWebServerSettings(payload);
+  return canonical;
+}
+
+function updateWebServerDirtyState() {
+  const fingerprint = computeWebServerFingerprint(readWebServerForm());
+  webServerState.dirty = fingerprint !== webServerState.lastAppliedFingerprint;
+  updateWebServerButtons();
+}
+
+function handleWebServerReset() {
+  if (webServerState.saving) {
+    return;
+  }
+  if (webServerState.pendingSnapshot) {
+    applyWebServerData(webServerState.pendingSnapshot, { markPristine: true });
+    setWebServerStatus("Loaded updated settings from disk.", "info", { autoHide: true, duration: 2500 });
+    return;
+  }
+  if (webServerState.current) {
+    applyWebServerData(webServerState.current, { markPristine: true });
+    setWebServerStatus("Reverted unsaved changes.", "info", { autoHide: true, duration: 2000 });
+  }
+}
+
+async function fetchWebServerSettings({ silent = false } = {}) {
+  if (webServerState.fetchInFlight) {
+    webServerState.fetchQueued = true;
+    return;
+  }
+  webServerState.fetchInFlight = true;
+  webServerState.loading = true;
+  if (!silent) {
+    setWebServerStatus("Loading web server settings…", "info");
+  }
+  try {
+    const response = await fetch(WEB_SERVER_ENDPOINT, { cache: "no-store" });
+    if (!response.ok) {
+      throw new Error(`Request failed with ${response.status}`);
+    }
+    const payload = await response.json();
+    const { settings, configPath } = normalizeWebServerResponse(payload);
+    applyWebServerData(settings, { markPristine: true });
+    updateWebServerConfigPath(configPath);
+    webServerState.loaded = true;
+    if (!silent) {
+      setWebServerStatus("Loaded web server settings.", "success", { autoHide: true, duration: 1800 });
+    } else if (!webServerState.dirty) {
+      setWebServerStatus("", "");
+    }
+  } catch (error) {
+    console.error("Failed to fetch web server settings", error);
+    const message = error && error.message ? error.message : "Unable to load web server settings.";
+    setWebServerStatus(message, "error");
+  } finally {
+    webServerState.fetchInFlight = false;
+    webServerState.loading = false;
+    updateWebServerButtons();
+    if (webServerState.fetchQueued) {
+      webServerState.fetchQueued = false;
+      fetchWebServerSettings({ silent: true });
+    }
+  }
+}
+
+function syncWebServerSnapshotFromConfig(cfg) {
+  if (!cfg || typeof cfg !== "object") {
+    return;
+  }
+  const snapshot = canonicalWebServerSettings(cfg.web_server);
+  const fingerprint = computeWebServerFingerprint(snapshot);
+  if (!webServerState.loaded) {
+    applyWebServerData(snapshot, { markPristine: true });
+    return;
+  }
+  if (fingerprint === webServerState.lastAppliedFingerprint) {
+    return;
+  }
+  if (!webServerState.dirty) {
+    applyWebServerData(snapshot, { markPristine: true });
+    setWebServerStatus("Web server settings updated from config file.", "info", {
+      autoHide: true,
+      duration: 2500,
+    });
+  } else {
+    webServerState.pendingSnapshot = snapshot;
+    webServerState.hasExternalUpdate = true;
+    setWebServerStatus("Web server settings changed on disk. Reset to load the new values.", "warning");
+    updateWebServerButtons();
+  }
+}
+
+async function saveWebServerSettings() {
+  if (webServerState.saving) {
+    return;
+  }
+  setWebServerSaving(true);
+  setWebServerStatus("Saving web server settings…", "info");
+  try {
+    const payload = readWebServerForm();
+    const response = await fetch(WEB_SERVER_ENDPOINT, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload),
+    });
+    if (!response.ok) {
+      const errorText = await extractErrorMessage(response);
+      throw new Error(errorText || `Request failed with ${response.status}`);
+    }
+    const body = await response.json();
+    const { settings, configPath } = normalizeWebServerResponse(body);
+    applyWebServerData(settings, { markPristine: true });
+    updateWebServerConfigPath(configPath);
+    webServerState.loaded = true;
+    setWebServerStatus("Saved web server settings.", "success", { autoHide: true, duration: 2000 });
+  } catch (error) {
+    console.error("Failed to save web server settings", error);
+    const message = error && error.message ? error.message : "Unable to save web server settings.";
+    setWebServerStatus(message, "error");
+  } finally {
+    setWebServerSaving(false);
+  }
+}
+
+function webServerModalFocusableElements() {
+  if (!dom.webServerDialog) {
+    return [];
+  }
+  const selectors =
+    'button:not([disabled]), [href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])';
+  const nodes = dom.webServerDialog.querySelectorAll(selectors);
+  const focusable = [];
+  for (const node of nodes) {
+    if (!(node instanceof HTMLElement)) {
+      continue;
+    }
+    if (node.hasAttribute("disabled")) {
+      continue;
+    }
+    if (node.getAttribute("aria-hidden") === "true") {
+      continue;
+    }
+    if (node.offsetParent === null && node !== document.activeElement) {
+      continue;
+    }
+    focusable.push(node);
+  }
+  return focusable;
+}
+
+function setWebServerModalVisible(visible) {
+  if (!dom.webServerModal) {
+    return;
+  }
+  dom.webServerModal.dataset.visible = visible ? "true" : "false";
+  dom.webServerModal.setAttribute("aria-hidden", visible ? "false" : "true");
+  if (visible) {
+    dom.webServerModal.removeAttribute("hidden");
+    lockDocumentScroll("web-server-settings");
+  } else {
+    dom.webServerModal.setAttribute("hidden", "hidden");
+    unlockDocumentScroll("web-server-settings");
+  }
+}
+
+function attachWebServerDialogKeydown() {
+  if (webServerDialogState.keydownHandler) {
+    return;
+  }
+  webServerDialogState.keydownHandler = (event) => {
+    if (!webServerDialogState.open) {
+      return;
+    }
+    const target = event.target;
+    const withinModal =
+      dom.webServerModal &&
+      target instanceof Node &&
+      (target === dom.webServerModal || dom.webServerModal.contains(target));
+    if (event.key === "Escape") {
+      event.preventDefault();
+      closeWebServerModal();
+      return;
+    }
+    if (event.key !== "Tab" || !withinModal) {
+      return;
+    }
+    const focusable = webServerModalFocusableElements();
+    if (focusable.length === 0) {
+      event.preventDefault();
+      if (dom.webServerDialog) {
+        dom.webServerDialog.focus();
+      }
+      return;
+    }
+    const [first] = focusable;
+    const last = focusable[focusable.length - 1];
+    const active = document.activeElement instanceof HTMLElement ? document.activeElement : null;
+    if (event.shiftKey) {
+      if (!active || active === first || active === dom.webServerDialog) {
+        event.preventDefault();
+        last.focus();
+      }
+    } else if (!active || active === last) {
+      event.preventDefault();
+      first.focus();
+    }
+  };
+  document.addEventListener("keydown", webServerDialogState.keydownHandler, true);
+}
+
+function detachWebServerDialogKeydown() {
+  if (!webServerDialogState.keydownHandler) {
+    return;
+  }
+  document.removeEventListener("keydown", webServerDialogState.keydownHandler, true);
+  webServerDialogState.keydownHandler = null;
+}
+
+function focusWebServerDialog() {
+  if (!dom.webServerDialog) {
+    return;
+  }
+  window.requestAnimationFrame(() => {
+    const focusable = webServerModalFocusableElements();
+    if (focusable.length > 0) {
+      focusable[0].focus();
+    } else {
+      dom.webServerDialog.focus();
+    }
+  });
+}
+
+function openWebServerModal(options = {}) {
+  if (!dom.webServerModal || !dom.webServerDialog) {
+    return;
+  }
+  const { focus = true } = options;
+  if (webServerDialogState.open) {
+    if (focus) {
+      focusWebServerDialog();
+    }
+    return;
+  }
+  webServerDialogState.open = true;
+  webServerDialogState.previouslyFocused =
+    document.activeElement instanceof HTMLElement ? document.activeElement : null;
+  setWebServerModalVisible(true);
+  if (dom.webServerOpen) {
+    dom.webServerOpen.setAttribute("aria-expanded", "true");
+  }
+  attachWebServerDialogKeydown();
+  if (!webServerState.loaded && !webServerState.fetchInFlight) {
+    fetchWebServerSettings({ silent: false });
+  } else if (webServerState.hasExternalUpdate && webServerState.pendingSnapshot && !webServerState.saving) {
+    setWebServerStatus(
+      "Web server settings changed on disk. Reset to load the new values.",
+      "warning"
+    );
+  } else {
+    updateWebServerButtons();
+  }
+  if (focus) {
+    focusWebServerDialog();
+  }
+}
+
+function closeWebServerModal(options = {}) {
+  if (!webServerDialogState.open) {
+    return;
+  }
+  const { restoreFocus = true } = options;
+  webServerDialogState.open = false;
+  setWebServerModalVisible(false);
+  if (dom.webServerOpen) {
+    dom.webServerOpen.setAttribute("aria-expanded", "false");
+  }
+  detachWebServerDialogKeydown();
+  const previous = webServerDialogState.previouslyFocused;
+  webServerDialogState.previouslyFocused = null;
+  if (restoreFocus && previous && typeof previous.focus === "function") {
+    previous.focus();
+  }
+}
+
 function archivalDefaults() {
   return {
     enabled: false,
@@ -8343,6 +8962,7 @@ async function fetchConfig({ silent = false } = {}) {
       updateRecorderConfigPath(payload.config_path);
     }
     syncRecorderSectionsFromConfig(payload);
+    syncWebServerSnapshotFromConfig(payload);
     syncArchivalSnapshotFromConfig(payload);
   } catch (error) {
     console.error("Failed to fetch config", error);
@@ -11641,6 +12261,55 @@ function attachEventListeners() {
     });
   }
 
+  if (dom.webServerOpen) {
+    dom.webServerOpen.addEventListener("click", () => {
+      closeAppMenu({ restoreFocus: false });
+      openWebServerModal();
+    });
+  }
+
+  if (dom.webServerClose) {
+    dom.webServerClose.addEventListener("click", () => {
+      closeWebServerModal();
+    });
+  }
+
+  if (dom.webServerModal) {
+    dom.webServerModal.addEventListener("mousedown", (event) => {
+      if (event.target === dom.webServerModal) {
+        event.preventDefault();
+      }
+    });
+    dom.webServerModal.addEventListener("click", (event) => {
+      if (event.target === dom.webServerModal) {
+        closeWebServerModal();
+      }
+    });
+  }
+
+  if (dom.webServerForm) {
+    dom.webServerForm.addEventListener("submit", (event) => {
+      event.preventDefault();
+      saveWebServerSettings();
+    });
+
+    const handleWebServerChange = (event) => {
+      if (event && (event.target === dom.webServerMode || event.target === dom.webServerTlsProvider)) {
+        updateWebServerVisibility();
+      }
+      updateWebServerDirtyState();
+    };
+
+    dom.webServerForm.addEventListener("input", handleWebServerChange);
+    dom.webServerForm.addEventListener("change", handleWebServerChange);
+  }
+
+  if (dom.webServerReset) {
+    dom.webServerReset.addEventListener("click", () => {
+      handleWebServerReset();
+    });
+  }
+
   if (dom.archivalOpen) {
     dom.archivalOpen.addEventListener("click", () => {
       closeAppMenu({ restoreFocus: false });
@@ -12198,15 +12867,19 @@ function initialize() {
   setLiveToggleDisabled(true, "Checking recorder service status…");
   setRecorderModalVisible(false);
   setConfigModalVisible(false);
+  setWebServerModalVisible(false);
   updateRecorderConfigPath(recorderState.configPath);
   registerRecorderSections();
   updateAudioFilterControls();
   setServicesModalVisible(false);
+  applyWebServerData(webServerDefaults(), { markPristine: true });
+  updateWebServerConfigPath(webServerState.configPath);
   applyArchivalData(archivalDefaults(), { markPristine: true });
   updateArchivalConfigPath(archivalState.configPath);
   attachEventListeners();
   fetchRecordings({ silent: false });
   fetchConfig({ silent: false });
+  fetchWebServerSettings({ silent: true });
   fetchArchivalSettings({ silent: true });
   startConfigRefresh();
   startHealthRefresh();

--- a/lib/webui/static/js/dashboard.js
+++ b/lib/webui/static/js/dashboard.js
@@ -391,6 +391,9 @@ const dom = {
   webServerLetsEncryptEmail: document.getElementById("web-server-letsencrypt-email"),
   webServerLetsEncryptStaging: document.getElementById("web-server-letsencrypt-staging"),
   webServerLetsEncryptHttpPort: document.getElementById("web-server-letsencrypt-http-port"),
+  webServerLetsEncryptCacheDir: document.getElementById("web-server-letsencrypt-cache-dir"),
+  webServerLetsEncryptCertbot: document.getElementById("web-server-letsencrypt-certbot"),
+  webServerLetsEncryptRenewBefore: document.getElementById("web-server-letsencrypt-renew-before"),
   webServerManualCert: document.getElementById("web-server-cert"),
   webServerManualKey: document.getElementById("web-server-key"),
   webServerStatus: document.getElementById("web-server-status"),
@@ -8231,6 +8234,15 @@ function applyWebServerData(settings, { markPristine = true } = {}) {
   if (dom.webServerLetsEncryptHttpPort) {
     dom.webServerLetsEncryptHttpPort.value = String(canonical.lets_encrypt.http_port);
   }
+  if (dom.webServerLetsEncryptCacheDir) {
+    dom.webServerLetsEncryptCacheDir.value = canonical.lets_encrypt.cache_dir || "";
+  }
+  if (dom.webServerLetsEncryptCertbot) {
+    dom.webServerLetsEncryptCertbot.value = canonical.lets_encrypt.certbot_path || "";
+  }
+  if (dom.webServerLetsEncryptRenewBefore) {
+    dom.webServerLetsEncryptRenewBefore.value = String(canonical.lets_encrypt.renew_before_days);
+  }
 
   updateWebServerVisibility();
 
@@ -8257,6 +8269,11 @@ function readWebServerForm() {
       domains: dom.webServerLetsEncryptDomains ? dom.webServerLetsEncryptDomains.value : "",
       staging: dom.webServerLetsEncryptStaging ? dom.webServerLetsEncryptStaging.checked : false,
       http_port: dom.webServerLetsEncryptHttpPort ? dom.webServerLetsEncryptHttpPort.value : "",
+      cache_dir: dom.webServerLetsEncryptCacheDir ? dom.webServerLetsEncryptCacheDir.value : "",
+      certbot_path: dom.webServerLetsEncryptCertbot ? dom.webServerLetsEncryptCertbot.value : "",
+      renew_before_days: dom.webServerLetsEncryptRenewBefore
+        ? dom.webServerLetsEncryptRenewBefore.value
+        : "",
     },
   };
   const canonical = canonicalWebServerSettings(payload);

--- a/lib/webui/templates/dashboard.html
+++ b/lib/webui/templates/dashboard.html
@@ -1624,6 +1624,27 @@
                   Port used for HTTP-01 validation (default 80). Ensure it is reachable from the public internet.
                 </p>
               </div>
+              <div class="settings-field">
+                <label for="web-server-letsencrypt-cache-dir">Cache directory</label>
+                <input id="web-server-letsencrypt-cache-dir" type="text" autocomplete="off" />
+                <p class="field-description">
+                  Directory where certbot stores account data and issued certificates. Update when using a custom storage path.
+                </p>
+              </div>
+              <div class="settings-field">
+                <label for="web-server-letsencrypt-certbot">Certbot command</label>
+                <input id="web-server-letsencrypt-certbot" type="text" autocomplete="off" />
+                <p class="field-description">
+                  Override the certbot executable (default <code>certbot</code>) if it is installed in a non-standard location.
+                </p>
+              </div>
+              <div class="settings-field">
+                <label for="web-server-letsencrypt-renew-before">Renew before (days)</label>
+                <input id="web-server-letsencrypt-renew-before" type="number" min="1" max="90" />
+                <p class="field-description">
+                  How many days before expiration the recorder requests a renewal. Increase for short validation windows.
+                </p>
+              </div>
             </section>
 
             <section

--- a/lib/webui/templates/dashboard.html
+++ b/lib/webui/templates/dashboard.html
@@ -171,6 +171,16 @@
                     Archival settings
                   </button>
                   <button
+                    id="web-server-open"
+                    class="menu-item"
+                    type="button"
+                    role="menuitem"
+                    aria-haspopup="dialog"
+                    aria-expanded="false"
+                  >
+                    Web server
+                  </button>
+                  <button
                     id="services-open"
                     class="menu-item"
                     type="button"
@@ -1494,6 +1504,178 @@
       </div>
     </div>
     <div
+      id="web-server-modal"
+      class="settings-modal"
+      hidden
+      data-visible="false"
+      aria-hidden="true"
+    >
+      <div
+        id="web-server-dialog"
+        class="settings-dialog card"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="web-server-dialog-title"
+        aria-describedby="web-server-dialog-description"
+        tabindex="-1"
+      >
+        <div class="card-header settings-dialog-header">
+          <div class="card-heading">
+            <h2 id="web-server-dialog-title">Web server</h2>
+            <p id="web-server-dialog-description" class="card-subtitle">
+              Configure the dashboard listener and TLS settings.
+            </p>
+          </div>
+          <div class="settings-dialog-actions">
+            <button id="web-server-close" class="ghost-button small" type="button">
+              Close
+            </button>
+          </div>
+        </div>
+        <form id="web-server-form" class="settings-form">
+          <div class="settings-dialog-body">
+            <section class="settings-section">
+              <div class="settings-section-header">
+                <h3 class="settings-section-title">Listener</h3>
+                <p class="settings-section-description">
+                  Choose how the dashboard API binds to the network.
+                </p>
+              </div>
+              <div class="settings-field">
+                <label for="web-server-mode">Mode</label>
+                <select id="web-server-mode">
+                  <option value="http">HTTP (no TLS)</option>
+                  <option value="https">HTTPS (TLS)</option>
+                </select>
+                <p class="field-description">
+                  Switch to HTTPS to serve the dashboard securely using TLS certificates.
+                </p>
+              </div>
+              <div class="settings-field">
+                <label for="web-server-host">Bind address</label>
+                <input id="web-server-host" type="text" autocomplete="off" />
+                <p class="field-description">
+                  Default <code>0.0.0.0</code> listens on all interfaces. Use 127.0.0.1 to restrict to localhost.
+                </p>
+              </div>
+              <div class="settings-field">
+                <label for="web-server-port">Port</label>
+                <input id="web-server-port" type="number" min="1" max="65535" />
+                <p class="field-description">
+                  Recommended values: 80 for HTTP or 443 for HTTPS so browsers connect without a custom port.
+                </p>
+              </div>
+              <div class="settings-field">
+                <label for="web-server-tls-provider">TLS provider</label>
+                <select id="web-server-tls-provider">
+                  <option value="letsencrypt">Let's Encrypt (automatic)</option>
+                  <option value="manual">Manual certificate</option>
+                </select>
+                <p class="field-description">
+                  Automatic certificates require public DNS and access to the HTTP challenge port.
+                </p>
+              </div>
+            </section>
+
+            <section
+              id="web-server-letsencrypt-section"
+              class="settings-section"
+              data-active="false"
+              aria-hidden="true"
+              hidden
+            >
+              <div class="settings-section-header">
+                <h3 class="settings-section-title">Let's Encrypt</h3>
+                <p class="settings-section-description">
+                  Issue and renew certificates automatically using certbot.
+                </p>
+              </div>
+              <div class="settings-field">
+                <label for="web-server-letsencrypt-domains">Domains</label>
+                <textarea
+                  id="web-server-letsencrypt-domains"
+                  rows="3"
+                  placeholder="recorder.example.com"
+                ></textarea>
+                <p class="field-description">
+                  One domain per line. Each name must resolve to this recorder for validation to succeed.
+                </p>
+              </div>
+              <div class="settings-field">
+                <label for="web-server-letsencrypt-email">Contact email (optional)</label>
+                <input id="web-server-letsencrypt-email" type="email" autocomplete="off" />
+                <p class="field-description">
+                  Used for renewal notices from Let's Encrypt. Leave blank to register without an email.
+                </p>
+              </div>
+              <div class="settings-field checkbox-field">
+                <div class="field-control">
+                  <input id="web-server-letsencrypt-staging" type="checkbox" />
+                  <label for="web-server-letsencrypt-staging">Use Let's Encrypt staging</label>
+                </div>
+                <p class="field-description">
+                  Enable while testing to avoid production rate limits. Staging certificates are not trusted by browsers.
+                </p>
+              </div>
+              <div class="settings-field">
+                <label for="web-server-letsencrypt-http-port">Challenge port</label>
+                <input id="web-server-letsencrypt-http-port" type="number" min="1" max="65535" />
+                <p class="field-description">
+                  Port used for HTTP-01 validation (default 80). Ensure it is reachable from the public internet.
+                </p>
+              </div>
+            </section>
+
+            <section
+              id="web-server-manual-section"
+              class="settings-section"
+              data-active="false"
+              aria-hidden="true"
+              hidden
+            >
+              <div class="settings-section-header">
+                <h3 class="settings-section-title">Manual certificate</h3>
+                <p class="settings-section-description">
+                  Provide paths to existing PEM files that contain the certificate and private key.
+                </p>
+              </div>
+              <div class="settings-field">
+                <label for="web-server-cert">Certificate path</label>
+                <input id="web-server-cert" type="text" autocomplete="off" />
+              </div>
+              <div class="settings-field">
+                <label for="web-server-key">Private key path</label>
+                <input id="web-server-key" type="text" autocomplete="off" />
+              </div>
+            </section>
+          </div>
+          <footer class="settings-dialog-footer">
+            <div class="settings-footnote">
+              Saved to <code id="web-server-config-path"></code>
+            </div>
+            <div class="settings-footer-actions">
+              <div
+                id="web-server-status"
+                class="form-status"
+                role="status"
+                aria-live="polite"
+                aria-hidden="true"
+              ></div>
+              <div class="button-row">
+                <button id="web-server-reset" class="ghost-button" type="button" disabled>
+                  Reset
+                </button>
+                <button id="web-server-save" class="primary-button" type="submit" disabled>
+                  Save changes
+                </button>
+              </div>
+            </div>
+          </footer>
+        </form>
+      </div>
+    </div>
+
+    <div
       id="archival-modal"
       class="settings-modal"
       hidden
@@ -1664,6 +1846,7 @@
           </footer>
         </form>
       </div>
+    </div>
     </div>
   </body>
 </html>

--- a/main.py
+++ b/main.py
@@ -59,16 +59,22 @@ def run_once():
         pass
 
 
-def main():
-    stop_service()
-    print("[dev] Running live_stream_daemon (Ctrl-C to exit, Ctrl-R to restart)")
+def _start_dev_web_streamer() -> "WebStreamerHandle":
+    """Start the dashboard web streamer with the dev launcher defaults."""
 
-    web_streamer = start_web_streamer_in_thread(
+    return start_web_streamer_in_thread(
         host="0.0.0.0",
         port=8080,
         access_log=False,
         log_level="INFO",
     )
+
+
+def main():
+    stop_service()
+    print("[dev] Running live_stream_daemon (Ctrl-C to exit, Ctrl-R to restart)")
+
+    web_streamer = _start_dev_web_streamer()
 
     while True:
         watcher = KeyWatcher()
@@ -84,12 +90,7 @@ def main():
 
         if watcher.restart_requested:
             print("[dev] Restart requested via Ctrl-R")
-            web_streamer = start_web_streamer_in_thread(
-                host="0.0.0.0",
-                port=8080,
-                access_log=False,
-                log_level="INFO",
-            )
+            web_streamer = _start_dev_web_streamer()
             continue
         else:
             print("[dev] Exiting dev mode")

--- a/tests/test_25_web_streamer.py
+++ b/tests/test_25_web_streamer.py
@@ -3,15 +3,81 @@ from __future__ import annotations
 import asyncio
 import json
 import time
-from datetime import datetime, timezone
+from datetime import datetime, timezone, timedelta
 
 import pytest
 
 import copy
+import ssl
+import subprocess
+from pathlib import Path
+from types import SimpleNamespace
 
 import lib.web_streamer as web_streamer
+import lib.lets_encrypt as lets_encrypt
 
 pytest_plugins = ("aiohttp.pytest_plugin",)
+
+
+TEST_CERT_PEM = """-----BEGIN CERTIFICATE-----
+MIIDDTCCAfWgAwIBAgIUCetl27jBsWzLcDiiax1l5UG7YmAwDQYJKoZIhvcNAQEL
+BQAwFjEUMBIGA1UEAwwLZXhhbXBsZS5jb20wHhcNMjUxMDAyMTAxMTU2WhcNMjUx
+MDAzMTAxMTU2WjAWMRQwEgYDVQQDDAtleGFtcGxlLmNvbTCCASIwDQYJKoZIhvcN
+AQEBBQADggEPADCCAQoCggEBAK4Zgs0VnsxDRtnYT9eAFdDNAiYV2MZpQnsL9Eqo
+UoznUeamSf1McLYGmqMeM2Yf99IAVewBeWBbuqQl4Y6wVPUi7G5OwN7aSK+OI5Uu
+DseqM4dA/TgEskcDE6Gob7jgMfbQQg07YDIFK3nyc62gFuC+Qc78MDHqmYCI4czW
+rQhbxEpAqSnLLkG6Kr1PDOP0GpS+q+aZysTMPc4wKN7hdClJdgkdsTFcJNPJbLqi
+X2bMMiSZ9ZRvlELJKySCr+VX2reT5u8/qyEGNRvDCNElnikPCfDmAK5XmeLfriFF
+Hq/N/4GsiRHc4jGZ8lOPtvKUSvaKXPw2uh1lQTiyyowRgQcCAwEAAaNTMFEwHQYD
+VR0OBBYEFCCp4YpRmop+Id1rLRvL4CvUVFaoMB8GA1UdIwQYMBaAFCCp4YpRmop+
+Id1rLRvL4CvUVFaoMA8GA1UdEwEB/wQFMAMBAf8wDQYJKoZIhvcNAQELBQADggEB
+AEcbhmet4FeyIK3b5GnYcI3apXoskLo8gIgBzzBI/BsFoE6KI5eRwJyFLkqqa3n0
+rPyH4IoDcBLzomRrid3Nsycu17Br1kCQtVdhcWvUIXT+YNw3SzF3aSG0qorKJTFi
+DWW8tNCwo/l4eNYDSjtC/C2NLLtXzXWgpUJoPLOlvRUFDTlwkdY2sbcvew8Tf+B8
+Fuun8Va4RaPN/oEQ/geTZctmi/ZjGlrxnqAkgLKFVAFcqqaLMLScadQ5J1AyZOje
+/s6KQXCeFowoi6qWBfOKR+z6b9XBzu3PL6t09UyphcivJfClZ8SuTdxBK0uUFu2p
+y/DBb2/pfS2PDXTyIFwhtc8=
+-----END CERTIFICATE-----
+"""
+
+
+TEST_KEY_PEM = """-----BEGIN PRIVATE KEY-----
+MIIEvwIBADANBgkqhkiG9w0BAQEFAASCBKkwggSlAgEAAoIBAQCuGYLNFZ7MQ0bZ
+2E/XgBXQzQImFdjGaUJ7C/RKqFKM51Hmpkn9THC2BpqjHjNmH/fSAFXsAXlgW7qk
+JeGOsFT1IuxuTsDe2kivjiOVLg7HqjOHQP04BLJHAxOhqG+44DH20EINO2AyBSt5
+8nOtoBbgvkHO/DAx6pmAiOHM1q0IW8RKQKkpyy5Buiq9Twzj9BqUvqvmmcrEzD3O
+MCje4XQpSXYJHbExXCTTyWy6ol9mzDIkmfWUb5RCySskgq/lV9q3k+bvP6shBjUb
+wwjRJZ4pDwnw5gCuV5ni364hRR6vzf+BrIkR3OIxmfJTj7bylEr2ilz8NrodZUE4
+ssqMEYEHAgMBAAECggEAHNEFKOvksluKXSFkKb++HKbqLaKdFE403kf+weK1czQQ
+htRMV9wwpbhXHRuxFzzAWKaMkjk2PWBBdsz8VhFSppaGusVXQCuyLzigJB+Q+7Rs
+vfzgTMbeOUnFlJLcFyYorvkOjcEfrXfUl+UtB3aBguaK3vc4BPMXQEKn2S9JSaIc
+3N5QcWTf8w9yV6bzCskSu2aLm3rX4QxHtJcxOMLeFL83FGHQE2yFbIJI/Rwa9DP0
+oj3fMZEobvoGz82j98mdfZ6uxjlrk14VS9fDLs+Z9mwg2E9hLS0cE/CUR1dh64fd
+QSp5QjZ5m/abSUhTxvK93NN5dDqZgUn1tEtg0hm0gQKBgQDbjyM8agOfXD8wxm09
+p3QOCfbmHHyXivlPHByNyHC62Gn3JT/la0RHotWdSLJKtqMeVDQVYHrKgL7ys+Yp
+DmVajYF2ly2+3WDvEpS+ZLawnKNjCKL2oOybrZA8bP0gmAhspBYcTQksv/La5juz
+8VxxLYiYGis3LCty09kGwwwugQKBgQDK/teuAoAyHWoj4yVJ80dckeyxybnP+qGm
+WmfEe6V8NopT44bX1u3xQBxCuKcYum21tGuNl8mNljpGXitSx6oT5/Dk4e+jD/VC
++DkQP4ER3kNKMk0g6Fj37fPJ7Cx+E8PPC2zO55iPTtZ2YkfeQNHJHDlaH77jjRec
+MOG3Gc17hwKBgQCPQK001dbXO1Dfehf8ii1mm4nESgHgvoQ74ZOfzo/+2QUKg/tU
+rNA4DT5jCPOLW+7B8x6oc/Kp/aaYpFgfoYzvsDQwNCNczQRZ+D2knAG26fyQuSna
+0NSQHoZlZpchlRCqEcV7YagC0pqZyG5b0bcHATaGR0y7Cs6udRq9FrX0AQKBgQCa
+m4yzyM3Q3ZxopulQsIzqkW3gX085e5/A7txXxwDcYUHr8MBUBiwF8hlULAWAjQVg
+PoEoP7JQN1o9HB4NF2uPa7mK6hY1cMMRdbMoj+WDMXC4wyUBalXQx5hFc67Te8RI
+HmCKGdSVWat4URSBz4a4kNmRrdoav+x6lrRjW7CoYwKBgQCiMK5qox22o8bqOjVX
+Ww/0QDnKHa/H60576XKSiR0K37h3M9fO6ufVM0vbfbnVjZuSP32IvbqTgjNIf1A7
+QGkTnrHQiZ/OdOnwTRN97oyn3jLA90bzEDsckxvqDWag2cd66Jmo2/l7VGSYfX5s
+aC7kjiyNhRRWDfsToon9z4F5WQ==
+-----END PRIVATE KEY-----
+"""
+
+
+def _write_test_certificate(tmp_path: Path) -> tuple[Path, Path]:
+    cert_path = tmp_path / "cert.pem"
+    key_path = tmp_path / "key.pem"
+    cert_path.write_text(TEST_CERT_PEM, encoding="utf-8")
+    key_path.write_text(TEST_KEY_PEM, encoding="utf-8")
+    return cert_path, key_path
 
 
 @pytest.mark.asyncio
@@ -169,6 +235,135 @@ def test_normalize_webrtc_ice_servers_custom_entries():
 
 def test_normalize_webrtc_ice_servers_disable():
     assert web_streamer._normalize_webrtc_ice_servers([]) == []
+
+
+def test_resolve_web_server_runtime_http_defaults():
+    cfg = {"web_server": {"mode": "http", "listen_host": "127.0.0.1", "listen_port": 9090}}
+    host, port, ssl_ctx, manager = web_streamer._resolve_web_server_runtime(cfg)
+
+    assert host == "127.0.0.1"
+    assert port == 9090
+    assert ssl_ctx is None
+    assert manager is None
+
+
+def test_resolve_web_server_runtime_manual(tmp_path):
+    cert_path, key_path = _write_test_certificate(tmp_path)
+    cfg = {
+        "web_server": {
+            "mode": "https",
+            "listen_host": "0.0.0.0",
+            "listen_port": 443,
+            "tls_provider": "manual",
+            "certificate_path": str(cert_path),
+            "private_key_path": str(key_path),
+        }
+    }
+
+    host, port, ssl_ctx, manager = web_streamer._resolve_web_server_runtime(cfg)
+
+    assert host == "0.0.0.0"
+    assert port == 443
+    assert isinstance(ssl_ctx, ssl.SSLContext)
+    assert manager is None
+
+
+def test_resolve_web_server_runtime_letsencrypt(tmp_path):
+    cert_path, key_path = _write_test_certificate(tmp_path)
+    captured: dict[str, object] = {}
+
+    class StubManager:
+        def __init__(self, **kwargs):
+            captured["kwargs"] = kwargs
+
+        def ensure_certificate(self):
+            captured["called"] = True
+            return cert_path, key_path
+
+    cfg = {
+        "web_server": {
+            "mode": "https",
+            "listen_host": "0.0.0.0",
+            "listen_port": 443,
+            "tls_provider": "letsencrypt",
+            "lets_encrypt": {
+                "domains": ["recorder.example.com"],
+                "email": "ops@example.com",
+                "cache_dir": str(tmp_path / "cache"),
+                "staging": True,
+                "certbot_path": "/usr/bin/certbot",
+                "http_port": 8080,
+                "renew_before_days": 10,
+            },
+        }
+    }
+
+    host, port, ssl_ctx, manager = web_streamer._resolve_web_server_runtime(
+        cfg, manager_factory=StubManager
+    )
+
+    assert host == "0.0.0.0"
+    assert port == 443
+    assert isinstance(ssl_ctx, ssl.SSLContext)
+    assert isinstance(manager, StubManager)
+    assert captured.get("called") is True
+    kwargs = captured.get("kwargs")
+    assert isinstance(kwargs, dict)
+    assert kwargs["domains"] == ["recorder.example.com"]
+
+
+def test_resolve_web_server_runtime_requires_domains():
+    cfg = {"web_server": {"mode": "https", "tls_provider": "letsencrypt", "lets_encrypt": {"domains": []}}}
+
+    with pytest.raises(RuntimeError):
+        web_streamer._resolve_web_server_runtime(cfg)
+
+
+def test_resolve_web_server_runtime_requires_manual_paths():
+    cfg = {"web_server": {"mode": "https", "tls_provider": "manual"}}
+
+    with pytest.raises(RuntimeError):
+        web_streamer._resolve_web_server_runtime(cfg)
+
+
+def test_lets_encrypt_manager_requests_certificate(tmp_path, monkeypatch):
+    manager = lets_encrypt.LetsEncryptManager(
+        domains=["recorder.example.com"],
+        email="ops@example.com",
+        cache_dir=tmp_path / "le",
+        staging=True,
+        http_port=8080,
+        renew_before_days=15,
+        certbot_path="certbot",
+    )
+
+    monkeypatch.setattr(manager, "_resolve_certbot", lambda: "/usr/bin/certbot")
+
+    run_calls: list[list[str]] = []
+
+    def fake_run(cmd, *, check, stdout, stderr, text):
+        run_calls.append(cmd)
+        cert_dest, key_dest = manager.certificate_paths()
+        cert_dest.parent.mkdir(parents=True, exist_ok=True)
+        cert_dest.write_text(TEST_CERT_PEM, encoding="utf-8")
+        key_dest.write_text(TEST_KEY_PEM, encoding="utf-8")
+        return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+
+    future_expiration = datetime.now(timezone.utc) + timedelta(days=90)
+    monkeypatch.setattr(manager, "_certificate_expiration", lambda path: future_expiration)
+
+    cert_path, key_path = manager.ensure_certificate()
+    assert cert_path.exists()
+    assert key_path.exists()
+    assert len(run_calls) == 1
+
+    run_calls.clear()
+    cert_path_2, key_path_2 = manager.ensure_certificate()
+    assert not run_calls
+    assert cert_path_2 == cert_path
+    assert key_path_2 == key_path
 
 
 def test_parse_show_output_handles_blank_fields():


### PR DESCRIPTION
## Summary
- wire up the dashboard web server modal with focus management, state syncing, and REST integration
- relocate the modal markup and extend menu entries for the new web server operation settings
- add LetsEncrypt helper module and backend/web UI tests covering web-server endpoints and runtime resolution
- add a TR-52 release note stub that triggers the downstream deployment workflow

## Testing
- export DEV=1 && pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68de49ef17f08327a691a4c1cd5e1e94