### PR TITLE
TR-65: Reuse live waveforms when finalizing streaming recordings

### DIFF
--- a/tests/test_10_segmenter.py
+++ b/tests/test_10_segmenter.py
@@ -179,6 +179,13 @@ def test_parallel_encode_starts_when_cpu_available(tmp_path, monkeypatch):
     assert Path(existing_path).exists()
     assert existing_path.endswith(segmenter.STREAMING_EXTENSION)
     assert Path(existing_path).parent == rec_dir / "20240102"
+    waveform_path = Path(f"{existing_path}.waveform.json")
+    assert waveform_path.exists()
+    payload = json.loads(waveform_path.read_text(encoding="utf-8"))
+    assert payload.get("frame_count", 0) > 0
+    assert not Path(encoder.partial_path).exists()
+    partial_waveform = Path(f"{encoder.partial_path}.waveform.json")
+    assert not partial_waveform.exists()
 
 
 def test_live_waveform_updates_status(tmp_path, monkeypatch):


### PR DESCRIPTION
## What / Why
- Stop deleting streaming encoder artifacts so closing an event immediately reuses the already-encoded opus and waveform sidecars.

## How (high-level)
- Persist the live waveform file to the final recording path and surface it in the final event status before cleaning up transient state.
- Teach `bin/encode_and_store.sh` to keep an existing waveform JSON sidecar instead of regenerating it from the WAV when one already exists.
- Extend the parallel streaming test to assert that the waveform sidecar is preserved alongside the reused opus output.

## Risk / Rollback
- Low risk: if persisting the live waveform fails we fall back to the previous cleanup path and the encode worker still regenerates artifacts.
- Roll back by reverting this change set to restore the original cleanup and encode behaviour.

## Links
- Jira: https://mfisbv.atlassian.net/browse/TR-65
- Task run: not available (offline execution environment)
- Preview: n/a

------
https://chatgpt.com/codex/tasks/task_e_68e2394174688327b46e2ae029f9b7a5