### PR TITLE
TR-50: Add save-all button to recorder configuration modal

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,7 @@ Uploads run immediately after the encoder finishes so recordings land in the arc
 - Recycle bin view provides inline audio preview before you restore or permanently clear recordings.
 - Audio preview player with waveform visualization, trigger/release markers, and timeline scrubbing.
 - Config viewer that renders the merged runtime configuration (post-environment overrides).
+- Recorder configuration modal supports saving individual sections or using the **Save all changes** button to persist every dirty section in one go.
 - Persistent SD card health banner fed by the monitor service when kernel/syslog errors appear.
 - JSON APIs (`/api/recordings`, `/api/recycle-bin`, `/api/config`, `/api/recordings/delete`, `/hls/stats` or `/webrtc/stats`, etc.) consumed by the dashboard and available for automation.
 - Legacy HLS status page at `/hls` retained for compatibility with earlier deployments.

--- a/lib/webui/static/js/dashboard.js
+++ b/lib/webui/static/js/dashboard.js
@@ -450,6 +450,8 @@ const recorderDom = {
   dialog: document.getElementById("recorder-settings-dialog"),
   close: document.getElementById("recorder-settings-close"),
   configPath: document.getElementById("recorder-settings-config-path"),
+  saveAll: document.getElementById("recorder-save-all"),
+  saveAllStatus: document.getElementById("recorder-save-all-status"),
   sections: {
     audio: {
       form: document.getElementById("audio-form"),
@@ -1209,6 +1211,11 @@ const recorderState = {
   loaded: false,
   loadingPromise: null,
   sections: new Map(),
+};
+
+const recorderSaveAllState = {
+  saving: false,
+  statusTimeoutId: null,
 };
 
 const recorderDialogState = {
@@ -7054,6 +7061,80 @@ function getRecorderSection(key) {
   return section;
 }
 
+function getRecorderSectionLabel(key) {
+  if (typeof key !== "string" || !key) {
+    return "section";
+  }
+  const safeKey = key.replace(/"/g, '\\"');
+  const selector = `.recorder-section[data-section-key="${safeKey}"] .settings-section-title`;
+  const heading = document.querySelector(selector);
+  if (heading && heading.textContent) {
+    return heading.textContent.trim();
+  }
+  return key.replace(/_/g, " ");
+}
+
+function setRecorderSaveAllStatus(text, state, options = {}) {
+  const statusElement = recorderDom.saveAllStatus;
+  if (!statusElement) {
+    return;
+  }
+
+  if (recorderSaveAllState.statusTimeoutId) {
+    window.clearTimeout(recorderSaveAllState.statusTimeoutId);
+    recorderSaveAllState.statusTimeoutId = null;
+  }
+
+  const message = typeof text === "string" ? text : "";
+  statusElement.textContent = message;
+  if (state) {
+    statusElement.dataset.state = state;
+  } else if (statusElement.dataset.state) {
+    delete statusElement.dataset.state;
+  }
+  statusElement.setAttribute("aria-hidden", message ? "false" : "true");
+
+  if (!message || !options.autoHide) {
+    return;
+  }
+
+  const duration = typeof options.duration === "number" ? Math.max(1000, options.duration) : 3200;
+  recorderSaveAllState.statusTimeoutId = window.setTimeout(() => {
+    recorderSaveAllState.statusTimeoutId = null;
+    statusElement.textContent = "";
+    if (statusElement.dataset.state) {
+      delete statusElement.dataset.state;
+    }
+    statusElement.setAttribute("aria-hidden", "true");
+  }, duration);
+}
+
+function getDirtyRecorderSectionKeys() {
+  const dirty = [];
+  for (const [key, section] of recorderState.sections.entries()) {
+    if (section.state.dirty) {
+      dirty.push(key);
+    }
+  }
+  return dirty;
+}
+
+function updateSaveAllButtonState() {
+  const button = recorderDom.saveAll;
+  if (!button) {
+    return;
+  }
+  const anySectionSaving = Array.from(recorderState.sections.values()).some((section) => section.state.saving);
+  const dirtyKeys = getDirtyRecorderSectionKeys();
+  const disable =
+    recorderSaveAllState.saving ||
+    anySectionSaving ||
+    dirtyKeys.length === 0;
+
+  button.disabled = disable;
+  button.setAttribute("aria-busy", recorderSaveAllState.saving ? "true" : "false");
+}
+
 function setRecorderStatus(key, text, state, options = {}) {
   const section = getRecorderSection(key);
   const statusElement = section.options.status;
@@ -7102,6 +7183,7 @@ function updateRecorderButtons(key) {
   if (form) {
     form.setAttribute("aria-busy", section.state.saving ? "true" : "false");
   }
+  updateSaveAllButtonState();
 }
 
 function applyRecorderSectionData(key, data, { markPristine = false } = {}) {
@@ -7157,6 +7239,44 @@ function resetRecorderSection(key) {
   }
 }
 
+async function saveAllRecorderSections() {
+  if (recorderSaveAllState.saving) {
+    return;
+  }
+  const dirtyKeys = getDirtyRecorderSectionKeys();
+  if (dirtyKeys.length === 0) {
+    return;
+  }
+
+  recorderSaveAllState.saving = true;
+  updateSaveAllButtonState();
+  setRecorderSaveAllStatus("Saving all changes…", "pending");
+
+  const failures = [];
+  for (const key of dirtyKeys) {
+    // eslint-disable-next-line no-await-in-loop
+    const ok = await saveRecorderSection(key);
+    if (!ok) {
+      failures.push(key);
+    }
+  }
+
+  recorderSaveAllState.saving = false;
+  updateSaveAllButtonState();
+
+  if (failures.length === 0) {
+    setRecorderSaveAllStatus("Saved all pending changes.", "success", { autoHide: true, duration: 3600 });
+    return;
+  }
+
+  const labels = failures.map((key) => getRecorderSectionLabel(key)).join(", ");
+  if (failures.length === dirtyKeys.length) {
+    setRecorderSaveAllStatus("Unable to save any sections. Check the errors above.", "error");
+  } else {
+    setRecorderSaveAllStatus(`Saved some changes, but ${labels} failed. Check the errors above.`, "warning");
+  }
+}
+
 function summariseRestartResults(results) {
   if (!Array.isArray(results) || results.length === 0) {
     return { message: "Saved changes.", state: "success" };
@@ -7182,10 +7302,10 @@ function summariseRestartResults(results) {
 async function saveRecorderSection(key) {
   const section = getRecorderSection(key);
   if (section.state.saving || !section.state.dirty) {
-    return;
+    return true;
   }
   if (typeof section.options.read !== "function" || !section.options.endpoint) {
-    return;
+    return false;
   }
 
   const payload = section.options.read();
@@ -7193,6 +7313,7 @@ async function saveRecorderSection(key) {
   updateRecorderButtons(key);
   setRecorderStatus(key, "Saving…", "pending");
 
+  let success = true;
   try {
     const response = await fetch(apiPath(section.options.endpoint), {
       method: "POST",
@@ -7231,10 +7352,12 @@ async function saveRecorderSection(key) {
   } catch (error) {
     const message = error && error.message ? error.message : "Unable to save settings.";
     setRecorderStatus(key, message, "error");
+    success = false;
   } finally {
     section.state.saving = false;
     updateRecorderButtons(key);
   }
+  return success;
 }
 
 async function fetchRecorderSection(key) {
@@ -11599,6 +11722,12 @@ function attachEventListeners() {
   if (recorderDom.close) {
     recorderDom.close.addEventListener("click", () => {
       closeRecorderDialog();
+    });
+  }
+
+  if (recorderDom.saveAll) {
+    recorderDom.saveAll.addEventListener("click", () => {
+      void saveAllRecorderSections();
     });
   }
 

--- a/lib/webui/templates/dashboard.html
+++ b/lib/webui/templates/dashboard.html
@@ -1490,6 +1490,20 @@
               </div>
             </form>
           </section>
+          <footer class="settings-dialog-footer recorder-settings-footer">
+            <div class="settings-footer-actions">
+              <div
+                id="recorder-save-all-status"
+                class="form-status"
+                role="status"
+                aria-live="polite"
+                aria-hidden="true"
+              ></div>
+              <div class="button-row">
+                <button id="recorder-save-all" class="primary-button" type="button" disabled>Save all changes</button>
+              </div>
+            </div>
+          </footer>
         </div>
       </div>
     </div>


### PR DESCRIPTION
**What / Why**
- Add a Save all control to the recorder configuration modal so operators can persist multiple sections at once.
- Document the capability in the README for dashboard users.

**How (high-level)**
- Added a footer section to the modal template with a Save all button and shared status line.
- Tracked dirty section state in `dashboard.js` to enable/disable the control, sequentially POST dirty sections, and surface aggregate success/failure.
- Updated the README to mention the Save all workflow.
- Validated with `pytest tests/test_37_web_dashboard.py`, `pytest tests/test_25_web_streamer.py`, and `pytest -q`.

**Risk / Rollback**
- Low risk: leverages existing per-section endpoints and reuses existing status messaging. Roll back by removing the new footer markup and helper logic if the aggregate save workflow misbehaves.

**Links**
- Jira: https://mfisbv.atlassian.net/browse/TR-50

------
https://chatgpt.com/codex/tasks/task_e_68dfba7077b88327bdbfd4a8e90d2b3d