### PR TITLE
TR-75: Keep live stream active in background and persist dashboard UI state

### DIFF
--- a/lib/webui/static/js/dashboard.js
+++ b/lib/webui/static/js/dashboard.js
@@ -117,9 +117,12 @@ const DEFAULT_LIMIT = 200;
 const VALID_TIME_RANGES = new Set(["", "1h", "2h", "4h", "8h", "12h", "1d"]);
 const MAX_LIMIT = 1000;
 const FILTER_STORAGE_KEY = "tricorder.dashboard.filters";
+const SORT_STORAGE_KEY = "tricorder.dashboard.sort";
+const FILTER_PANEL_STORAGE_KEY = "tricorder.dashboard.filtersPanel";
 const CLIPPER_STORAGE_KEY = "tricorder.dashboard.clipper";
 const THEME_STORAGE_KEY = "tricorder.dashboard.theme";
 const RECYCLE_BIN_STATE_STORAGE_KEY = "tricorder.dashboard.recycleBin";
+const WAVEFORM_STORAGE_KEY = "tricorder.dashboard.waveform";
 
 const STREAM_MODE = (() => {
   if (typeof document === "undefined" || !document.body || !document.body.dataset) {
@@ -1232,6 +1235,11 @@ const transportState = {
   isJogging: false,
 };
 
+const focusState = {
+  previewPointer: false,
+  livePointer: false,
+};
+
 const confirmDialogState = {
   open: false,
   resolve: null,
@@ -1262,6 +1270,62 @@ const filtersLayoutState = {
   expanded: true,
   userOverride: false,
 };
+
+function readStoredFilterPanelPreference() {
+  try {
+    if (typeof window === "undefined" || !window.localStorage) {
+      return null;
+    }
+  } catch (error) {
+    return null;
+  }
+  try {
+    const raw = window.localStorage.getItem(FILTER_PANEL_STORAGE_KEY);
+    if (!raw) {
+      return null;
+    }
+    const parsed = JSON.parse(raw);
+    if (!parsed || typeof parsed !== "object") {
+      return null;
+    }
+    if (typeof parsed.expanded === "boolean") {
+      return parsed.expanded;
+    }
+    return null;
+  } catch (error) {
+    return null;
+  }
+}
+
+function persistFilterPanelPreference(expanded) {
+  try {
+    if (typeof window === "undefined" || !window.localStorage) {
+      return;
+    }
+  } catch (error) {
+    return;
+  }
+  try {
+    window.localStorage.setItem(
+      FILTER_PANEL_STORAGE_KEY,
+      JSON.stringify({ expanded: Boolean(expanded) })
+    );
+  } catch (error) {
+    /* ignore persistence errors */
+  }
+}
+
+function restoreFilterPanelPreference() {
+  const stored = readStoredFilterPanelPreference();
+  if (typeof stored !== "boolean") {
+    return;
+  }
+  filtersLayoutState.expanded = stored;
+  filtersLayoutState.userOverride = true;
+  if (dom.filtersPanel) {
+    dom.filtersPanel.dataset.state = stored ? "expanded" : "collapsed";
+  }
+}
 
 const configState = {
   prePadSeconds: null,
@@ -1513,6 +1577,71 @@ function clearStoredFilters() {
   }
 }
 
+function readStoredSortPreference() {
+  try {
+    if (typeof window === "undefined" || !window.localStorage) {
+      return null;
+    }
+  } catch (error) {
+    return null;
+  }
+  try {
+    const raw = window.localStorage.getItem(SORT_STORAGE_KEY);
+    if (!raw) {
+      return null;
+    }
+    const parsed = JSON.parse(raw);
+    if (!parsed || typeof parsed !== "object") {
+      return null;
+    }
+    return parsed;
+  } catch (error) {
+    return null;
+  }
+}
+
+function persistSortPreference() {
+  try {
+    if (typeof window === "undefined" || !window.localStorage) {
+      return;
+    }
+  } catch (error) {
+    return;
+  }
+  try {
+    const direction = state.sort.direction === "desc" ? "desc" : "asc";
+    const payload = {
+      key: state.sort.key,
+      direction,
+    };
+    window.localStorage.setItem(SORT_STORAGE_KEY, JSON.stringify(payload));
+  } catch (error) {
+    /* ignore persistence errors */
+  }
+}
+
+function restoreSortFromStorage() {
+  const stored = readStoredSortPreference();
+  if (!stored) {
+    return;
+  }
+  const validKeys = new Set(
+    dom.sortButtons
+      .map((button) => (button.dataset.sortKey ?? "").trim())
+      .filter((value) => value)
+  );
+  const candidateKey =
+    typeof stored.key === "string" && stored.key.trim() ? stored.key.trim() : "";
+  if (candidateKey && validKeys.has(candidateKey)) {
+    state.sort.key = candidateKey;
+  }
+  const candidateDirection =
+    typeof stored.direction === "string" ? stored.direction.toLowerCase() : "";
+  if (candidateDirection === "asc" || candidateDirection === "desc") {
+    state.sort.direction = candidateDirection;
+  }
+}
+
 function readStoredClipperPreference() {
   try {
     if (typeof window === "undefined" || !window.localStorage) {
@@ -1593,6 +1722,9 @@ function setFiltersExpanded(expanded, options = {}) {
     filtersLayoutState.userOverride = false;
   } else if (fromUser) {
     filtersLayoutState.userOverride = true;
+  }
+  if (fromUser) {
+    persistFilterPanelPreference(expanded);
   }
   const stateValue = expanded ? "expanded" : "collapsed";
   dom.filtersPanel.dataset.state = stateValue;
@@ -4890,6 +5022,58 @@ function normalizeWaveformZoom(value) {
   return clamp(candidate, min, max);
 }
 
+function readStoredWaveformPreferences() {
+  try {
+    if (typeof window === "undefined" || !window.localStorage) {
+      return null;
+    }
+  } catch (error) {
+    return null;
+  }
+  try {
+    const raw = window.localStorage.getItem(WAVEFORM_STORAGE_KEY);
+    if (!raw) {
+      return null;
+    }
+    const parsed = JSON.parse(raw);
+    if (!parsed || typeof parsed !== "object") {
+      return null;
+    }
+    return parsed;
+  } catch (error) {
+    return null;
+  }
+}
+
+function persistWaveformPreferences() {
+  try {
+    if (typeof window === "undefined" || !window.localStorage) {
+      return;
+    }
+  } catch (error) {
+    return;
+  }
+  try {
+    const normalized = normalizeWaveformZoom(waveformState.amplitudeScale);
+    const payload = { amplitudeScale: normalized };
+    window.localStorage.setItem(WAVEFORM_STORAGE_KEY, JSON.stringify(payload));
+  } catch (error) {
+    /* ignore persistence errors */
+  }
+}
+
+function restoreWaveformPreferences() {
+  const stored = readStoredWaveformPreferences();
+  if (!stored || typeof stored !== "object") {
+    return;
+  }
+  const rawValue = Number.parseFloat(stored.amplitudeScale ?? stored.zoom);
+  if (!Number.isFinite(rawValue) || rawValue <= 0) {
+    return;
+  }
+  waveformState.amplitudeScale = normalizeWaveformZoom(rawValue);
+}
+
 function formatWaveformZoom(value) {
   if (!Number.isFinite(value) || value <= 0) {
     return `${WAVEFORM_ZOOM_DEFAULT}×`;
@@ -5967,6 +6151,7 @@ function seekFromPointer(event) {
 
 function handleWaveformPointerDown(event) {
   event.stopPropagation();
+  focusPreviewSurface();
   const duration = getPlayerDurationSeconds();
   if (!Number.isFinite(duration) || duration <= 0) {
     return;
@@ -12549,6 +12734,48 @@ function closeLiveStreamPanel() {
   stopLiveStream({ sendSignal: true });
 }
 
+function focusElementSilently(element) {
+  if (!element || typeof element.focus !== "function") {
+    return false;
+  }
+  try {
+    element.focus({ preventScroll: true });
+    return true;
+  } catch (error) {
+    try {
+      element.focus();
+      return true;
+    } catch (error2) {
+      return false;
+    }
+  }
+}
+
+function focusLiveStreamPanel() {
+  if (!dom.livePanel || dom.livePanel.getAttribute("aria-hidden") === "true") {
+    return false;
+  }
+  return focusElementSilently(dom.livePanel);
+}
+
+function focusPreviewSurface() {
+  if (dom.waveformContainer && !dom.waveformContainer.hidden) {
+    if (focusElementSilently(dom.waveformContainer)) {
+      return true;
+    }
+  }
+  if (
+    dom.playerCard &&
+    dom.playerCard.dataset.active === "true" &&
+    dom.playerCard.hidden !== true
+  ) {
+    if (focusElementSilently(dom.playerCard)) {
+      return true;
+    }
+  }
+  return false;
+}
+
 function releaseLiveAudioFocus() {
   if (!dom.liveAudio || typeof document === "undefined") {
     return;
@@ -12557,13 +12784,8 @@ function releaseLiveAudioFocus() {
   if (active !== dom.liveAudio) {
     return;
   }
-  if (dom.liveToggle && typeof dom.liveToggle.focus === "function" && !dom.liveToggle.disabled) {
-    try {
-      dom.liveToggle.focus();
-      return;
-    } catch (error) {
-      /* ignore focus errors */
-    }
+  if (focusLiveStreamPanel()) {
+    return;
   }
   try {
     dom.liveAudio.blur();
@@ -12979,6 +13201,7 @@ function attachEventListeners() {
         state.sort.direction = "asc";
       }
       updateSortIndicators();
+      persistSortPreference();
       renderRecords();
     });
   }
@@ -13148,7 +13371,10 @@ function attachEventListeners() {
   }
 
   if (dom.waveformZoomInput instanceof HTMLInputElement) {
-    const initial = normalizeWaveformZoom(Number.parseFloat(dom.waveformZoomInput.value));
+    const storedValue = Number.isFinite(waveformState.amplitudeScale)
+      ? waveformState.amplitudeScale
+      : Number.parseFloat(dom.waveformZoomInput.value);
+    const initial = normalizeWaveformZoom(storedValue);
     waveformState.amplitudeScale = initial;
     dom.waveformZoomInput.value = initial.toString();
     updateWaveformZoomDisplay(initial);
@@ -13160,12 +13386,13 @@ function attachEventListeners() {
       waveformState.amplitudeScale = normalized;
       event.target.value = normalized.toString();
       updateWaveformZoomDisplay(normalized);
+      persistWaveformPreferences();
       redrawWaveform();
     };
     dom.waveformZoomInput.addEventListener("input", handleWaveformZoomChange);
     dom.waveformZoomInput.addEventListener("change", handleWaveformZoomChange);
   } else {
-    updateWaveformZoomDisplay(waveformState.amplitudeScale);
+    updateWaveformZoomDisplay(normalizeWaveformZoom(waveformState.amplitudeScale));
   }
 
   if (dom.waveformContainer) {
@@ -13184,6 +13411,32 @@ function attachEventListeners() {
   window.addEventListener("keyup", handleTransportKeyup);
   window.addEventListener("blur", cancelKeyboardJog);
   window.addEventListener("keydown", handleSpacebarShortcut);
+
+  const handlePreviewPointerReset = () => {
+    focusState.previewPointer = false;
+  };
+
+  dom.player.addEventListener("pointerdown", () => {
+    focusState.previewPointer = true;
+  });
+  dom.player.addEventListener("pointerup", handlePreviewPointerReset);
+  dom.player.addEventListener("pointercancel", handlePreviewPointerReset);
+  dom.player.addEventListener("focus", () => {
+    if (!focusState.previewPointer) {
+      return;
+    }
+    focusState.previewPointer = false;
+    window.requestAnimationFrame(() => {
+      if (!focusPreviewSurface()) {
+        try {
+          dom.player.blur();
+        } catch (error) {
+          /* ignore blur errors */
+        }
+      }
+    });
+  });
+  dom.player.addEventListener("blur", handlePreviewPointerReset);
 
   const suppressPlayerPropagation = (event) => {
     event.stopPropagation();
@@ -13313,6 +13566,12 @@ function attachEventListeners() {
 
   if (dom.playerCard) {
     dom.playerCard.addEventListener("keydown", handlePreviewKeydown);
+    dom.playerCard.addEventListener("pointerdown", (event) => {
+      if (findInteractiveElement(event.target, event)) {
+        return;
+      }
+      focusPreviewSurface();
+    });
   }
 
   if (dom.liveAudio) {
@@ -13348,6 +13607,30 @@ function attachEventListeners() {
     dom.liveAudio.addEventListener("ended", () => {
       playbackState.pausedViaSpacebar.delete(dom.liveAudio);
     });
+    const handleLivePointerReset = () => {
+      focusState.livePointer = false;
+    };
+    dom.liveAudio.addEventListener("pointerdown", () => {
+      focusState.livePointer = true;
+    });
+    dom.liveAudio.addEventListener("pointerup", handleLivePointerReset);
+    dom.liveAudio.addEventListener("pointercancel", handleLivePointerReset);
+    dom.liveAudio.addEventListener("focus", () => {
+      if (!focusState.livePointer) {
+        return;
+      }
+      focusState.livePointer = false;
+      window.requestAnimationFrame(() => {
+        if (!focusLiveStreamPanel()) {
+          try {
+            dom.liveAudio.blur();
+          } catch (error) {
+            /* ignore blur errors */
+          }
+        }
+      });
+    });
+    dom.liveAudio.addEventListener("blur", handleLivePointerReset);
   }
 
   window.addEventListener("beforeunload", () => {
@@ -13376,12 +13659,8 @@ function attachEventListeners() {
       stopServicesRefresh();
       stopHealthRefresh();
       stopConfigRefresh();
-      if (liveState.open) {
+      if (liveState.open && liveState.active) {
         cancelLiveStats();
-        sendStop(false);
-        if (dom.liveAudio) {
-          dom.liveAudio.pause();
-        }
       }
     } else {
       startAutoRefresh();
@@ -13392,7 +13671,6 @@ function attachEventListeners() {
       fetchConfig({ silent: true });
       if (liveState.open && liveState.active) {
         scheduleLiveStats();
-        sendStart();
         if (dom.liveAudio) {
           dom.liveAudio.play().catch(() => undefined);
         }
@@ -13415,12 +13693,15 @@ function attachEventListeners() {
 function initialize() {
   initializeTheme();
   restoreFiltersFromStorage();
+  restoreSortFromStorage();
+  restoreFilterPanelPreference();
   setupResponsiveFilters();
   populateFilters();
   updateSelectionUI();
   updateSortIndicators();
   updatePaginationControls();
   resetWaveform();
+  restoreWaveformPreferences();
   restoreClipperPreference();
   setClipperVisible(false);
   updateClipperStatusElement();

--- a/lib/webui/templates/dashboard.html
+++ b/lib/webui/templates/dashboard.html
@@ -347,7 +347,12 @@
         data-active="false"
         aria-hidden="true"
       >
-        <div id="live-stream-panel" class="live-stream-panel" aria-hidden="true">
+        <div
+          id="live-stream-panel"
+          class="live-stream-panel"
+          aria-hidden="true"
+          tabindex="-1"
+        >
           <div class="live-stream-header">
             <div class="live-stream-titles">
               <h3>Live stream</h3>
@@ -360,11 +365,18 @@
             </div>
           </div>
           <audio id="live-stream-audio" controls preload="auto"></audio>
-          <p class="live-stream-hint">Streaming pauses automatically when hidden.</p>
+          <p class="live-stream-hint">Streaming continues when backgrounded. Use the toggle to stop it.</p>
         </div>
       </section>
       <section class="main-grid">
-        <div id="player-card" class="card player-card" hidden data-active="false" data-context="recordings">
+        <div
+          id="player-card"
+          class="card player-card"
+          hidden
+          data-active="false"
+          data-context="recordings"
+          tabindex="-1"
+        >
           <div class="card-header">
             <div class="card-heading">
               <h2>Preview</h2>
@@ -404,7 +416,7 @@
                 data-active="false"
               >--:--:--</div>
             </div>
-            <div class="waveform-container" id="waveform-container" hidden>
+            <div class="waveform-container" id="waveform-container" hidden tabindex="-1">
               <canvas id="waveform-canvas"></canvas>
               <div
                 id="waveform-trigger-marker"


### PR DESCRIPTION
**What / Why**
* Keep the live stream playing when the dashboard tab loses focus so that it behaves like recorded playback.
* Persist additional dashboard preferences (sort order, filter panel expansion, waveform zoom) so users return to familiar settings.
* Improve focus handling so pointer interactions shift focus to the preview surface instead of trapping it on controls.

**How (high-level)**
* Adjust the visibilitychange handler to stop pausing the stream and only pause live stats polling while hidden, and resume playback/stat updates on return.
* Store and restore sort, filter panel, and waveform zoom preferences via `localStorage`, and initialize the UI from those saved values.
* Introduce shared focus helpers plus pointer listeners, and update markup to provide focus targets for the live stream panel, preview card, and waveform.

**Risk / Rollback**
* Moderate – touches dashboard JS/UI; rollback by reverting this change set if regressions appear in the web UI.

**Links**
* Jira: https://mfisbv.atlassian.net/browse/TR-75
* Task run: N/A
* Preview: N/A

------
https://chatgpt.com/codex/tasks/task_e_68e38daa9f148327800142b0f3a9a7e6