### PR TITLE
TR-57: Pause auto refresh while interactive overlays are open

### DIFF
--- a/docs/tr-57-navigation-lockout.md
+++ b/docs/tr-57-navigation-lockout.md
@@ -1,0 +1,39 @@
+# TR-57 navigation lockout bug report
+
+## Summary
+- Refreshing while a dropdown, modal, or other apply-confirming field is focused traps the UI in that element.
+- Global keyboard shortcuts are not rebound after the re-render and remain unusable until the page is hard refreshed.
+- Users lose the ability to exit the element gracefully, making navigation impossible without reloading the entire app.
+
+## Steps to reproduce
+1. Open the dashboard and focus an interactive widget that requires input (dropdown, expandable form, modal with **Apply** button, etc.).
+2. Trigger a refresh or hot re-render (manually reload or wait for the automatic cycle).
+3. Attempt to dismiss the element or interact with global keyboard shortcuts.
+
+## Expected behaviour
+- Focused controls should close, blur, or otherwise reset when the page is refreshed.
+- Global shortcuts should be rebound automatically and remain available at all times.
+- Users should always be able to recover with keyboard navigation (e.g., <kbd>Esc</kbd>) without performing a full page reload.
+
+## Actual behaviour
+- The element remains focused and cannot be dismissed through normal interactions.
+- Application-level shortcuts are no longer active while the element is "stuck".
+- The only recovery path is a full page refresh.
+
+## Environment
+- Browser: (fill in exact browser + version observed).
+- OS: (fill in operating system).
+- App version / commit: (fill in current release hash or semantic version).
+
+## Impact and severity
+High. This defect blocks end-to-end navigation flows and prevents power users from relying on keyboard shortcuts, forcing disruptive reloads during routine operations.
+
+## Acceptance criteria for QA
+- Dropdown → refresh: the element blurs automatically and <kbd>Esc</kbd> dismisses it after the reload.
+- Modal with **Apply** button → refresh: modal closes or reopens in a neutral state and global shortcuts (e.g., `?`, `g` bindings) respond immediately.
+- Expandable form field → auto-refresh: focus is released and the user can tab through the page without reloading.
+- Regression sweep across other form components confirms no control traps focus or disables shortcuts after refresh.
+
+## Follow-up notes
+- Audit interactive components to ensure they tear down correctly on refresh and rebind the shortcut manager.
+- Add automated smoke tests (if available) covering the scenarios above to prevent regressions.

--- a/lib/webui/static/js/dashboard.js
+++ b/lib/webui/static/js/dashboard.js
@@ -1033,6 +1033,7 @@ function stopConfigRefresh() {
 
 let autoRefreshIntervalMs = AUTO_REFRESH_INTERVAL_MS;
 let autoRefreshSuspended = false;
+const autoRefreshLocks = new Set();
 let fetchInFlight = false;
 let fetchQueued = false;
 let recordingsRefreshDeferred = false;
@@ -1699,8 +1700,11 @@ function resumeConfigRefresh() {
   startConfigRefresh();
 }
 
-function suspendAutoRefresh() {
+function suspendAutoRefresh(lockId = null) {
   suspendConfigRefresh();
+  if (lockId) {
+    autoRefreshLocks.add(lockId);
+  }
   if (autoRefreshSuspended) {
     return;
   }
@@ -1708,8 +1712,14 @@ function suspendAutoRefresh() {
   stopAutoRefresh();
 }
 
-function resumeAutoRefresh() {
+function resumeAutoRefresh(lockId = null) {
+  if (lockId) {
+    autoRefreshLocks.delete(lockId);
+  }
   if (state.recycleBin.open) {
+    return;
+  }
+  if (autoRefreshLocks.size > 0) {
     return;
   }
   if (!autoRefreshSuspended) {
@@ -8560,9 +8570,11 @@ function setWebServerModalVisible(visible) {
   if (visible) {
     dom.webServerModal.removeAttribute("hidden");
     lockDocumentScroll("web-server-settings");
+    suspendAutoRefresh("web-server-modal");
   } else {
     dom.webServerModal.setAttribute("hidden", "hidden");
     unlockDocumentScroll("web-server-settings");
+    resumeAutoRefresh("web-server-modal");
   }
 }
 
@@ -9506,8 +9518,10 @@ function setAppMenuVisible(visible) {
   dom.appMenu.setAttribute("aria-hidden", visible ? "false" : "true");
   if (visible) {
     dom.appMenu.removeAttribute("hidden");
+    suspendAutoRefresh("app-menu");
   } else {
     dom.appMenu.setAttribute("hidden", "hidden");
+    resumeAutoRefresh("app-menu");
   }
 }
 
@@ -9697,9 +9711,11 @@ function setRecorderModalVisible(visible) {
   if (visible) {
     recorderDom.modal.removeAttribute("hidden");
     lockDocumentScroll("recorder-settings");
+    suspendAutoRefresh("recorder-modal");
   } else {
     recorderDom.modal.setAttribute("hidden", "hidden");
     unlockDocumentScroll("recorder-settings");
+    resumeAutoRefresh("recorder-modal");
   }
 }
 
@@ -9945,9 +9961,11 @@ function setArchivalModalVisible(visible) {
   if (visible) {
     dom.archivalModal.removeAttribute("hidden");
     lockDocumentScroll("archival-settings");
+    suspendAutoRefresh("archival-modal");
   } else {
     dom.archivalModal.setAttribute("hidden", "hidden");
     unlockDocumentScroll("archival-settings");
+    resumeAutoRefresh("archival-modal");
   }
 }
 
@@ -10105,9 +10123,11 @@ function setConfigModalVisible(visible) {
   if (visible) {
     dom.configModal.removeAttribute("hidden");
     lockDocumentScroll("config-snapshot");
+    suspendAutoRefresh("config-modal");
   } else {
     dom.configModal.setAttribute("hidden", "hidden");
     unlockDocumentScroll("config-snapshot");
+    resumeAutoRefresh("config-modal");
   }
 }
 
@@ -10265,9 +10285,11 @@ function setServicesModalVisible(visible) {
   if (visible) {
     dom.servicesModal.removeAttribute("hidden");
     lockDocumentScroll("services");
+    suspendAutoRefresh("services-modal");
   } else {
     dom.servicesModal.setAttribute("hidden", "hidden");
     unlockDocumentScroll("services");
+    resumeAutoRefresh("services-modal");
   }
 }
 
@@ -10423,9 +10445,11 @@ function setRecycleBinModalVisible(visible) {
   if (visible) {
     dom.recycleBinModal.removeAttribute("hidden");
     lockDocumentScroll("recycle-bin");
+    suspendAutoRefresh("recycle-bin-modal");
   } else {
     dom.recycleBinModal.setAttribute("hidden", "hidden");
     unlockDocumentScroll("recycle-bin");
+    resumeAutoRefresh("recycle-bin-modal");
   }
 }
 


### PR DESCRIPTION
## What / Why
- Prevent the dashboard auto refresh loop from firing while dropdowns and modals are active so re-renders no longer trap focus or disable shortcuts.
- Add lightweight locking so multiple overlays can safely suspend refresh until the last one closes.

## How (high-level)
- Track outstanding auto-refresh locks and only resume polling when no interactive UI overlays are active.
- Suspend/resume refresh around the app menu and each modal (recorder, archival, config, services, recycle bin, web server).

## Risk / Rollback
- Medium: affects dashboard refresh scheduling; verify overlays close correctly and auto refresh resumes afterward.
- Rollback by reverting this commit.

## Links
- [Jira TR-57](https://mfisbv.atlassian.net/browse/TR-57)


------
https://chatgpt.com/codex/tasks/task_e_68e13616c5a483279965e90d530eca23