### PR TITLE
TR-64: Ensure config migrations seed new defaults

### DIFF
--- a/tests/test_config_migrations.py
+++ b/tests/test_config_migrations.py
@@ -46,6 +46,27 @@ archival:
       - -az
     ssh_options:
       - -oStrictHostKeyChecking=no
+streaming:
+  mode: hls
+dashboard:
+  services: []
+  web_service: web-streamer.service
+web_server:
+  mode: http
+  listen_host: 0.0.0.0
+  listen_port: 8080
+  tls_provider: letsencrypt
+  certificate_path: ""
+  private_key_path: ""
+  lets_encrypt:
+    enabled: false
+    email: ""
+    domains: []
+    cache_dir: /apps/tricorder/letsencrypt
+    staging: false
+    certbot_path: certbot
+    http_port: 80
+    renew_before_days: 30
 """.strip()
     )
 
@@ -58,3 +79,31 @@ archival:
     cfg = config_module.get_cfg()
     assert cfg["archival"]["rsync"]["options"] == ["-az"]
     assert cfg["archival"]["rsync"]["ssh_options"] == ["-oStrictHostKeyChecking=no"]
+
+
+def test_apply_config_migrations_adds_new_sections(monkeypatch, tmp_path):
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(
+        """
+audio:
+  device: hw:CARD=Device,DEV=0
+""".strip()
+    )
+
+    monkeypatch.setenv("TRICORDER_CONFIG", str(config_path))
+    _reset_config_state(monkeypatch)
+
+    changed = config_module.apply_config_migrations()
+    assert changed is True
+
+    data = yaml.safe_load(config_path.read_text())
+    assert "streaming" in data
+    assert data["streaming"]["mode"] == "hls"
+    assert "dashboard" in data
+    assert data["dashboard"]["web_service"] == "web-streamer.service"
+    assert "web_server" in data
+    assert data["web_server"]["mode"] in {"http", "https"}
+
+    _reset_config_state(monkeypatch)
+    changed_again = config_module.apply_config_migrations()
+    assert changed_again is False


### PR DESCRIPTION
## What / Why
- Populate newly added streaming, dashboard, and web_server sections when migrating existing installs so the shipped defaults stay documented.
- Run config migrations from the installer so older deployments pick up template updates immediately.

## How (high-level)
- Added a migration helper that seeds missing sections from the comment template and rehydrates configs lacking inline docs.
- Triggered migrations during install.sh after copying YAML assets so $BASE/config.yaml stays current.
- Extended migration tests to cover the new section seeding behaviour and idempotence.

## Risk / Rollback
- Low risk: migration writes occur only when the config exists and fall back to defaults; rollback by reverting the migration helper and installer hook.

## Links
- Jira: https://mfisbv.atlassian.net/browse/TR-64
- Task run: (internal)


------
https://chatgpt.com/codex/tasks/task_e_68e23186728883278695d96f350c3460