### PR TITLE
TR-61: Start encode jobs in parallel

### DIFF
--- a/README.md
+++ b/README.md
@@ -370,7 +370,7 @@ Key configuration sections (see `config.yaml` for defaults and documentation):
 
 - `audio` – device, sample rate, frame size, gain, VAD aggressiveness, optional filter chain for hum/rumble control.
 - `paths` – tmpfs, recordings, dropbox, ingest work directory, encoder script path.
-- `segmenter` – pre/post pads, RMS threshold, debounce windows, optional denoise toggles, filter chain timing budgets, custom event tags. When `segmenter.streaming_encode` is enabled the recorder mirrors audio frames into a background ffmpeg process that writes a `.partial.opus` (or `.partial.webm`) beside the eventual recording so browsers can tail the file while waveform/transcription jobs run.
+- `segmenter` – pre/post pads, RMS threshold, debounce windows, optional denoise toggles, filter chain timing budgets, custom event tags. When `segmenter.streaming_encode` is enabled the recorder mirrors audio frames into a background ffmpeg process that writes a `.partial.opus` (or `.partial.webm`) beside the eventual recording so browsers can tail the file while waveform/transcription jobs run. `segmenter.parallel_encode` performs the same mirroring opportunistically even when live streaming is disabled, emitting a `.parallel.opus` artifact in tmpfs so the post-event encoder can jump straight to waveform/transcription work instead of re-encoding the entire WAV.
 - Dashboard recordings mark any in-progress `.partial.*` capture with a live badge, streaming audio directly from the growing container until the encoder finalizes and renames it.
 - `adaptive_rms` – background noise follower for automatically raising/lowering thresholds.
   - `max_rms` enforces a hard ceiling using linear RMS units (same scale as `segmenter.rms_threshold`).

--- a/config.yaml
+++ b/config.yaml
@@ -167,6 +167,19 @@ segmenter:
   # Container format for streaming output. Supported values: "opus" (default) or "webm".
   streaming_encode_container: "opus"
 
+  # Opportunistic parallel encoding mirrors audio frames into a background ffmpeg worker
+  # that writes a .parallel.opus file in tmpfs while the WAV is still growing. When the
+  # event finishes, the encoder job reuses the pre-built Opus container and only runs the
+  # waveform/transcription pipeline. Disable on systems that cannot spare a CPU core.
+  parallel_encode:
+    enabled: true
+    # Trigger when the 1-minute load average per CPU falls below this threshold.
+    load_avg_per_cpu: 0.75
+    # Minimum event duration (seconds) before the parallel encoder starts.
+    min_event_seconds: 1.0
+    # How often to poll load averages while waiting to start (seconds). Set 0 for every frame.
+    cpu_check_interval_sec: 1.0
+
   # Max queued frames before backpressure/drop (safety). With 20ms @ 48k mono: 512 ≈ 10.24s of audio.
   # Keep modest to avoid memory spikes. Typical: 256–1024.
   max_queue_frames: 512


### PR DESCRIPTION
**What / Why**
* Start opportunistic parallel encoding to reuse output while events still record.
* Document and expose configuration for enabling/disabling the feature.

**How (high-level)**
* Introduce load-aware parallel encoder gating and reuse StreamingOpusEncoder outputs during finalize.
* Surface new config (`segmenter.parallel_encode`) and extend status reporting/test coverage.

**Risk / Rollback**
* Risk: Additional ffmpeg worker may consume CPU on constrained devices; fallback to offline encode remains intact.
* Rollback by disabling `segmenter.parallel_encode` in config or reverting the changeset.

**Links**
* Jira: https://mfisbv.atlassian.net/browse/TR-61
* Task Run: N/A
* Preview: N/A

------
https://chatgpt.com/codex/tasks/task_e_68e14d297b7c8327b78dcba7bbf240b1