### PR TITLE
TR-63: Guard aioice STUN sends after transport shutdown

### DIFF
--- a/lib/aioice_patches.py
+++ b/lib/aioice_patches.py
@@ -1,0 +1,36 @@
+"""Compatibility patches for aioice behaviour on older asyncio versions."""
+
+from __future__ import annotations
+
+import importlib
+import logging
+from functools import wraps
+from typing import Any, Optional, Tuple
+
+_LOG = logging.getLogger("webrtc_manager")
+
+_spec = importlib.util.find_spec("aioice.ice")
+if _spec is not None:
+    aioice_ice = importlib.import_module("aioice.ice")
+    StunProtocol = getattr(aioice_ice, "StunProtocol", None)
+    if StunProtocol is not None:
+        original_send_stun = StunProtocol.send_stun
+
+        if getattr(original_send_stun, "__tricorder_patch__", False):
+            safe_send_stun = original_send_stun
+        else:
+
+            @wraps(original_send_stun)
+            def safe_send_stun(self: Any, message: Any, addr: Tuple[str, int]) -> Optional[object]:
+                transport = getattr(self, "transport", None)
+                if transport is None:
+                    if _LOG.isEnabledFor(logging.DEBUG):
+                        _LOG.debug(
+                            "Ignoring STUN send on closed transport for %s to %s", self, addr
+                        )
+                    return None
+                return original_send_stun(self, message, addr)
+
+            setattr(safe_send_stun, "__tricorder_patch__", True)
+
+        StunProtocol.send_stun = safe_send_stun

--- a/lib/webrtc_stream.py
+++ b/lib/webrtc_stream.py
@@ -8,6 +8,8 @@ import os
 from fractions import Fraction
 from typing import Dict, Optional, TYPE_CHECKING
 
+from . import aioice_patches  # noqa: F401
+
 try:
     from aiortc import (
         RTCConfiguration as _RTCConfiguration,


### PR DESCRIPTION
**What / Why**
* Prevent asyncio AttributeErrors when aioice retries STUN messages after its transport is closed during peer connection teardown.

**How (high-level)**
* Added an `aioice_patches` helper that wraps `StunProtocol.send_stun` to drop retries once the datagram transport has been torn down.
* Imported the patch module from the WebRTC stream manager so the guard is installed before creating peer connections.

**Risk / Rollback**
* Low. The patch only suppresses retries after shutdown; rollback by removing the patch module import if issues arise.

**Links**
* [Jira TR-63](https://mfisbv.atlassian.net/browse/TR-63)
* Task run: (current)


------
https://chatgpt.com/codex/tasks/task_e_68e16673b5bc83279a1f5c978aac3fe9