### PR TITLE
TR-61: Refresh partial waveforms during capture

### DIFF
--- a/lib/webui/static/js/dashboard.js
+++ b/lib/webui/static/js/dashboard.js
@@ -109,6 +109,7 @@ function normalizeStartTimestamps(source) {
 
 const AUTO_REFRESH_INTERVAL_MS = 1000;
 const OFFLINE_REFRESH_INTERVAL_MS = 5000;
+const WAVEFORM_REFRESH_INTERVAL_MS = 3000;
 const MARKER_MIN_GAP_SECONDS = 0.05;
 const KEYBOARD_JOG_RATE_SECONDS_PER_SECOND = 4;
 const MIN_CLIP_DURATION_SECONDS = 0.05;
@@ -1127,6 +1128,8 @@ const waveformState = {
   peakScale: 32767,
   startEpoch: null,
   rmsValues: null,
+  refreshTimer: null,
+  refreshRecordPath: "",
 };
 
 const clipperState = {
@@ -4589,8 +4592,43 @@ function startCursorAnimation() {
   waveformState.animationFrame = window.requestAnimationFrame(step);
 }
 
+function clearWaveformRefresh() {
+  if (waveformState.refreshTimer !== null) {
+    window.clearTimeout(waveformState.refreshTimer);
+    waveformState.refreshTimer = null;
+  }
+  waveformState.refreshRecordPath = "";
+}
+
+function scheduleWaveformRefresh(record) {
+  if (!record || !record.isPartial) {
+    return;
+  }
+  const path = typeof record.path === "string" ? record.path : "";
+  if (!path) {
+    return;
+  }
+
+  clearWaveformRefresh();
+  waveformState.refreshRecordPath = path;
+  waveformState.refreshTimer = window.setTimeout(() => {
+    waveformState.refreshTimer = null;
+    const current = state.current && state.current.path === path ? state.current : null;
+    if (!current) {
+      waveformState.refreshRecordPath = "";
+      return;
+    }
+    if (dom.player && !dom.player.paused && !dom.player.ended) {
+      scheduleWaveformRefresh(current);
+      return;
+    }
+    loadWaveform(current);
+  }, WAVEFORM_REFRESH_INTERVAL_MS);
+}
+
 function resetWaveform() {
   stopCursorAnimation();
+  clearWaveformRefresh();
   waveformState.peaks = null;
   waveformState.duration = 0;
   waveformState.lastFraction = 0;
@@ -5424,6 +5462,7 @@ async function loadWaveform(record) {
   if (!dom.waveformContainer || !dom.waveformEmpty) {
     return;
   }
+  clearWaveformRefresh();
   if (!record) {
     resetWaveform();
     return;
@@ -5618,6 +5657,10 @@ async function loadWaveform(record) {
       renderRecords();
     }
     updatePlayerMeta(record);
+
+    if (waveformState.requestId === requestId) {
+      scheduleWaveformRefresh(record);
+    }
   } catch (error) {
     if (controller.signal.aborted) {
       return;


### PR DESCRIPTION
**What / Why**
* Serve in-progress waveform JSON files as snapshots so the dashboard can render progress immediately instead of waiting for the stream to end.
* Add a polling loop in the dashboard to refresh partial recordings every few seconds when playback is idle.
* Cover the regression with a dashboard test that exercises partial waveform retrieval.

**How (high-level)**
* Introduced a `_serve_partial_json` helper so partial `.waveform.json` files bypass the streaming loop and return their current contents with JSON headers.
* Extended the waveform state on the dashboard with refresh bookkeeping and scheduled reloads for partial records unless audio is actively playing.
* Added a pytest that verifies partial waveform responses complete promptly with the expected headers and payload.

**Risk / Rollback**
* Medium: touches waveform delivery and playback refresh logic; rollback by reverting this PR if issues arise.

**Links**
* Jira: https://mfisbv.atlassian.net/browse/TR-61
* Task run: (current CODE run)


------
https://chatgpt.com/codex/tasks/task_e_68e2308b0bd0832786e52e93a9e55909