### PR TITLE
TR-63: Avoid double-closing aioice transports during shutdown

### DIFF
--- a/lib/aioice_patches.py
+++ b/lib/aioice_patches.py
@@ -1,0 +1,76 @@
+"""Compatibility patches for aioice behaviour on older asyncio versions."""
+
+from __future__ import annotations
+
+import importlib
+import logging
+from functools import wraps
+from typing import Any, Optional, Tuple
+
+_LOG = logging.getLogger("webrtc_manager")
+
+_spec = importlib.util.find_spec("aioice.ice")
+if _spec is not None:
+    aioice_ice = importlib.import_module("aioice.ice")
+    StunProtocol = getattr(aioice_ice, "StunProtocol", None)
+    if StunProtocol is not None:
+        original_send_stun = StunProtocol.send_stun
+
+        if getattr(original_send_stun, "__tricorder_patch__", False):
+            safe_send_stun = original_send_stun
+        else:
+
+            @wraps(original_send_stun)
+            def safe_send_stun(self: Any, message: Any, addr: Tuple[str, int]) -> Optional[object]:
+                transport = getattr(self, "transport", None)
+                if transport is None:
+                    if _LOG.isEnabledFor(logging.DEBUG):
+                        _LOG.debug(
+                            "Ignoring STUN send on closed transport for %s to %s", self, addr
+                        )
+                    return None
+                return original_send_stun(self, message, addr)
+
+            setattr(safe_send_stun, "__tricorder_patch__", True)
+
+        StunProtocol.send_stun = safe_send_stun
+
+        original_close = getattr(StunProtocol, "close", None)
+        if callable(original_close) and not getattr(original_close, "__tricorder_patch__", False):
+
+            @wraps(original_close)
+            async def safe_close(self: Any, *args: Any, **kwargs: Any) -> Optional[object]:
+                transport = getattr(self, "transport", None)
+                should_call_original = True
+
+                if transport is None:
+                    should_call_original = False
+                else:
+                    is_closing = getattr(transport, "is_closing", None)
+                    if callable(is_closing):
+                        try:
+                            if transport.is_closing():
+                                should_call_original = False
+                        except Exception:
+                            pass
+
+                if should_call_original:
+                    return await original_close(self, *args, **kwargs)
+
+                closed_future = getattr(self, "_StunProtocol__closed", None)
+                if closed_future is not None:
+                    if not closed_future.done():
+                        try:
+                            await closed_future
+                        except Exception:
+                            if _LOG.isEnabledFor(logging.DEBUG):
+                                _LOG.debug(
+                                    "Ignoring error awaiting STUN close completion for %s", self,
+                                    exc_info=True,
+                                )
+                    return None
+
+                return await original_close(self, *args, **kwargs)
+
+            setattr(safe_close, "__tricorder_patch__", True)
+            StunProtocol.close = safe_close

--- a/lib/webrtc_stream.py
+++ b/lib/webrtc_stream.py
@@ -8,6 +8,8 @@ import os
 from fractions import Fraction
 from typing import Dict, Optional, TYPE_CHECKING
 
+from . import aioice_patches  # noqa: F401
+
 try:
     from aiortc import (
         RTCConfiguration as _RTCConfiguration,

--- a/tests/test_aioice_patches.py
+++ b/tests/test_aioice_patches.py
@@ -1,0 +1,62 @@
+import asyncio
+
+from lib import aioice_patches  # noqa: F401
+
+
+class _DummyReceiver:
+    def __init__(self) -> None:
+        self.closed = False
+
+    def data_received(self, *_args):
+        self.closed = True
+
+
+class _DummyTransport:
+    def __init__(self, *, closing: bool) -> None:
+        self._closing = closing
+        self.closed = False
+
+    def is_closing(self) -> bool:
+        return self._closing
+
+    def close(self) -> None:
+        self.closed = True
+
+
+def test_stun_close_skips_when_transport_already_closing():
+    from aioice.ice import StunProtocol
+
+    async def runner() -> None:
+        receiver = _DummyReceiver()
+        protocol = StunProtocol(receiver)  # type: ignore[call-arg]
+        transport = _DummyTransport(closing=True)
+        protocol.transport = transport  # type: ignore[attr-defined]
+        protocol._StunProtocol__closed.set_result(True)  # type: ignore[attr-defined]
+
+        await protocol.close()
+
+        assert not transport.closed
+
+    asyncio.run(runner())
+
+
+def test_stun_close_closes_when_transport_active():
+    from aioice.ice import StunProtocol
+
+    async def runner() -> None:
+        receiver = _DummyReceiver()
+        protocol = StunProtocol(receiver)  # type: ignore[call-arg]
+        transport = _DummyTransport(closing=False)
+        protocol.transport = transport  # type: ignore[attr-defined]
+
+        async def mark_closed() -> None:
+            await asyncio.sleep(0)
+            protocol._StunProtocol__closed.set_result(True)  # type: ignore[attr-defined]
+
+        asyncio.get_running_loop().create_task(mark_closed())
+
+        await protocol.close()
+
+        assert transport.closed
+
+    asyncio.run(runner())


### PR DESCRIPTION
**What / Why**
* Guard the aioice STUN protocol close path so asyncio does not crash when the datagram transport has already entered a fatal error state during shutdown.
* Add a regression test that exercises the patched behaviour without requiring a live aiortc peer connection.

**How (high-level)**
* Wrap `StunProtocol.close` to skip duplicate `transport.close()` calls and simply await the existing close future when the transport is already closing.
* Provide unit coverage that ensures the new guard avoids double-close while still closing active transports.

**Risk / Rollback**
* Low. The patch only changes shutdown flows and has direct tests; rollback by removing the new guard and associated test.

**Links**
* [Jira TR-63](https://mfisbv.atlassian.net/browse/TR-63)
* Task run: (current)


------
https://chatgpt.com/codex/tasks/task_e_68e16673b5bc83279a1f5c978aac3fe9