### PR TITLE
TR-56: Show recycle bin file counts

### DIFF
--- a/lib/webui/static/css/dashboard.css
+++ b/lib/webui/static/css/dashboard.css
@@ -670,7 +670,7 @@ body[data-theme="light"] .app-menu-toggle {
   gap: 1rem;
 }
 
-.status-bar .stat {
+.stat {
   background: var(--card-bg);
   border: 1px solid var(--card-border);
   border-radius: 1rem;
@@ -681,19 +681,19 @@ body[data-theme="light"] .app-menu-toggle {
   gap: 0.25rem;
 }
 
-.status-bar .label {
+.stat .label {
   font-size: 0.75rem;
   text-transform: uppercase;
   letter-spacing: 0.08em;
   color: var(--text-muted);
 }
 
-.status-bar .value {
+.stat .value {
   font-size: 1.5rem;
   font-weight: 600;
 }
 
-.status-bar .stat-counts {
+.stat.stat-counts {
   gap: 0.75rem;
 }
 
@@ -704,8 +704,8 @@ body[data-theme="light"] .app-menu-toggle {
   gap: 0.75rem;
 }
 
-.status-bar .stat-counts .value,
-.status-bar .stat-resource .value {
+.stat.stat-counts .value,
+.stat.stat-resource .value {
   font-size: 1.3rem;
 }
 
@@ -2021,7 +2021,17 @@ body[data-scroll-locked="true"] {
 
 .recycle-bin-header {
   align-items: flex-start;
+  flex-wrap: wrap;
   gap: 1rem;
+}
+
+.recycle-bin-header .card-heading {
+  flex: 1 1 220px;
+}
+
+.recycle-bin-counts {
+  min-width: 180px;
+  flex: 0 0 auto;
 }
 
 .recycle-bin-header-actions {

--- a/lib/webui/static/js/dashboard.js
+++ b/lib/webui/static/js/dashboard.js
@@ -311,6 +311,8 @@ const dom = {
   renameSelected: document.getElementById("rename-selected"),
   deleteSelected: document.getElementById("delete-selected"),
   recycleBinOpen: document.getElementById("open-recycle-bin"),
+  recycleBinTotalCount: document.getElementById("recycle-bin-total-count"),
+  recycleBinSelectedCount: document.getElementById("recycle-bin-selected-count"),
   refreshIndicator: document.getElementById("refresh-indicator"),
   themeToggle: document.getElementById("theme-toggle"),
   connectionStatus: document.getElementById("connection-status"),
@@ -10769,6 +10771,13 @@ function restoreRecycleBinPreview() {
 
 function updateRecycleBinControls() {
   const selectedCount = state.recycleBin.selected.size;
+  const totalCount = state.recycleBin.items.length;
+  if (dom.recycleBinTotalCount) {
+    dom.recycleBinTotalCount.textContent = totalCount.toString();
+  }
+  if (dom.recycleBinSelectedCount) {
+    dom.recycleBinSelectedCount.textContent = selectedCount.toString();
+  }
   if (dom.recycleBinRestore) {
     dom.recycleBinRestore.disabled =
       !selectedCount || state.recycleBin.loading || state.recycleBin.items.length === 0;

--- a/lib/webui/templates/dashboard.html
+++ b/lib/webui/templates/dashboard.html
@@ -743,6 +743,16 @@
               Recently removed recordings are staged here until you restore them.
             </p>
           </div>
+          <div class="stat stat-counts recycle-bin-counts" role="status" aria-live="polite">
+            <div class="stat-count-row">
+              <span class="label">Recordings</span>
+              <span class="value" id="recycle-bin-total-count">0</span>
+            </div>
+            <div class="stat-count-row">
+              <span class="label">Selected</span>
+              <span class="value" id="recycle-bin-selected-count">0</span>
+            </div>
+          </div>
           <div class="recycle-bin-header-actions">
             <button id="recycle-bin-refresh" class="ghost-button small" type="button">Refresh</button>
             <button id="recycle-bin-restore" class="primary-button small" type="button" disabled>


### PR DESCRIPTION
## What / Why
* Reuse the dashboard count widget in the recycle bin modal to expose total and selected recording counts.

## How (high-level)
* Apply the shared `.stat` styles to work outside the status bar so the modal reuses the dashboard count markup verbatim.
* Keep the recycle bin header layout flexible while relying on the shared stat card styling for the counts.

## Risk / Rollback
* Low – UI-only changes scoped to the recycle bin dialog.
* Rollback by reverting this PR.

## Links
* [Jira TR-56](https://mfisbv.atlassian.net/browse/TR-56)
* Task run: N/A
* Preview URL: N/A

------
https://chatgpt.com/codex/tasks/task_e_68e10a3dc1a0832799fb77344e397d42