### PR TITLE
TR-66: Restore live playhead scrubbing

### DIFF
--- a/lib/webui/static/js/dashboard.js
+++ b/lib/webui/static/js/dashboard.js
@@ -1133,6 +1133,43 @@ const waveformState = {
   refreshRecordPath: "",
 };
 
+function getPlayerDurationSeconds() {
+  if (!dom.player) {
+    return Number.NaN;
+  }
+
+  const nativeDuration = Number(dom.player.duration);
+  if (Number.isFinite(nativeDuration) && nativeDuration > 0) {
+    return nativeDuration;
+  }
+
+  const seekable = dom.player.seekable;
+  if (seekable && typeof seekable.length === "number" && seekable.length > 0) {
+    try {
+      const end = seekable.end(seekable.length - 1);
+      if (Number.isFinite(end) && end > 0) {
+        return end;
+      }
+    } catch (error) {
+      /* ignore seekable errors */
+    }
+  }
+
+  if (Number.isFinite(waveformState.duration) && waveformState.duration > 0) {
+    return waveformState.duration;
+  }
+
+  const record = state.current;
+  if (record && record.duration_seconds !== undefined) {
+    const recordDuration = Number(record.duration_seconds);
+    if (Number.isFinite(recordDuration) && recordDuration > 0) {
+      return recordDuration;
+    }
+  }
+
+  return Number.NaN;
+}
+
 const clipperState = {
   enabled: false,
   available: false,
@@ -4546,12 +4583,15 @@ function updateCursorFromPlayer() {
   if (!dom.waveformContainer || dom.waveformContainer.hidden) {
     return;
   }
-  const duration = numericValue(dom.player.duration, 0);
-  if (duration <= 0) {
+  const duration = getPlayerDurationSeconds();
+  if (!Number.isFinite(duration) || duration <= 0) {
     setCursorFraction(0);
     return;
   }
-  const fraction = clamp(dom.player.currentTime / duration, 0, 1);
+  const currentTime = Number.isFinite(dom.player.currentTime)
+    ? dom.player.currentTime
+    : 0;
+  const fraction = clamp(currentTime / duration, 0, 1);
   setCursorFraction(fraction);
 }
 
@@ -5698,8 +5738,8 @@ function seekFromPointer(event) {
     return;
   }
   const fraction = clamp((event.clientX - rect.left) / rect.width, 0, 1);
-  const duration = numericValue(dom.player.duration, 0);
-  if (duration <= 0) {
+  const duration = getPlayerDurationSeconds();
+  if (!Number.isFinite(duration) || duration <= 0) {
     return;
   }
   dom.player.currentTime = fraction * duration;
@@ -5708,7 +5748,8 @@ function seekFromPointer(event) {
 
 function handleWaveformPointerDown(event) {
   event.stopPropagation();
-  if (!Number.isFinite(dom.player.duration) || dom.player.duration <= 0) {
+  const duration = getPlayerDurationSeconds();
+  if (!Number.isFinite(duration) || duration <= 0) {
     return;
   }
   waveformState.isScrubbing = true;
@@ -5762,7 +5803,7 @@ function seekToEventEnd() {
   if (!previewIsActive() || !dom.player) {
     return false;
   }
-  const duration = numericValue(dom.player.duration, NaN);
+  const duration = getPlayerDurationSeconds();
   if (!Number.isFinite(duration) || duration <= 0) {
     return false;
   }
@@ -5779,7 +5820,7 @@ function seekBySeconds(offsetSeconds) {
   if (!previewIsActive() || !dom.player || !Number.isFinite(offsetSeconds) || offsetSeconds === 0) {
     return false;
   }
-  const duration = numericValue(dom.player.duration, NaN);
+  const duration = getPlayerDurationSeconds();
   if (!Number.isFinite(duration) || duration <= 0) {
     return false;
   }
@@ -5853,12 +5894,11 @@ function isArrowKey(event, name) {
 }
 
 function canUseKeyboardJog() {
-  return (
-    dom.player &&
-    hasPlayableSource(dom.player) &&
-    Number.isFinite(dom.player.duration) &&
-    dom.player.duration > 0
-  );
+  if (!dom.player || !hasPlayableSource(dom.player)) {
+    return false;
+  }
+  const duration = getPlayerDurationSeconds();
+  return Number.isFinite(duration) && duration > 0;
 }
 
 function startKeyboardJog(direction) {
@@ -5910,12 +5950,14 @@ function performKeyboardJogStep(timestamp) {
   if (transportState.lastTimestamp !== null) {
     const deltaSeconds = (timestamp - transportState.lastTimestamp) / 1000;
     if (Number.isFinite(deltaSeconds) && deltaSeconds > 0 && transportState.direction !== 0) {
-      const duration = dom.player.duration;
-      const currentTime = Number.isFinite(dom.player.currentTime) ? dom.player.currentTime : 0;
-      const offset = transportState.direction * KEYBOARD_JOG_RATE_SECONDS_PER_SECOND * deltaSeconds;
-      const nextTime = clamp(currentTime + offset, 0, duration);
-      dom.player.currentTime = nextTime;
-      updateCursorFromPlayer();
+      const duration = getPlayerDurationSeconds();
+      if (Number.isFinite(duration) && duration > 0) {
+        const currentTime = Number.isFinite(dom.player.currentTime) ? dom.player.currentTime : 0;
+        const offset = transportState.direction * KEYBOARD_JOG_RATE_SECONDS_PER_SECOND * deltaSeconds;
+        const nextTime = clamp(currentTime + offset, 0, duration);
+        dom.player.currentTime = nextTime;
+        updateCursorFromPlayer();
+      }
     }
   }
 


### PR DESCRIPTION
## What / Why
- ensure the dashboard playhead advances for live/partial recordings so operators can monitor progress and interact.
- allow scrubbing and keyboard jog shortcuts when the live recording lacks a finite HTMLMediaElement duration.

## How (high-level)
- add an effective player duration helper that falls back to seekable ranges, waveform metadata, or record metadata when the native duration is unavailable.
- update cursor refresh, waveform scrubbing, seek helpers, and keyboard jog logic to use the computed duration.

## Risk / Rollback
- Low: changes are isolated to the dashboard playback controls and preserve prior behavior whenever the built-in duration is already finite. Roll back by reverting this PR if regressions are observed.

## Links
- [Jira TR-66](https://mfisbv.atlassian.net/browse/TR-66)
- Task Run: current
- Preview: N/A

------
https://chatgpt.com/codex/tasks/task_e_68e246c86708832796d6d96031896761