### PR TITLE
TR-55: Add preview toggles for filter and denoise

### DIFF
--- a/lib/web_streamer.py
+++ b/lib/web_streamer.py
@@ -4825,12 +4825,14 @@ def build_app(lets_encrypt_manager: LetsEncryptManager | None = None) -> web.App
             try:
                 await loop.run_in_executor(
                     None,
-                    _apply_filter_chain_to_wav,
-                    current,
-                    filtered,
-                    chain=processing.chain,
-                    sample_rate=processing.sample_rate,
-                    frame_ms=processing.frame_ms,
+                    functools.partial(
+                        _apply_filter_chain_to_wav,
+                        current,
+                        filtered,
+                        chain=processing.chain,
+                        sample_rate=processing.sample_rate,
+                        frame_ms=processing.frame_ms,
+                    ),
                 )
             except Exception as exc:
                 log.warning("Preview filter chain failed for %s: %s", context_label, exc)

--- a/lib/webui/static/css/dashboard.css
+++ b/lib/webui/static/css/dashboard.css
@@ -1372,6 +1372,78 @@ button.small {
   gap: 1rem;
 }
 
+.waveform-controls {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.6rem;
+  flex-wrap: wrap;
+}
+
+.waveform-toggle {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-size: 0.78rem;
+  color: var(--text-muted);
+  cursor: pointer;
+  user-select: none;
+}
+
+.waveform-toggle input {
+  position: absolute;
+  opacity: 0;
+  width: 1px;
+  height: 1px;
+}
+
+.waveform-toggle-slider {
+  position: relative;
+  width: 1.9rem;
+  height: 1.05rem;
+  border-radius: 999px;
+  background: rgba(148, 163, 184, 0.3);
+  transition: background 0.2s ease;
+  flex-shrink: 0;
+}
+
+.waveform-toggle-slider::after {
+  content: "";
+  position: absolute;
+  top: 0.14rem;
+  left: 0.14rem;
+  width: 0.75rem;
+  height: 0.75rem;
+  border-radius: 50%;
+  background: var(--surface);
+  box-shadow: 0 1px 2px rgba(15, 23, 42, 0.18);
+  transition: transform 0.2s ease;
+}
+
+.waveform-toggle input:checked + .waveform-toggle-slider {
+  background: var(--primary);
+}
+
+.waveform-toggle input:checked + .waveform-toggle-slider::after {
+  transform: translateX(0.85rem);
+}
+
+.waveform-toggle input:focus-visible + .waveform-toggle-slider {
+  box-shadow: 0 0 0 3px var(--input-focus-ring);
+}
+
+.waveform-toggle input:disabled + .waveform-toggle-slider {
+  background: rgba(148, 163, 184, 0.18);
+}
+
+.waveform-toggle input:disabled + .waveform-toggle-slider::after {
+  box-shadow: none;
+}
+
+.waveform-toggle-text {
+  white-space: nowrap;
+}
+
 .waveform-header span:first-child {
   font-weight: 600;
   letter-spacing: 0.05em;

--- a/lib/webui/static/js/dashboard.js
+++ b/lib/webui/static/js/dashboard.js
@@ -437,6 +437,9 @@ const dom = {
   waveformEmpty: document.getElementById("waveform-empty"),
   waveformStatus: document.getElementById("waveform-status"),
   waveformRmsRow: document.getElementById("waveform-rms-row"),
+  waveformControls: document.getElementById("waveform-controls"),
+  waveformFilterToggle: document.getElementById("waveform-filter-toggle"),
+  waveformDenoiseToggle: document.getElementById("waveform-denoise-toggle"),
   waveformRmsValue: document.getElementById("waveform-rms-value"),
   clipperContainer: document.getElementById("clipper-container"),
   clipperSection: document.getElementById("clipper-section"),
@@ -1126,6 +1129,165 @@ const waveformState = {
   startEpoch: null,
   rmsValues: null,
 };
+
+const previewProcessingState = {
+  filterEnabled: true,
+  denoiseEnabled: true,
+  userOverride: false,
+  pendingSeek: null,
+  shouldResume: false,
+  updatingUi: false,
+  configDefaults: { filterEnabled: true, denoiseEnabled: true },
+};
+
+function currentPreviewProcessing() {
+  return {
+    filterEnabled: previewProcessingState.filterEnabled,
+    denoiseEnabled: previewProcessingState.denoiseEnabled,
+  };
+}
+
+function coerceConfigBoolean(value, fallback) {
+  if (value === undefined || value === null) {
+    return fallback;
+  }
+  return parseBoolean(value);
+}
+
+function derivePreviewProcessingFromConfig(config) {
+  const defaults = { filterEnabled: true, denoiseEnabled: true };
+  if (!config || typeof config !== "object") {
+    return defaults;
+  }
+
+  const audio = config.audio;
+  if (audio && typeof audio === "object") {
+    const chain = audio.filter_chain;
+    if (chain && typeof chain === "object") {
+      if (Object.prototype.hasOwnProperty.call(chain, "enabled")) {
+        defaults.filterEnabled = coerceConfigBoolean(chain.enabled, defaults.filterEnabled);
+      } else {
+        const stages = ["highpass", "notch", "spectral_gate"];
+        let anyStage = false;
+        for (const stage of stages) {
+          const stageCfg = chain[stage];
+          if (stageCfg && typeof stageCfg === "object") {
+            anyStage = coerceConfigBoolean(stageCfg.enabled, anyStage) || anyStage;
+          }
+        }
+        if (!anyStage) {
+          defaults.filterEnabled = false;
+        }
+      }
+    }
+  }
+
+  const segmenter = config.segmenter;
+  if (segmenter && typeof segmenter === "object") {
+    if (Object.prototype.hasOwnProperty.call(segmenter, "denoise_before_vad")) {
+      defaults.denoiseEnabled = coerceConfigBoolean(
+        segmenter.denoise_before_vad,
+        defaults.denoiseEnabled,
+      );
+    }
+  }
+
+  return defaults;
+}
+
+function updatePreviewProcessingUI() {
+  previewProcessingState.updatingUi = true;
+  if (dom.waveformFilterToggle instanceof HTMLInputElement) {
+    dom.waveformFilterToggle.checked = Boolean(previewProcessingState.filterEnabled);
+  }
+  if (dom.waveformDenoiseToggle instanceof HTMLInputElement) {
+    dom.waveformDenoiseToggle.checked = Boolean(previewProcessingState.denoiseEnabled);
+  }
+  previewProcessingState.updatingUi = false;
+}
+
+function setPreviewProcessing(options = {}, { fromUser = false, reload = true } = {}) {
+  const nextFilter =
+    Object.prototype.hasOwnProperty.call(options, "filterEnabled")
+      ? Boolean(options.filterEnabled)
+      : previewProcessingState.filterEnabled;
+  const nextDenoise =
+    Object.prototype.hasOwnProperty.call(options, "denoiseEnabled")
+      ? Boolean(options.denoiseEnabled)
+      : previewProcessingState.denoiseEnabled;
+
+  const changed =
+    nextFilter !== previewProcessingState.filterEnabled ||
+    nextDenoise !== previewProcessingState.denoiseEnabled;
+
+  previewProcessingState.filterEnabled = nextFilter;
+  previewProcessingState.denoiseEnabled = nextDenoise;
+  updatePreviewProcessingUI();
+
+  if (fromUser) {
+    previewProcessingState.userOverride = true;
+  }
+
+  if (reload && changed) {
+    applyPreviewProcessingChanges({ fromUser });
+  }
+}
+
+function applyPreviewProcessingChanges({ fromUser = false } = {}) {
+  if (fromUser) {
+    previewProcessingState.userOverride = true;
+  }
+  if (!previewIsActive() || !state.current) {
+    if (previewIsActive()) {
+      loadWaveform(state.current);
+    }
+    return;
+  }
+
+  if (dom.player) {
+    const wasPlaying = !dom.player.paused && !dom.player.ended;
+    const resumeTime = Number.isFinite(dom.player.currentTime) ? dom.player.currentTime : 0;
+
+    previewProcessingState.pendingSeek = Number.isFinite(resumeTime) ? resumeTime : null;
+    previewProcessingState.shouldResume = wasPlaying;
+
+    const url = recordAudioUrl(state.current, {
+      previewProcessing: currentPreviewProcessing(),
+    });
+
+    try {
+      dom.player.pause();
+    } catch (error) {
+      /* ignore pause errors */
+    }
+
+    playbackState.resetOnLoad = false;
+    playbackState.enforcePauseOnLoad = !wasPlaying;
+
+    if (url) {
+      dom.player.src = url;
+    } else {
+      dom.player.removeAttribute("src");
+      previewProcessingState.pendingSeek = null;
+      previewProcessingState.shouldResume = false;
+    }
+    dom.player.load();
+  }
+
+  loadWaveform(state.current);
+}
+
+function initializePreviewProcessingControls() {
+  updatePreviewProcessingUI();
+}
+
+function syncPreviewProcessingFromConfig(config) {
+  const defaults = derivePreviewProcessingFromConfig(config);
+  previewProcessingState.configDefaults = defaults;
+  if (!previewProcessingState.userOverride) {
+    setPreviewProcessing(defaults, { fromUser: false, reload: previewIsActive() });
+  }
+}
 
 const clipperState = {
   enabled: false,
@@ -3013,27 +3175,45 @@ if (dom.renameModal) {
   });
 }
 
-function recordingUrl(path, { download = false } = {}) {
+function applyPreviewProcessingParams(params, previewProcessing) {
+  if (!(params instanceof URLSearchParams) || !previewProcessing) {
+    return;
+  }
+  if (Object.prototype.hasOwnProperty.call(previewProcessing, "filterEnabled")) {
+    params.set("preview_filter", previewProcessing.filterEnabled ? "1" : "0");
+  }
+  if (Object.prototype.hasOwnProperty.call(previewProcessing, "denoiseEnabled")) {
+    params.set("preview_denoise", previewProcessing.denoiseEnabled ? "1" : "0");
+  }
+}
+
+function recordingUrl(path, { download = false, previewProcessing = null } = {}) {
   const encoded = path
     .split("/")
     .filter(Boolean)
     .map((segment) => encodeURIComponent(segment))
     .join("/");
-  const suffix = download ? "?download=1" : "";
+  const params = new URLSearchParams();
+  if (download) {
+    params.set("download", "1");
+  }
+  applyPreviewProcessingParams(params, previewProcessing);
+  const query = params.toString();
+  const suffix = query ? `?${query}` : "";
   return apiPath(`/recordings/${encoded}${suffix}`);
 }
 
-function recordAudioUrl(record, { download = false } = {}) {
+function recordAudioUrl(record, { download = false, previewProcessing = null } = {}) {
   if (isRecycleBinRecord(record)) {
-    return recycleBinAudioUrl(record.recycleBinId, { download });
+    return recycleBinAudioUrl(record.recycleBinId, { download, previewProcessing });
   }
   if (record && typeof record.path === "string" && record.path) {
-    return recordingUrl(record.path, { download });
+    return recordingUrl(record.path, { download, previewProcessing });
   }
   return "";
 }
 
-function recordWaveformUrl(record) {
+function recordWaveformUrl(record, { previewProcessing = null } = {}) {
   if (!record) {
     return "";
   }
@@ -3045,10 +3225,10 @@ function recordWaveformUrl(record) {
       typeof record.waveform_path === "string" && record.waveform_path
         ? record.waveform_path
         : record.recycleBinId;
-    return recycleBinWaveformUrl(identifier);
+    return recycleBinWaveformUrl(identifier, { previewProcessing });
   }
   if (typeof record.waveform_path === "string" && record.waveform_path) {
-    return recordingUrl(record.waveform_path);
+    return recordingUrl(record.waveform_path, { previewProcessing });
   }
   return "";
 }
@@ -3915,7 +4095,7 @@ function setNowPlaying(record, options = {}) {
   playbackState.resetOnLoad = resetToStart;
   playbackState.enforcePauseOnLoad = !autoplay;
 
-  const url = recordAudioUrl(record);
+  const url = recordAudioUrl(record, { previewProcessing: currentPreviewProcessing() });
   if (url) {
     dom.player.src = url;
   } else {
@@ -4506,6 +4686,21 @@ function handlePlayerLoadedMetadata() {
   }
   playbackState.resetOnLoad = false;
   playbackState.enforcePauseOnLoad = false;
+
+  if (Number.isFinite(previewProcessingState.pendingSeek) && previewProcessingState.pendingSeek >= 0) {
+    try {
+      const duration = Number.isFinite(dom.player.duration) ? dom.player.duration : previewProcessingState.pendingSeek;
+      const clamped = duration > 0 ? Math.min(previewProcessingState.pendingSeek, duration) : previewProcessingState.pendingSeek;
+      dom.player.currentTime = clamped;
+    } catch (error) {
+      /* ignore seek errors */
+    }
+  }
+  if (previewProcessingState.shouldResume && !playbackState.enforcePauseOnLoad) {
+    dom.player.play().catch(() => undefined);
+  }
+  previewProcessingState.pendingSeek = null;
+  previewProcessingState.shouldResume = false;
   updateCursorFromPlayer();
 }
 
@@ -5365,7 +5560,9 @@ async function loadWaveform(record) {
     resetWaveform();
     return;
   }
-  const waveformUrl = recordWaveformUrl(record);
+  const waveformUrl = recordWaveformUrl(record, {
+    previewProcessing: currentPreviewProcessing(),
+  });
   if (!waveformUrl) {
     resetWaveform();
     if (dom.waveformEmpty) {
@@ -7445,6 +7642,7 @@ function syncRecorderSectionsFromConfig(config) {
     const canonical = section.options.fromConfig(config);
     handleRecorderConfigSnapshot(key, canonical);
   }
+  syncPreviewProcessingFromConfig(config);
   if (!recorderState.loaded) {
     recorderState.loaded = true;
   }
@@ -10676,21 +10874,29 @@ function applyRecycleBinRangeSelection(anchorId, targetId, shouldSelect) {
   return true;
 }
 
-function recycleBinAudioUrl(id, { download = false } = {}) {
+function recycleBinAudioUrl(id, { download = false, previewProcessing = null } = {}) {
   if (typeof id !== "string" || !id) {
     return "";
   }
   const encoded = encodeURIComponent(id);
-  const suffix = download ? "?download=1" : "";
+  const params = new URLSearchParams();
+  if (download) {
+    params.set("download", "1");
+  }
+  applyPreviewProcessingParams(params, previewProcessing);
+  const suffix = params.toString() ? `?${params.toString()}` : "";
   return apiPath(`/recycle-bin/${encoded}${suffix}`);
 }
 
-function recycleBinWaveformUrl(id) {
+function recycleBinWaveformUrl(id, { previewProcessing = null } = {}) {
   if (typeof id !== "string" || !id) {
     return "";
   }
   const encoded = encodeURIComponent(id);
-  return apiPath(`/api/recycle-bin/${encoded}/waveform`);
+  const params = new URLSearchParams();
+  applyPreviewProcessingParams(params, previewProcessing);
+  const suffix = params.toString() ? `?${params.toString()}` : "";
+  return apiPath(`/api/recycle-bin/${encoded}/waveform${suffix}`);
 }
 
 function getRecycleBinRow(id) {
@@ -12876,6 +13082,24 @@ function attachEventListeners() {
     });
   }
 
+  if (dom.waveformFilterToggle instanceof HTMLInputElement) {
+    dom.waveformFilterToggle.addEventListener("change", () => {
+      if (previewProcessingState.updatingUi) {
+        return;
+      }
+      setPreviewProcessing({ filterEnabled: dom.waveformFilterToggle.checked }, { fromUser: true });
+    });
+  }
+
+  if (dom.waveformDenoiseToggle instanceof HTMLInputElement) {
+    dom.waveformDenoiseToggle.addEventListener("change", () => {
+      if (previewProcessingState.updatingUi) {
+        return;
+      }
+      setPreviewProcessing({ denoiseEnabled: dom.waveformDenoiseToggle.checked }, { fromUser: true });
+    });
+  }
+
   if (dom.playerRename) {
     dom.playerRename.addEventListener("click", () => {
       if (renameDialogState.pending || !state.current) {
@@ -13017,6 +13241,7 @@ function initialize() {
   updateRecorderConfigPath(recorderState.configPath);
   registerRecorderSections();
   updateAudioFilterControls();
+  initializePreviewProcessingControls();
   setServicesModalVisible(false);
   applyWebServerData(webServerDefaults(), { markPristine: true });
   updateWebServerConfigPath(webServerState.configPath);

--- a/lib/webui/static/js/dashboard.js
+++ b/lib/webui/static/js/dashboard.js
@@ -1249,7 +1249,7 @@ function applyPreviewProcessingChanges({ fromUser = false } = {}) {
     const resumeTime = Number.isFinite(dom.player.currentTime) ? dom.player.currentTime : 0;
 
     previewProcessingState.pendingSeek = Number.isFinite(resumeTime) ? resumeTime : null;
-    previewProcessingState.shouldResume = wasPlaying;
+    previewProcessingState.shouldResume = false;
 
     const url = recordAudioUrl(state.current, {
       previewProcessing: currentPreviewProcessing(),
@@ -1262,7 +1262,7 @@ function applyPreviewProcessingChanges({ fromUser = false } = {}) {
     }
 
     playbackState.resetOnLoad = false;
-    playbackState.enforcePauseOnLoad = !wasPlaying;
+    playbackState.enforcePauseOnLoad = true;
 
     if (url) {
       dom.player.src = url;

--- a/lib/webui/templates/dashboard.html
+++ b/lib/webui/templates/dashboard.html
@@ -372,6 +372,23 @@
           <div class="waveform-section" id="waveform-section">
             <div class="waveform-header">
               <span>Waveform</span>
+              <div
+                class="waveform-controls"
+                id="waveform-controls"
+                aria-label="Preview processing toggles"
+                role="group"
+              >
+                <label class="waveform-toggle" id="waveform-filter-toggle-label">
+                  <input id="waveform-filter-toggle" type="checkbox" checked />
+                  <span class="waveform-toggle-slider" aria-hidden="true"></span>
+                  <span class="waveform-toggle-text">Filter</span>
+                </label>
+                <label class="waveform-toggle" id="waveform-denoise-toggle-label">
+                  <input id="waveform-denoise-toggle" type="checkbox" checked />
+                  <span class="waveform-toggle-slider" aria-hidden="true"></span>
+                  <span class="waveform-toggle-text">Denoise</span>
+                </label>
+              </div>
               <span class="waveform-status" id="waveform-status"></span>
             </div>
             <div class="waveform-clock-row" data-active="false">


### PR DESCRIPTION
## What / Why
- expose filter and denoise toggles alongside the waveform preview so users can control processing when pipeline defaults are disabled
- keep the preview controls aligned with recorder settings and refresh playback when the selection changes

## How (high-level)
- add toggle markup next to the waveform header and style compact switch controls in the dashboard CSS
- extend dashboard.js with preview-processing state management, syncing against config snapshots, and reloading audio/waveform URLs with preview parameters when toggles change

## Risk / Rollback
- medium risk: touches preview playback logic and could impact waveform/audio loading; verify preview audio still plays with toggles
- rollback by reverting this PR

## Links
- Jira: https://mfisbv.atlassian.net/browse/TR-55
- Tests: `export DEV=0; pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68e0f3e1c9f88327b6acbfe547555d4e