### PR TITLE
TR-69: Add waveform amplitude zoom control

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ Uploads run immediately after the encoder finishes so recordings land in the arc
 - Recording browser with search, day filtering, pagination, and a recycle bin for safe deletion and restoration.
 - Recycle bin view provides inline audio preview before you restore or permanently clear recordings.
 - Audio preview player with waveform visualization, trigger/release markers, and timeline scrubbing.
+- Adjustable waveform amplitude zoom control for inspecting quiet or loud passages.
 - Config viewer that renders the merged runtime configuration (post-environment overrides).
 - Recorder configuration modal supports saving individual sections or using the **Save all changes** button to persist every dirty section in one go.
 - Persistent SD card health banner fed by the monitor service when kernel/syslog errors appear.

--- a/lib/webui/static/css/dashboard.css
+++ b/lib/webui/static/css/dashboard.css
@@ -1368,8 +1368,17 @@ button.small {
 .waveform-header {
   display: flex;
   justify-content: space-between;
-  align-items: baseline;
+  align-items: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.waveform-header-meta {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
   gap: 1rem;
+  flex-wrap: wrap;
 }
 
 .waveform-header span:first-child {
@@ -1382,6 +1391,30 @@ button.small {
 .waveform-status {
   font-size: 0.85rem;
   color: var(--text-muted);
+}
+
+.waveform-zoom-control {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.85rem;
+  color: var(--text-muted);
+}
+
+.waveform-zoom-control label {
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.waveform-zoom-control input[type="range"] {
+  width: 8rem;
+}
+
+.waveform-zoom-value {
+  min-width: 2.5rem;
+  text-align: right;
+  font-variant-numeric: tabular-nums;
 }
 
 .waveform-clock-row {

--- a/lib/webui/static/js/dashboard.js
+++ b/lib/webui/static/js/dashboard.js
@@ -442,6 +442,8 @@ const dom = {
   waveformReleaseMarker: document.getElementById("waveform-release-marker"),
   waveformEmpty: document.getElementById("waveform-empty"),
   waveformStatus: document.getElementById("waveform-status"),
+  waveformZoomInput: document.getElementById("waveform-zoom"),
+  waveformZoomValue: document.getElementById("waveform-zoom-value"),
   waveformRmsRow: document.getElementById("waveform-rms-row"),
   waveformRmsValue: document.getElementById("waveform-rms-value"),
   clipperContainer: document.getElementById("clipper-container"),
@@ -1128,6 +1130,10 @@ const renameDialogState = {
   previouslyFocused: null,
 };
 
+const WAVEFORM_ZOOM_DEFAULT = 1;
+const WAVEFORM_ZOOM_MIN = 0.25;
+const WAVEFORM_ZOOM_MAX = 4;
+
 const waveformState = {
   peaks: null,
   requestId: 0,
@@ -1144,6 +1150,7 @@ const waveformState = {
   rmsValues: null,
   refreshTimer: null,
   refreshRecordPath: "",
+  amplitudeScale: WAVEFORM_ZOOM_DEFAULT,
 };
 
 function getPlayerDurationSeconds() {
@@ -4855,6 +4862,60 @@ function resetWaveform() {
   updateWaveformClock();
 }
 
+function getWaveformZoomLimits() {
+  let min = WAVEFORM_ZOOM_MIN;
+  let max = WAVEFORM_ZOOM_MAX;
+  const input = dom.waveformZoomInput;
+  if (input) {
+    const parsedMin = Number.parseFloat(input.min);
+    if (Number.isFinite(parsedMin) && parsedMin > 0) {
+      min = parsedMin;
+    }
+    const parsedMax = Number.parseFloat(input.max);
+    if (Number.isFinite(parsedMax) && parsedMax > 0) {
+      max = parsedMax;
+    }
+  }
+  if (!(max > min)) {
+    min = WAVEFORM_ZOOM_MIN;
+    max = WAVEFORM_ZOOM_MAX;
+  }
+  return { min, max };
+}
+
+function normalizeWaveformZoom(value) {
+  const { min, max } = getWaveformZoomLimits();
+  const fallback = WAVEFORM_ZOOM_DEFAULT;
+  const candidate = Number.isFinite(value) && value > 0 ? value : fallback;
+  return clamp(candidate, min, max);
+}
+
+function formatWaveformZoom(value) {
+  if (!Number.isFinite(value) || value <= 0) {
+    return `${WAVEFORM_ZOOM_DEFAULT}×`;
+  }
+  const decimals = value < 1 ? 2 : 1;
+  const fixed = value.toFixed(decimals);
+  const trimmed = Number.parseFloat(fixed).toString();
+  return `${trimmed}×`;
+}
+
+function updateWaveformZoomDisplay(scale) {
+  const formatted = formatWaveformZoom(scale);
+  if (dom.waveformZoomValue) {
+    dom.waveformZoomValue.textContent = formatted;
+  }
+  if (dom.waveformZoomInput) {
+    dom.waveformZoomInput.setAttribute("aria-valuetext", formatted);
+  }
+}
+
+function getWaveformAmplitudeScale() {
+  const normalized = normalizeWaveformZoom(waveformState.amplitudeScale);
+  waveformState.amplitudeScale = normalized;
+  return normalized;
+}
+
 function drawWaveformFromPeaks(peaks) {
   if (!dom.waveformCanvas || !dom.waveformContainer) {
     return;
@@ -4885,6 +4946,7 @@ function drawWaveformFromPeaks(peaks) {
 
   const mid = height / 2;
   const amplitude = height / 2;
+  const gain = getWaveformAmplitudeScale();
   const denom = sampleCount > 1 ? sampleCount - 1 : 1;
 
   ctx.beginPath();
@@ -4892,13 +4954,15 @@ function drawWaveformFromPeaks(peaks) {
   for (let i = 0; i < sampleCount; i += 1) {
     const x = (i / denom) * width;
     const peak = peaks[i * 2 + 1];
-    const y = mid - peak * amplitude;
+    const scaled = clamp(peak * gain, -1, 1);
+    const y = mid - scaled * amplitude;
     ctx.lineTo(x, y);
   }
   for (let i = sampleCount - 1; i >= 0; i -= 1) {
     const x = (i / denom) * width;
     const trough = peaks[i * 2];
-    const y = mid - trough * amplitude;
+    const scaled = clamp(trough * gain, -1, 1);
+    const y = mid - scaled * amplitude;
     ctx.lineTo(x, y);
   }
   ctx.closePath();
@@ -4909,7 +4973,8 @@ function drawWaveformFromPeaks(peaks) {
   for (let i = 0; i < sampleCount; i += 1) {
     const x = (i / denom) * width;
     const peak = peaks[i * 2 + 1];
-    const y = mid - peak * amplitude;
+    const scaled = clamp(peak * gain, -1, 1);
+    const y = mid - scaled * amplitude;
     if (i === 0) {
       ctx.moveTo(x, y);
     } else {
@@ -4924,7 +4989,8 @@ function drawWaveformFromPeaks(peaks) {
   for (let i = 0; i < sampleCount; i += 1) {
     const x = (i / denom) * width;
     const trough = peaks[i * 2];
-    const y = mid - trough * amplitude;
+    const scaled = clamp(trough * gain, -1, 1);
+    const y = mid - scaled * amplitude;
     if (i === 0) {
       ctx.moveTo(x, y);
     } else {
@@ -13079,6 +13145,27 @@ function attachEventListeners() {
         openRenameDialog(record);
       }
     });
+  }
+
+  if (dom.waveformZoomInput instanceof HTMLInputElement) {
+    const initial = normalizeWaveformZoom(Number.parseFloat(dom.waveformZoomInput.value));
+    waveformState.amplitudeScale = initial;
+    dom.waveformZoomInput.value = initial.toString();
+    updateWaveformZoomDisplay(initial);
+    const handleWaveformZoomChange = (event) => {
+      if (!(event.target instanceof HTMLInputElement)) {
+        return;
+      }
+      const normalized = normalizeWaveformZoom(Number.parseFloat(event.target.value));
+      waveformState.amplitudeScale = normalized;
+      event.target.value = normalized.toString();
+      updateWaveformZoomDisplay(normalized);
+      redrawWaveform();
+    };
+    dom.waveformZoomInput.addEventListener("input", handleWaveformZoomChange);
+    dom.waveformZoomInput.addEventListener("change", handleWaveformZoomChange);
+  } else {
+    updateWaveformZoomDisplay(waveformState.amplitudeScale);
   }
 
   if (dom.waveformContainer) {

--- a/lib/webui/templates/dashboard.html
+++ b/lib/webui/templates/dashboard.html
@@ -375,7 +375,26 @@
           <div class="waveform-section" id="waveform-section">
             <div class="waveform-header">
               <span>Waveform</span>
-              <span class="waveform-status" id="waveform-status"></span>
+              <div class="waveform-header-meta">
+                <div class="waveform-zoom-control">
+                  <label for="waveform-zoom">Waveform Zoom</label>
+                  <input
+                    id="waveform-zoom"
+                    type="range"
+                    min="0.25"
+                    max="4"
+                    step="0.25"
+                    value="1"
+                  />
+                  <span
+                    id="waveform-zoom-value"
+                    class="waveform-zoom-value"
+                    aria-live="polite"
+                    aria-atomic="true"
+                  >1×</span>
+                </div>
+                <span class="waveform-status" id="waveform-status"></span>
+              </div>
             </div>
             <div class="waveform-clock-row" data-active="false">
               <div


### PR DESCRIPTION
**What / Why**
* Add a Waveform Zoom control so operators can inspect quiet or loud segments more easily.
* Document the new waveform gain option alongside existing dashboard capabilities.

**How (high-level)**
* Extend the dashboard template/CSS with a labeled range input that displays the current gain.
* Normalize the slider value, clamp peaks and troughs by the selected gain before drawing, and update the label dynamically when the user changes the setting.

**Risk / Rollback**
* Low risk: scoped to dashboard rendering. Roll back by reverting this change if UI issues appear.

**Links**
* Jira: https://mfisbv.atlassian.net/browse/TR-69
* Task Run: (see CODEX task log)
* Preview: N/A

------
https://chatgpt.com/codex/tasks/task_e_68e270f9658c8327ab908d8fe9b6f240