### PR TITLE
TR-68: Pin encoder affinity and skip redundant offline reencode

### DIFF
--- a/bin/encode_and_store.sh
+++ b/bin/encode_and_store.sh
@@ -38,7 +38,9 @@ run_python_module() {
   "$PYTHON_BIN" -m "$module" "$@"
 }
 day="$(date +%Y%m%d)"
-outdir="/apps/tricorder/recordings/$day"
+recordings_root="${ENCODER_RECORDINGS_DIR:-/apps/tricorder/recordings}"
+recordings_root="${recordings_root%/}"
+outdir="${recordings_root}/${day}"
 mkdir -p "$outdir"
 
 if [[ -n "$existing_opus" ]]; then

--- a/tests/test_10_segmenter.py
+++ b/tests/test_10_segmenter.py
@@ -2,10 +2,14 @@
 import builtins
 import json
 import os
+import queue
 import re
+import subprocess
+import sys
 import time
 import wave
 from datetime import datetime, timezone
+from pathlib import Path
 
 import os
 import pytest
@@ -1002,3 +1006,70 @@ def test_filter_chain_metrics_emit_structured_logs(monkeypatch, tmp_path):
     assert latest["filter_chain_avg_ms"] >= 5.0
     assert latest["filter_chain_avg_budget_ms"] == pytest.approx(segmenter.FILTER_CHAIN_AVG_BUDGET_MS)
     assert latest["filter_chain_peak_budget_ms"] == pytest.approx(segmenter.FILTER_CHAIN_PEAK_BUDGET_MS)
+
+
+def test_encoder_worker_pins_affinity(monkeypatch):
+    calls: dict[str, object] = {}
+
+    def fake_run(cmd, *, capture_output, text, check, env, preexec_fn):  # noqa: D401 - signature matches subprocess
+        calls["cmd"] = cmd
+        calls["preexec_fn"] = preexec_fn
+        return subprocess.CompletedProcess(cmd, 0, "", "")
+
+    monkeypatch.setattr(segmenter.subprocess, "run", fake_run)
+    monkeypatch.setattr(segmenter, "ENCODER", "/bin/true")
+
+    job_queue: queue.Queue = queue.Queue()
+    worker = segmenter._EncoderWorker(job_queue)
+    worker.start()
+    job_queue.put((123, "/tmp/sample.wav", "sample", None))
+    job_queue.put(None)
+    worker.join(timeout=2.0)
+
+    assert not worker.is_alive(), "worker should exit after sentinel"
+    assert calls["cmd"][0] == "/bin/true"
+    assert calls["preexec_fn"] is segmenter._set_single_core_affinity
+
+
+def test_encode_script_fast_path_skips_ffmpeg(tmp_path):
+    repo_root = Path(__file__).resolve().parents[1]
+    script_path = repo_root / "bin" / "encode_and_store.sh"
+
+    stub_bin = tmp_path / "bin"
+    stub_bin.mkdir()
+
+    ffmpeg_stub = stub_bin / "ffmpeg"
+    ffmpeg_stub.write_text("#!/usr/bin/env bash\nexit 42\n", encoding="utf-8")
+    ffmpeg_stub.chmod(0o755)
+
+    systemd_stub = stub_bin / "systemd-cat"
+    systemd_stub.write_text("#!/usr/bin/env bash\nexit 0\n", encoding="utf-8")
+    systemd_stub.chmod(0o755)
+
+    existing_opus = tmp_path / "stream.opus"
+    existing_opus.write_bytes(b"opus")
+    waveform = existing_opus.with_suffix(existing_opus.suffix + ".waveform.json")
+    waveform.write_text("{}", encoding="utf-8")
+    transcript = existing_opus.with_suffix(existing_opus.suffix + ".transcript.json")
+    transcript.write_text("{}", encoding="utf-8")
+    wav_path = tmp_path / "capture.wav"
+    wav_path.write_bytes(b"wavdata")
+
+    env = os.environ.copy()
+    env["PATH"] = f"{stub_bin}:{env['PATH']}"
+    env["PYTHONPATH"] = str(repo_root)
+    env["ENCODER_PYTHON"] = sys.executable
+    env["DENOISE"] = "0"
+    env["STREAMING_CONTAINER_FORMAT"] = "opus"
+    env["STREAMING_EXTENSION"] = ".opus"
+
+    result = subprocess.run(
+        [str(script_path), str(wav_path), "sample", str(existing_opus)],
+        env=env,
+        cwd=repo_root,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert not wav_path.exists(), "temporary WAV should be removed"

--- a/tests/test_10_segmenter.py
+++ b/tests/test_10_segmenter.py
@@ -1062,6 +1062,7 @@ def test_encode_script_fast_path_skips_ffmpeg(tmp_path):
     env["DENOISE"] = "0"
     env["STREAMING_CONTAINER_FORMAT"] = "opus"
     env["STREAMING_EXTENSION"] = ".opus"
+    env["ENCODER_RECORDINGS_DIR"] = str(tmp_path / "recordings")
 
     result = subprocess.run(
         [str(script_path), str(wav_path), "sample", str(existing_opus)],


### PR DESCRIPTION
**What / Why**
* Pin the offline encoder worker to a single CPU to avoid load spikes while jobs run.
* Skip redundant ffmpeg passes when the streaming pipeline already produced an Opus file so we only perform metadata work.

**How (high-level)**
* Add a `_set_single_core_affinity` helper and use it as the `preexec_fn` for `_EncoderWorker` subprocess launches.
* Extend `bin/encode_and_store.sh` with a reusable Python runner and an existing-Opus fast path that generates sidecars/archival without re-encoding.
* Backfill regression tests that assert affinity pinning and validate the shell script fast path via stubbed binaries.

**Risk / Rollback**
* Moderate risk: affinity and script changes affect offline finalization; revert this commit if CPU utilization or archival/transcription regress.

**Links**
* [Jira TR-68](https://mfisbv.atlassian.net/browse/TR-68)
* CODE Task Run: (current)
* Preview URL: N/A


------
https://chatgpt.com/codex/tasks/task_e_68e2621bd8b88327acec7bc4d159f954