### PR TITLE
TR-61: Preserve streaming partial encodes

### DIFF
--- a/systemd/voice-recorder.service
+++ b/systemd/voice-recorder.service
@@ -16,6 +16,10 @@ Nice=5
 StandardOutput=journal
 StandardError=journal
 NoNewPrivileges=true
+KillMode=process
+KillSignal=SIGINT
+SendSIGKILL=no
+TimeoutStopSec=infinity
 
 [Install]
 WantedBy=multi-user.target

--- a/tests/test_10_segmenter.py
+++ b/tests/test_10_segmenter.py
@@ -479,14 +479,19 @@ def test_startup_recovery_requeues_and_cleans(tmp_path, monkeypatch):
     assert tmp_arg == str(wav_path)
     assert base_arg == expected_final_base
     assert source_arg == "recovery"
-    assert existing_arg is None
+    expected_extension = segmenter.STREAMING_EXTENSION
+    if not expected_extension.startswith("."):
+        expected_extension = f".{expected_extension}"
+    expected_opus = day_dir / f"{expected_final_base}{expected_extension}"
+    assert existing_arg == str(expected_opus)
 
     assert report.requeued == [expected_final_base]
     assert not partial_path.exists()
     assert not partial_waveform.exists()
     assert not filtered_path.exists()
     assert wav_path.exists()
-    assert any(str(partial_path) == entry for entry in report.removed_artifacts)
+    assert str(partial_path) not in report.removed_artifacts
+    assert str(partial_waveform) not in report.removed_artifacts
     assert report.removed_wavs == []
 
 


### PR DESCRIPTION
**What / Why**
* Prevent streaming recovery from discarding usable `.partial` Opus outputs so we avoid duplicate re-encodes after a restart.
* Ensure the live recorder exits cleanly by waiting for encode workers before systemd tears down the service.

**How (high-level)**
* Promote leftover streaming partials and waveform sidecars to their final names during startup recovery and hand the path to the encode job for post-processing.
* Wait for outstanding encode jobs to finish on shutdown and tell systemd to leave the recorder process alone while it drains.
* Updated the recovery unit test to cover the new reuse behaviour.

**Risk / Rollback**
* Low: touches recovery and shutdown paths; rollback by reverting this commit if partial promotion causes issues.

**Links**
* Jira: https://mfisbv.atlassian.net/browse/TR-61
* Task run: (current automated task)


------
https://chatgpt.com/codex/tasks/task_e_68e2463918548327857b88eaa15a84f4