### PR TITLE
TR-61: Preserve streaming partial encodes

### DIFF
--- a/lib/webui/static/js/dashboard.js
+++ b/lib/webui/static/js/dashboard.js
@@ -1782,7 +1782,11 @@ function setRecordingIndicatorStatus(rawStatus) {
     setRecordingIndicatorUnknown();
     return;
   }
-  const capturing = Boolean(rawStatus.capturing);
+  const event = rawStatus && typeof rawStatus.event === "object" ? rawStatus.event : null;
+  let capturing = Boolean(rawStatus.capturing);
+  if (!capturing && event && parseBoolean(event.in_progress)) {
+    capturing = true;
+  }
   const rawStopReason =
     typeof rawStatus.last_stop_reason === "string"
       ? rawStatus.last_stop_reason.trim()
@@ -1793,7 +1797,6 @@ function setRecordingIndicatorStatus(rawStatus) {
   let message;
 
   if (capturing) {
-    const event = rawStatus.event;
     let detail = "";
     let startedLabel = "";
     if (event && typeof event === "object") {
@@ -1825,8 +1828,14 @@ function setRecordingIndicatorStatus(rawStatus) {
     const lastEvent = rawStatus.last_event;
     let detail = "";
     if (lastEvent && typeof lastEvent === "object") {
+      const startedEpoch = toFiniteOrNull(lastEvent.started_epoch);
       const endedEpoch = toFiniteOrNull(lastEvent.ended_epoch);
-      if (endedEpoch !== null) {
+      if (startedEpoch !== null) {
+        const startedDate = new Date(startedEpoch * 1000);
+        detail = `Last ${dateFormatter.format(startedDate)}`;
+      } else if (typeof lastEvent.started_at === "string" && lastEvent.started_at) {
+        detail = `Last ${lastEvent.started_at}`;
+      } else if (endedEpoch !== null) {
         const endedDate = new Date(endedEpoch * 1000);
         detail = `Last ${dateFormatter.format(endedDate)}`;
       } else if (typeof lastEvent.base_name === "string" && lastEvent.base_name) {
@@ -1935,14 +1944,17 @@ function updateRecordingMeta(rawStatus) {
     return;
   }
   const status = rawStatus && typeof rawStatus === "object" ? rawStatus : null;
-  const capturing = status ? Boolean(status.capturing) : false;
+  const event = status && typeof status.event === "object" ? status.event : null;
+  let capturing = status ? Boolean(status.capturing) : false;
+  if (!capturing && event && parseBoolean(event.in_progress)) {
+    capturing = true;
+  }
   if (!capturing) {
     hideRecordingMeta();
     return;
   }
   const durationSeconds = status ? toFiniteOrNull(status.event_duration_seconds) : null;
   const sizeBytes = status ? toFiniteOrNull(status.event_size_bytes) : null;
-  const event = status && typeof status.event === "object" ? status.event : null;
   const startedEpoch = event ? toFiniteOrNull(event.started_epoch) : null;
 
   if (durationSeconds !== null) {


### PR DESCRIPTION
**What / Why**
* Prevent streaming recovery from discarding usable `.partial` Opus outputs so we avoid duplicate re-encodes after a restart.
* Ensure the live recorder exits cleanly by waiting for encode workers before systemd tears down the service.
* Fix the dashboard recording label so live captures remain marked active and last-event timestamps reflect the event start time.

**How (high-level)**
* Promote leftover streaming partials and waveform sidecars to their final names during startup recovery and hand the path to the encode job for post-processing.
* Wait for outstanding encode jobs to finish on shutdown and tell systemd to leave the recorder process alone while it drains.
* Mirror the broader encode wait in the dropbox ingest utility to prevent premature exits during backlog processing.
* Treat in-progress capture events as active in the dashboard status helpers and prefer the event start timestamp when rendering the "Last" indicator.

**Risk / Rollback**
* Low: touches recovery and shutdown paths; rollback by reverting this commit if partial promotion causes issues.

**Links**
* Jira: https://mfisbv.atlassian.net/browse/TR-61
* Task run: (current automated task)


------
https://chatgpt.com/codex/tasks/task_e_68e24d5ebe248327904960c734c58f59