### PR TITLE
TR-78: Replace preview audio controls with custom transport

### DIFF
--- a/lib/webui/static/css/dashboard.css
+++ b/lib/webui/static/css/dashboard.css
@@ -1022,10 +1022,155 @@ button.small {
 }
 
 .player-card audio {
-  width: 100%;
+  display: none;
+}
+
+.player-card .player-transport {
+  margin-top: 1rem;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.player-card .player-transport[hidden] {
+  display: none !important;
+}
+
+.transport-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.transport-primary {
+  align-items: stretch;
+}
+
+.transport-buttons {
+  display: inline-flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.transport-button {
+  appearance: none;
+  border: 1px solid var(--storage-track);
+  background: var(--surface-soft);
+  color: inherit;
   border-radius: 0.75rem;
+  padding: 0.35rem 0.75rem;
+  min-height: 2.25rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.4rem;
+  cursor: pointer;
+  transition: background 0.2s ease, border-color 0.2s ease, transform 0.2s ease;
+  font: inherit;
+  line-height: 1.2;
+}
+
+.transport-button:hover {
   background: var(--surface-strong);
-  margin-top: 0.75rem;
+  border-color: var(--surface-border-strong, var(--storage-track));
+  transform: translateY(-1px);
+}
+
+.transport-button:active {
+  transform: translateY(0);
+}
+
+.transport-button:focus-visible {
+  outline: 2px solid rgba(191, 219, 254, 0.9);
+  outline-offset: 3px;
+}
+
+.transport-button[disabled] {
+  cursor: not-allowed;
+  opacity: 0.55;
+  transform: none;
+}
+
+.transport-button-primary {
+  background: var(--primary-button-bg, var(--surface-strong));
+  color: var(--primary-button-text, inherit);
+  border-color: var(--primary-button-border, var(--surface-border-strong, var(--storage-track)));
+  font-weight: 600;
+}
+
+.transport-button-primary:hover {
+  background: var(--primary-button-hover, var(--surface-stronger));
+}
+
+.transport-button-icon {
+  font-size: 1rem;
+  line-height: 1;
+}
+
+.transport-button-text {
+  font-size: 0.95rem;
+}
+
+.transport-time {
+  display: grid;
+  grid-template-columns: auto 1fr auto;
+  gap: 0.65rem;
+  align-items: center;
+  flex: 1 1 260px;
+  min-width: 0;
+}
+
+.transport-time-label {
+  font-variant-numeric: tabular-nums;
+  color: var(--text-muted);
+  min-width: 3.5ch;
+  text-align: center;
+}
+
+.transport-scrubber {
+  width: 100%;
+  cursor: pointer;
+}
+
+.transport-secondary {
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.transport-volume {
+  display: flex;
+  align-items: center;
+  gap: 0.65rem;
+}
+
+.transport-volume-slider {
+  width: min(220px, 40vw);
+}
+
+.transport-speed {
+  display: inline-flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  font-size: 0.9rem;
+}
+
+.transport-speed select {
+  min-width: 6rem;
+}
+
+@media (max-width: 768px) {
+  .transport-secondary {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .transport-volume {
+    justify-content: space-between;
+  }
+
+  .transport-volume-slider {
+    width: 100%;
+  }
 }
 
 .player-card .player-meta {

--- a/lib/webui/static/js/dashboard.js
+++ b/lib/webui/static/js/dashboard.js
@@ -123,6 +123,12 @@ const CLIPPER_STORAGE_KEY = "tricorder.dashboard.clipper";
 const THEME_STORAGE_KEY = "tricorder.dashboard.theme";
 const RECYCLE_BIN_STATE_STORAGE_KEY = "tricorder.dashboard.recycleBin";
 const WAVEFORM_STORAGE_KEY = "tricorder.dashboard.waveform";
+const TRANSPORT_STORAGE_KEY = "tricorder.dashboard.transport";
+const TRANSPORT_SCRUB_MAX = 1000;
+const TRANSPORT_SKIP_BACK_SECONDS = 10;
+const TRANSPORT_SKIP_FORWARD_SECONDS = 30;
+const MIN_PLAYBACK_RATE = 0.25;
+const MAX_PLAYBACK_RATE = 2;
 
 const STREAM_MODE = (() => {
   if (typeof document === "undefined" || !document.body || !document.body.dataset) {
@@ -358,6 +364,22 @@ const dom = {
   playerDownload: document.getElementById("player-download"),
   playerRename: document.getElementById("player-rename"),
   playerDelete: document.getElementById("player-delete"),
+  transportContainer: document.getElementById("player-transport"),
+  transportRestart: document.getElementById("transport-restart"),
+  transportRewind: document.getElementById("transport-rewind"),
+  transportPlay: document.getElementById("transport-play"),
+  transportPlayIcon: document.querySelector("#transport-play .transport-button-icon"),
+  transportPlayText: document.querySelector("#transport-play .transport-button-text"),
+  transportForward: document.getElementById("transport-forward"),
+  transportEnd: document.getElementById("transport-end"),
+  transportScrubber: document.getElementById("transport-scrubber"),
+  transportCurrent: document.getElementById("transport-current"),
+  transportDuration: document.getElementById("transport-duration"),
+  transportMute: document.getElementById("transport-mute"),
+  transportMuteIcon: document.querySelector("#transport-mute .transport-button-icon"),
+  transportMuteText: document.querySelector("#transport-mute .transport-button-text"),
+  transportVolume: document.getElementById("transport-volume"),
+  transportSpeed: document.getElementById("transport-speed-select"),
   configViewer: document.getElementById("config-viewer"),
   configOpen: document.getElementById("config-open"),
   configModal: document.getElementById("config-modal"),
@@ -1194,6 +1216,524 @@ function getPlayerDurationSeconds() {
   return Number.NaN;
 }
 
+function clampVolume(value) {
+  if (!Number.isFinite(value)) {
+    return 1;
+  }
+  return clamp(value, 0, 1);
+}
+
+function clampPlaybackRateValue(value) {
+  if (!Number.isFinite(value)) {
+    return 1;
+  }
+  return clamp(value, MIN_PLAYBACK_RATE, MAX_PLAYBACK_RATE);
+}
+
+function formatTransportClock(seconds) {
+  if (!Number.isFinite(seconds) || seconds < 0) {
+    return "0:00";
+  }
+  const totalSeconds = Math.floor(seconds);
+  const hours = Math.floor(totalSeconds / 3600);
+  const minutes = Math.floor((totalSeconds % 3600) / 60);
+  const secs = totalSeconds % 60;
+  if (hours > 0) {
+    return `${hours}:${minutes.toString().padStart(2, "0")}:${secs
+      .toString()
+      .padStart(2, "0")}`;
+  }
+  return `${minutes}:${secs.toString().padStart(2, "0")}`;
+}
+
+function formatPlaybackRateLabel(value) {
+  const normalized = clampPlaybackRateValue(value);
+  if (Number.isInteger(normalized)) {
+    return `${normalized}×`;
+  }
+  const formatted = normalized.toFixed(2).replace(/0+$/, "").replace(/\.$/, "");
+  return `${formatted}×`;
+}
+
+function loadTransportPreferences() {
+  if (typeof window === "undefined" || !window.localStorage) {
+    return;
+  }
+  try {
+    const raw = window.localStorage.getItem(TRANSPORT_STORAGE_KEY);
+    if (!raw) {
+      return;
+    }
+    const parsed = JSON.parse(raw);
+    if (!parsed || typeof parsed !== "object") {
+      return;
+    }
+    if (Number.isFinite(parsed.volume)) {
+      transportPreferences.volume = clampVolume(parsed.volume);
+    }
+    if (typeof parsed.muted === "boolean") {
+      transportPreferences.muted = parsed.muted;
+    }
+    if (Number.isFinite(parsed.playbackRate)) {
+      transportPreferences.playbackRate = clampPlaybackRateValue(parsed.playbackRate);
+    }
+  } catch (error) {
+    console.warn("Unable to restore transport preferences", error);
+  }
+}
+
+function persistTransportPreferences() {
+  if (typeof window === "undefined" || !window.localStorage) {
+    return;
+  }
+  try {
+    const payload = {
+      volume: clampVolume(dom.player ? dom.player.volume : transportPreferences.volume),
+      muted: dom.player ? Boolean(dom.player.muted) : transportPreferences.muted,
+      playbackRate: clampPlaybackRateValue(
+        dom.player ? dom.player.playbackRate : transportPreferences.playbackRate,
+      ),
+    };
+    window.localStorage.setItem(TRANSPORT_STORAGE_KEY, JSON.stringify(payload));
+  } catch (error) {
+    console.warn("Unable to persist transport preferences", error);
+  }
+}
+
+function applyTransportPreferences() {
+  if (!dom.player) {
+    return;
+  }
+  const volume = clampVolume(transportPreferences.volume);
+  dom.player.volume = volume;
+  dom.player.muted = Boolean(transportPreferences.muted);
+  dom.player.playbackRate = clampPlaybackRateValue(transportPreferences.playbackRate);
+  if (!dom.player.muted && volume > 0) {
+    transportState.lastUserVolume = volume;
+  }
+}
+
+function ensureTransportRateOption(rate) {
+  if (!dom.transportSpeed) {
+    return;
+  }
+  const normalized = clampPlaybackRateValue(rate);
+  const existing = Array.from(dom.transportSpeed.options || []).find((option) => {
+    return Number.parseFloat(option.value) === normalized;
+  });
+  if (existing) {
+    return;
+  }
+  const option = document.createElement("option");
+  option.value = normalized.toString();
+  option.textContent = formatPlaybackRateLabel(normalized);
+  dom.transportSpeed.append(option);
+}
+
+function setTransportActive(active) {
+  if (!dom.transportContainer) {
+    return;
+  }
+  dom.transportContainer.hidden = !active;
+  dom.transportContainer.dataset.active = active ? "true" : "false";
+  if (!active) {
+    dom.transportContainer.removeAttribute("data-ready");
+  }
+}
+
+function setTransportControlsDisabled(disabled) {
+  const controls = [
+    dom.transportRestart,
+    dom.transportRewind,
+    dom.transportPlay,
+    dom.transportForward,
+    dom.transportEnd,
+    dom.transportMute,
+    dom.transportVolume,
+    dom.transportSpeed,
+  ];
+  for (const control of controls) {
+    if (!control) {
+      continue;
+    }
+    control.disabled = disabled;
+    if (disabled) {
+      control.setAttribute("aria-disabled", "true");
+    } else {
+      control.removeAttribute("aria-disabled");
+    }
+  }
+}
+
+function resetTransportUi() {
+  transportState.scrubbing = false;
+  transportState.scrubWasPlaying = false;
+  if (dom.transportScrubber) {
+    dom.transportScrubber.value = "0";
+    dom.transportScrubber.disabled = true;
+    dom.transportScrubber.setAttribute("aria-valuemin", "0");
+    dom.transportScrubber.setAttribute("aria-valuemax", TRANSPORT_SCRUB_MAX.toString());
+    dom.transportScrubber.setAttribute("aria-valuenow", "0");
+    dom.transportScrubber.setAttribute("aria-valuetext", "0:00");
+  }
+  if (dom.transportCurrent) {
+    dom.transportCurrent.textContent = "0:00";
+  }
+  if (dom.transportDuration) {
+    dom.transportDuration.textContent = "0:00";
+  }
+  setTransportControlsDisabled(true);
+  updateTransportPlayState();
+  updateTransportVolumeUI();
+  updateTransportSpeedUI();
+}
+
+function updateTransportAvailability() {
+  if (!dom.transportContainer) {
+    return;
+  }
+  const active = Boolean(state.current);
+  setTransportActive(active);
+  if (!active) {
+    resetTransportUi();
+    return;
+  }
+  const ready = hasPlayableSource(dom.player);
+  dom.transportContainer.dataset.ready = ready ? "true" : "false";
+  setTransportControlsDisabled(!ready);
+  if (dom.transportScrubber) {
+    dom.transportScrubber.disabled = !ready;
+  }
+  updateTransportPlayState();
+  updateTransportProgressUI();
+  updateTransportVolumeUI();
+  updateTransportSpeedUI();
+}
+
+function updateTransportPlayState() {
+  if (!dom.transportPlay) {
+    return;
+  }
+  const ready = Boolean(state.current) && hasPlayableSource(dom.player);
+  const playing = ready && dom.player && !dom.player.paused && !dom.player.ended;
+  dom.transportPlay.disabled = !ready;
+  dom.transportPlay.setAttribute("aria-pressed", playing ? "true" : "false");
+  const label = playing ? "Pause" : "Play";
+  dom.transportPlay.setAttribute("aria-label", label);
+  if (dom.transportPlayText) {
+    dom.transportPlayText.textContent = label;
+  } else {
+    dom.transportPlay.textContent = label;
+  }
+  if (dom.transportPlayIcon) {
+    dom.transportPlayIcon.textContent = playing ? "⏸" : "▶";
+  }
+}
+
+function scrubValueToSeconds(value, duration) {
+  if (!Number.isFinite(duration) || duration <= 0) {
+    return 0;
+  }
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric)) {
+    return 0;
+  }
+  const fraction = clamp(numeric / TRANSPORT_SCRUB_MAX, 0, 1);
+  return duration * fraction;
+}
+
+function updateTransportProgressUI() {
+  if (!dom.transportScrubber || !dom.transportCurrent || !dom.transportDuration) {
+    return;
+  }
+  const ready = Boolean(state.current) && hasPlayableSource(dom.player);
+  const duration = ready ? getPlayerDurationSeconds() : Number.NaN;
+  if (!Number.isFinite(duration) || duration <= 0) {
+    dom.transportScrubber.disabled = true;
+    if (!transportState.scrubbing) {
+      dom.transportScrubber.value = "0";
+    }
+    dom.transportScrubber.setAttribute("aria-valuemin", "0");
+    dom.transportScrubber.setAttribute("aria-valuemax", TRANSPORT_SCRUB_MAX.toString());
+    dom.transportScrubber.setAttribute("aria-valuenow", "0");
+    dom.transportScrubber.setAttribute("aria-valuetext", "0:00");
+    dom.transportCurrent.textContent = "0:00";
+    dom.transportDuration.textContent = ready ? "0:00" : "0:00";
+    return;
+  }
+
+  dom.transportScrubber.disabled = !ready;
+  const currentTime = Number.isFinite(dom.player.currentTime)
+    ? clamp(dom.player.currentTime, 0, duration)
+    : 0;
+  const fraction = clamp(currentTime / duration, 0, 1);
+  const sliderValue = Math.round(fraction * TRANSPORT_SCRUB_MAX);
+  if (!transportState.scrubbing) {
+    dom.transportScrubber.value = sliderValue.toString();
+  }
+  dom.transportScrubber.setAttribute("aria-valuemin", "0");
+  dom.transportScrubber.setAttribute("aria-valuemax", TRANSPORT_SCRUB_MAX.toString());
+  const displaySeconds = transportState.scrubbing
+    ? scrubValueToSeconds(dom.transportScrubber.value, duration)
+    : currentTime;
+  const ariaValue = transportState.scrubbing
+    ? dom.transportScrubber.value
+    : sliderValue.toString();
+  dom.transportScrubber.setAttribute("aria-valuenow", ariaValue);
+  const formattedCurrent = formatTransportClock(displaySeconds);
+  dom.transportScrubber.setAttribute("aria-valuetext", formattedCurrent);
+  dom.transportCurrent.textContent = formattedCurrent;
+  dom.transportDuration.textContent = formatTransportClock(duration);
+}
+
+function updateTransportVolumeUI() {
+  if (!dom.transportVolume && !dom.transportMute) {
+    return;
+  }
+  const ready = Boolean(state.current) && hasPlayableSource(dom.player);
+  const volume = dom.player ? clampVolume(dom.player.volume) : transportPreferences.volume;
+  const muted = dom.player ? Boolean(dom.player.muted) : transportPreferences.muted;
+  if (dom.transportVolume) {
+    const sliderValue = Math.round(volume * 100);
+    dom.transportVolume.value = sliderValue.toString();
+    dom.transportVolume.disabled = !ready;
+    dom.transportVolume.setAttribute("aria-valuenow", sliderValue.toString());
+    dom.transportVolume.setAttribute("aria-valuetext", `${sliderValue}%`);
+  }
+  if (dom.transportMute) {
+    dom.transportMute.disabled = !ready;
+    const effectiveMuted = muted || volume === 0;
+    dom.transportMute.setAttribute("aria-pressed", effectiveMuted ? "true" : "false");
+    if (dom.transportMuteText) {
+      dom.transportMuteText.textContent = effectiveMuted ? "Unmute" : "Mute";
+    } else {
+      dom.transportMute.textContent = effectiveMuted ? "Unmute" : "Mute";
+    }
+    if (dom.transportMuteIcon) {
+      dom.transportMuteIcon.textContent = effectiveMuted ? "🔇" : "🔊";
+    }
+  }
+}
+
+function updateTransportSpeedUI() {
+  if (!dom.transportSpeed) {
+    return;
+  }
+  const ready = Boolean(state.current) && hasPlayableSource(dom.player);
+  const playbackRate = dom.player
+    ? clampPlaybackRateValue(dom.player.playbackRate)
+    : transportPreferences.playbackRate;
+  ensureTransportRateOption(playbackRate);
+  dom.transportSpeed.value = playbackRate.toString();
+  dom.transportSpeed.disabled = !ready;
+}
+
+function beginTransportScrub() {
+  if (!dom.player || !hasPlayableSource(dom.player)) {
+    return;
+  }
+  if (!transportState.scrubbing) {
+    transportState.scrubbing = true;
+    transportState.scrubWasPlaying = !dom.player.paused && !dom.player.ended;
+    if (transportState.scrubWasPlaying) {
+      try {
+        dom.player.pause();
+      } catch (error) {
+        /* ignore pause errors */
+      }
+    }
+  }
+}
+
+function commitTransportScrub() {
+  if (!transportState.scrubbing) {
+    return;
+  }
+  transportState.scrubbing = false;
+  const duration = getPlayerDurationSeconds();
+  if (dom.player && Number.isFinite(duration) && duration > 0 && dom.transportScrubber) {
+    const nextSeconds = scrubValueToSeconds(dom.transportScrubber.value, duration);
+    try {
+      dom.player.currentTime = nextSeconds;
+    } catch (error) {
+      /* ignore seek errors */
+    }
+  }
+  const shouldResume = transportState.scrubWasPlaying;
+  transportState.scrubWasPlaying = false;
+  updateTransportProgressUI();
+  if (shouldResume && dom.player) {
+    dom.player.play().catch(() => undefined);
+  }
+}
+
+function skipTransportBy(offsetSeconds) {
+  if (!dom.player || !hasPlayableSource(dom.player)) {
+    return;
+  }
+  const duration = getPlayerDurationSeconds();
+  if (!Number.isFinite(duration) || duration <= 0) {
+    return;
+  }
+  const currentTime = Number.isFinite(dom.player.currentTime) ? dom.player.currentTime : 0;
+  const nextTime = clamp(currentTime + offsetSeconds, 0, duration);
+  try {
+    dom.player.currentTime = nextTime;
+  } catch (error) {
+    /* ignore seek errors */
+  }
+  updateTransportProgressUI();
+}
+
+function restartTransport() {
+  if (!dom.player || !hasPlayableSource(dom.player)) {
+    return;
+  }
+  const wasPlaying = !dom.player.paused && !dom.player.ended;
+  try {
+    dom.player.currentTime = 0;
+  } catch (error) {
+    /* ignore seek errors */
+  }
+  updateTransportProgressUI();
+  if (wasPlaying) {
+    dom.player.play().catch(() => undefined);
+  }
+}
+
+function jumpToTransportEnd() {
+  if (!dom.player || !hasPlayableSource(dom.player)) {
+    return;
+  }
+  const duration = getPlayerDurationSeconds();
+  if (!Number.isFinite(duration) || duration <= 0) {
+    return;
+  }
+  try {
+    dom.player.currentTime = duration;
+  } catch (error) {
+    /* ignore seek errors */
+  }
+  updateTransportProgressUI();
+}
+
+function rememberLastUserVolume(volume) {
+  const normalized = clampVolume(volume);
+  if (normalized > 0) {
+    transportState.lastUserVolume = normalized;
+  }
+}
+
+function handleTransportMuteToggle() {
+  if (!dom.player || !hasPlayableSource(dom.player)) {
+    return;
+  }
+  const currentlyMuted = dom.player.muted || dom.player.volume === 0;
+  if (currentlyMuted) {
+    dom.player.muted = false;
+    const restoreVolume = transportState.lastUserVolume > 0 ? transportState.lastUserVolume : 1;
+    dom.player.volume = clampVolume(restoreVolume);
+  } else {
+    rememberLastUserVolume(dom.player.volume);
+    dom.player.muted = true;
+  }
+}
+
+function handleTransportVolumeInput(event) {
+  if (!dom.player || !(event.target instanceof HTMLInputElement)) {
+    return;
+  }
+  const percent = Number.parseInt(event.target.value, 10);
+  if (!Number.isFinite(percent)) {
+    return;
+  }
+  const volume = clampVolume(percent / 100);
+  if (volume > 0) {
+    dom.player.muted = false;
+    dom.player.volume = volume;
+  } else {
+    dom.player.volume = 0;
+    dom.player.muted = true;
+  }
+}
+
+function handleTransportSpeedChange(event) {
+  if (!dom.player || !(event.target instanceof HTMLSelectElement)) {
+    return;
+  }
+  const rate = clampPlaybackRateValue(Number.parseFloat(event.target.value));
+  dom.player.playbackRate = rate;
+}
+
+function handleTransportPlayToggle() {
+  if (!dom.player || !hasPlayableSource(dom.player)) {
+    return;
+  }
+  if (dom.player.paused || dom.player.ended) {
+    dom.player.play().catch(() => undefined);
+  } else {
+    try {
+      dom.player.pause();
+    } catch (error) {
+      /* ignore pause errors */
+    }
+  }
+}
+
+function handleTransportScrubberInput() {
+  if (!dom.player || !dom.transportScrubber || !hasPlayableSource(dom.player)) {
+    return;
+  }
+  beginTransportScrub();
+  updateTransportProgressUI();
+}
+
+function handleTransportScrubberCommit() {
+  commitTransportScrub();
+}
+
+function handleTransportScrubberPointerDown() {
+  if (!dom.player || !hasPlayableSource(dom.player)) {
+    return;
+  }
+  beginTransportScrub();
+}
+
+function handleTransportScrubberPointerUp() {
+  handleTransportScrubberCommit();
+}
+
+function handleTransportScrubberBlur() {
+  if (transportState.scrubbing) {
+    handleTransportScrubberCommit();
+  }
+}
+
+function handlePlayerVolumeChange() {
+  if (!dom.player) {
+    return;
+  }
+  const volume = clampVolume(dom.player.volume);
+  const muted = Boolean(dom.player.muted);
+  if (!muted && volume > 0) {
+    rememberLastUserVolume(volume);
+  }
+  transportPreferences.volume = volume;
+  transportPreferences.muted = muted;
+  updateTransportVolumeUI();
+  persistTransportPreferences();
+}
+
+function handlePlayerRateChange() {
+  if (!dom.player) {
+    return;
+  }
+  const rate = clampPlaybackRateValue(dom.player.playbackRate);
+  transportPreferences.playbackRate = rate;
+  updateTransportSpeedUI();
+  persistTransportPreferences();
+}
+
 const clipperState = {
   enabled: false,
   available: false,
@@ -1234,6 +1774,15 @@ const transportState = {
   lastTimestamp: null,
   wasPlaying: false,
   isJogging: false,
+  scrubbing: false,
+  scrubWasPlaying: false,
+  lastUserVolume: 1,
+};
+
+const transportPreferences = {
+  volume: 1,
+  muted: false,
+  playbackRate: 1,
 };
 
 const focusState = {
@@ -4293,6 +4842,8 @@ function setNowPlaying(record, options = {}) {
   cancelKeyboardJog();
 
   playbackState.pausedViaSpacebar.delete(dom.player);
+  transportState.scrubbing = false;
+  transportState.scrubWasPlaying = false;
 
   if (!sameRecord && dom.player) {
     try {
@@ -4305,6 +4856,7 @@ function setNowPlaying(record, options = {}) {
   }
 
   state.current = record;
+  setTransportActive(Boolean(record));
   if (!record) {
     initializeClipper(null);
     updatePlayerMeta(null);
@@ -4322,6 +4874,8 @@ function setNowPlaying(record, options = {}) {
     if (dom.playerCard) {
       dom.playerCard.dataset.context = "recordings";
     }
+    resetTransportUi();
+    updateTransportAvailability();
     return;
   }
 
@@ -4357,6 +4911,7 @@ function setNowPlaying(record, options = {}) {
       }
     }
     updateWaveformMarkers();
+    updateTransportAvailability();
     return;
   }
 
@@ -4392,6 +4947,7 @@ function setNowPlaying(record, options = {}) {
   setWaveformMarker(dom.waveformTriggerMarker, null, null);
   setWaveformMarker(dom.waveformReleaseMarker, null, null);
   loadWaveform(record);
+  updateTransportAvailability();
 }
 
 function renderRecords() {
@@ -13518,25 +14074,88 @@ function attachEventListeners() {
   dom.player.addEventListener("play", () => {
     playbackState.pausedViaSpacebar.delete(dom.player);
     startCursorAnimation();
+    updateTransportPlayState();
+    updateTransportProgressUI();
   });
   dom.player.addEventListener("pause", () => {
     stopCursorAnimation();
     updateCursorFromPlayer();
+    updateTransportPlayState();
+    updateTransportProgressUI();
   });
-  dom.player.addEventListener("timeupdate", updateCursorFromPlayer);
-  dom.player.addEventListener("seeked", updateCursorFromPlayer);
-  dom.player.addEventListener("loadedmetadata", handlePlayerLoadedMetadata);
+  dom.player.addEventListener("timeupdate", () => {
+    updateCursorFromPlayer();
+    if (!transportState.scrubbing) {
+      updateTransportProgressUI();
+    }
+  });
+  dom.player.addEventListener("seeked", () => {
+    updateCursorFromPlayer();
+    updateTransportProgressUI();
+  });
+  dom.player.addEventListener("loadedmetadata", (event) => {
+    handlePlayerLoadedMetadata(event);
+    updateTransportAvailability();
+  });
+  dom.player.addEventListener("durationchange", updateTransportProgressUI);
   dom.player.addEventListener("ended", () => {
     applyNowPlayingHighlight();
     stopCursorAnimation();
     updateCursorFromPlayer();
+    updateTransportProgressUI();
+    updateTransportPlayState();
     playbackState.pausedViaSpacebar.delete(dom.player);
   });
   dom.player.addEventListener("emptied", () => {
     playbackState.pausedViaSpacebar.delete(dom.player);
     playbackState.resetOnLoad = false;
     playbackState.enforcePauseOnLoad = false;
+    resetTransportUi();
+    updateTransportAvailability();
   });
+  dom.player.addEventListener("volumechange", handlePlayerVolumeChange);
+  dom.player.addEventListener("ratechange", handlePlayerRateChange);
+
+  if (dom.transportPlay) {
+    dom.transportPlay.addEventListener("click", handleTransportPlayToggle);
+  }
+  if (dom.transportRestart) {
+    dom.transportRestart.addEventListener("click", () => {
+      restartTransport();
+    });
+  }
+  if (dom.transportRewind) {
+    dom.transportRewind.addEventListener("click", () => {
+      skipTransportBy(-TRANSPORT_SKIP_BACK_SECONDS);
+    });
+  }
+  if (dom.transportForward) {
+    dom.transportForward.addEventListener("click", () => {
+      skipTransportBy(TRANSPORT_SKIP_FORWARD_SECONDS);
+    });
+  }
+  if (dom.transportEnd) {
+    dom.transportEnd.addEventListener("click", () => {
+      jumpToTransportEnd();
+    });
+  }
+  if (dom.transportMute) {
+    dom.transportMute.addEventListener("click", handleTransportMuteToggle);
+  }
+  if (dom.transportVolume) {
+    dom.transportVolume.addEventListener("input", handleTransportVolumeInput);
+  }
+  if (dom.transportSpeed) {
+    dom.transportSpeed.addEventListener("change", handleTransportSpeedChange);
+  }
+  if (dom.transportScrubber) {
+    dom.transportScrubber.addEventListener("input", handleTransportScrubberInput);
+    dom.transportScrubber.addEventListener("change", handleTransportScrubberCommit);
+    dom.transportScrubber.addEventListener("pointerdown", handleTransportScrubberPointerDown);
+    dom.transportScrubber.addEventListener("pointerup", handleTransportScrubberPointerUp);
+    dom.transportScrubber.addEventListener("pointercancel", handleTransportScrubberPointerUp);
+    dom.transportScrubber.addEventListener("blur", handleTransportScrubberBlur);
+  }
 
   if (dom.clipperSetStart) {
     dom.clipperSetStart.addEventListener("click", () => {
@@ -13769,6 +14388,10 @@ function initialize() {
   updateSortIndicators();
   updatePaginationControls();
   resetWaveform();
+  loadTransportPreferences();
+  applyTransportPreferences();
+  setTransportActive(false);
+  resetTransportUi();
   restoreWaveformPreferences();
   restoreClipperPreference();
   setClipperVisible(false);
@@ -13789,6 +14412,7 @@ function initialize() {
   applyArchivalData(archivalDefaults(), { markPristine: true });
   updateArchivalConfigPath(archivalState.configPath);
   attachEventListeners();
+  updateTransportAvailability();
   fetchRecordings({ silent: false });
   fetchConfig({ silent: false });
   fetchWebServerSettings({ silent: true });

--- a/lib/webui/templates/dashboard.html
+++ b/lib/webui/templates/dashboard.html
@@ -383,7 +383,88 @@
             </div>
             <button id="preview-close" class="ghost-button small" type="button">Hide</button>
           </div>
-          <audio id="preview-player" controls preload="none"></audio>
+          <audio id="preview-player" preload="none" aria-hidden="true"></audio>
+          <div class="player-transport" id="player-transport" hidden data-active="false">
+            <div class="transport-row transport-primary">
+              <div class="transport-buttons" role="group" aria-label="Playback controls">
+                <button id="transport-restart" class="transport-button" type="button">
+                  <span aria-hidden="true">⏮</span>
+                  <span class="sr-only">Restart</span>
+                </button>
+                <button id="transport-rewind" class="transport-button" type="button">
+                  <span aria-hidden="true">⏪</span>
+                  <span class="sr-only">Rewind 10 seconds</span>
+                </button>
+                <button
+                  id="transport-play"
+                  class="transport-button transport-button-primary"
+                  type="button"
+                  aria-pressed="false"
+                >
+                  <span class="transport-button-icon" aria-hidden="true">▶</span>
+                  <span class="transport-button-text">Play</span>
+                </button>
+                <button id="transport-forward" class="transport-button" type="button">
+                  <span aria-hidden="true">⏩</span>
+                  <span class="sr-only">Forward 30 seconds</span>
+                </button>
+                <button id="transport-end" class="transport-button" type="button">
+                  <span aria-hidden="true">⏭</span>
+                  <span class="sr-only">Skip to end</span>
+                </button>
+              </div>
+              <div class="transport-time" role="group" aria-label="Playback position">
+                <span id="transport-current" class="transport-time-label">0:00</span>
+                <input
+                  id="transport-scrubber"
+                  class="transport-scrubber"
+                  type="range"
+                  min="0"
+                  max="1000"
+                  step="1"
+                  value="0"
+                  aria-label="Playback position"
+                />
+                <span id="transport-duration" class="transport-time-label">0:00</span>
+              </div>
+            </div>
+            <div class="transport-row transport-secondary">
+              <div class="transport-volume" role="group" aria-label="Volume">
+                <button
+                  id="transport-mute"
+                  class="transport-button"
+                  type="button"
+                  aria-pressed="false"
+                >
+                  <span class="transport-button-icon" aria-hidden="true">🔊</span>
+                  <span class="transport-button-text">Mute</span>
+                </button>
+                <input
+                  id="transport-volume"
+                  class="transport-volume-slider"
+                  type="range"
+                  min="0"
+                  max="100"
+                  step="1"
+                  value="100"
+                  aria-label="Volume"
+                />
+              </div>
+              <label class="transport-speed" for="transport-speed-select">
+                <span>Speed</span>
+                <select id="transport-speed-select">
+                  <option value="0.25">0.25×</option>
+                  <option value="0.5">0.5×</option>
+                  <option value="0.75">0.75×</option>
+                  <option value="1" selected>1×</option>
+                  <option value="1.25">1.25×</option>
+                  <option value="1.5">1.5×</option>
+                  <option value="1.75">1.75×</option>
+                  <option value="2">2×</option>
+                </select>
+              </label>
+            </div>
+          </div>
           <div class="waveform-section" id="waveform-section">
             <div class="waveform-header">
               <span>Waveform</span>


### PR DESCRIPTION
## What / Why
* Provide custom transport controls for the preview player so mobile browsers no longer rely on the native "Live" UI.
* Expose playback position, skipping, volume, and playback speed controls consistently across devices.

## How (high-level)
* Replace the native `<audio>` controls in the preview card with a transport toolbar and supporting markup.
* Add dashboard CSS for the new transport layout and buttons, hiding the browser audio element.
* Extend `dashboard.js` with transport state management, persisted preferences, event handlers, and initialize/update hooks to drive the custom controls.

## Risk / Rollback
* Risk: regressions in audio preview playback due to new control logic; mitigated by reusing the existing player element and updating listeners.
* Rollback: revert this commit to restore the prior native audio controls.

## Links
* [Jira TR-78](https://mfisbv.atlassian.net/browse/TR-78)
* Task run: (internal)
* Preview: n/a

------
https://chatgpt.com/codex/tasks/task_e_68e3adc1c6c083279b51934fd514cdd2