### PR TITLE
TR-80: Restyle preview transport

### DIFF
--- a/lib/webui/static/css/dashboard.css
+++ b/lib/webui/static/css/dashboard.css
@@ -1027,149 +1027,138 @@ button.small {
 
 .player-card .player-transport {
   margin-top: 1rem;
-  display: grid;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
   gap: 0.75rem;
+  padding: 0.75rem 1rem;
+  border-radius: 0.75rem;
+  background-color: var(--surface-strong, #1f2937);
+  background-image: linear-gradient(180deg, rgba(255, 255, 255, 0.05), rgba(15, 23, 42, 0.92));
+  border: 1px solid var(--surface-border-strong, rgba(148, 163, 184, 0.35));
+  box-shadow: 0 10px 20px rgba(15, 23, 42, 0.28);
 }
 
 .player-card .player-transport[hidden] {
   display: none !important;
 }
 
-.transport-row {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 0.75rem;
-  align-items: center;
-}
-
-.transport-primary {
-  align-items: stretch;
-}
-
 .transport-buttons {
   display: inline-flex;
   flex-wrap: wrap;
   gap: 0.5rem;
+  align-items: center;
 }
 
 .transport-button {
   appearance: none;
-  border: 1px solid var(--storage-track);
-  background: var(--surface-soft);
+  border-radius: 0.5rem;
+  border: 1px solid var(--surface-border-strong, rgba(148, 163, 184, 0.4));
+  background-color: var(--surface-stronger, #111827);
+  background-image: linear-gradient(180deg, rgba(255, 255, 255, 0.08), rgba(15, 23, 42, 0.85));
   color: inherit;
-  border-radius: 0.75rem;
-  padding: 0.35rem 0.75rem;
-  min-height: 2.25rem;
+  width: 2.75rem;
+  height: 2.75rem;
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  gap: 0.4rem;
   cursor: pointer;
-  transition: background 0.2s ease, border-color 0.2s ease, transform 0.2s ease;
+  transition: transform 0.12s ease, box-shadow 0.12s ease, background-image 0.2s ease;
   font: inherit;
-  line-height: 1.2;
+  line-height: 1;
+  box-shadow: 0 2px 6px rgba(15, 23, 42, 0.35);
 }
 
 .transport-button:hover {
-  background: var(--surface-strong);
-  border-color: var(--surface-border-strong, var(--storage-track));
+  background-image: linear-gradient(180deg, rgba(255, 255, 255, 0.12), rgba(15, 23, 42, 0.8));
+  box-shadow: 0 4px 10px rgba(15, 23, 42, 0.45);
   transform: translateY(-1px);
 }
 
 .transport-button:active {
   transform: translateY(0);
+  box-shadow: inset 0 3px 6px rgba(0, 0, 0, 0.4);
 }
 
 .transport-button:focus-visible {
-  outline: 2px solid rgba(191, 219, 254, 0.9);
+  outline: 2px solid rgba(56, 189, 248, 0.9);
   outline-offset: 3px;
 }
 
 .transport-button[disabled] {
   cursor: not-allowed;
-  opacity: 0.55;
+  opacity: 0.6;
   transform: none;
+  box-shadow: none;
 }
 
 .transport-button-primary {
-  background: var(--primary-button-bg, var(--surface-strong));
-  color: var(--primary-button-text, inherit);
-  border-color: var(--primary-button-border, var(--surface-border-strong, var(--storage-track)));
-  font-weight: 600;
+  background-color: var(--primary-button-bg, #2563eb);
+  background-image: linear-gradient(180deg, var(--primary-button-bg, #2563eb), var(--primary-button-hover, #1d4ed8));
+  color: var(--primary-button-text, #ffffff);
+  border-color: var(--primary-button-border, rgba(37, 99, 235, 0.85));
 }
 
 .transport-button-primary:hover {
-  background: var(--primary-button-hover, var(--surface-stronger));
+  background-image: linear-gradient(180deg, var(--primary-button-hover, #1d4ed8), var(--primary-button-bg, #2563eb));
 }
 
 .transport-button-icon {
-  font-size: 1rem;
+  font-size: 1.15rem;
   line-height: 1;
 }
 
 .transport-button-text {
-  font-size: 0.95rem;
+  font-size: 0.85rem;
 }
 
-.transport-time {
-  display: grid;
-  grid-template-columns: auto 1fr auto;
-  gap: 0.65rem;
+.transport-options {
+  display: inline-flex;
   align-items: center;
-  flex: 1 1 260px;
-  min-width: 0;
-}
-
-.transport-time-label {
-  font-variant-numeric: tabular-nums;
-  color: var(--text-muted);
-  min-width: 3.5ch;
-  text-align: center;
-}
-
-.transport-scrubber {
-  width: 100%;
-  cursor: pointer;
-}
-
-.transport-secondary {
-  justify-content: space-between;
-  gap: 1rem;
-}
-
-.transport-volume {
-  display: flex;
-  align-items: center;
-  gap: 0.65rem;
-}
-
-.transport-volume-slider {
-  width: min(220px, 40vw);
+  gap: 0.5rem;
+  margin-left: auto;
+  flex-wrap: wrap;
 }
 
 .transport-speed {
   display: inline-flex;
   flex-direction: column;
-  gap: 0.25rem;
-  font-size: 0.9rem;
+  gap: 0.2rem;
+  font-size: 0.85rem;
+  color: var(--text-muted);
+}
+
+.transport-speed-label {
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+  font-size: 0.7rem;
 }
 
 .transport-speed select {
   min-width: 6rem;
+  padding: 0.35rem 0.6rem;
+  border-radius: 0.5rem;
+  border: 1px solid var(--surface-border-strong, rgba(148, 163, 184, 0.45));
+  background: var(--surface-soft, #0f172a);
+  color: inherit;
+  font: inherit;
 }
 
-@media (max-width: 768px) {
-  .transport-secondary {
-    flex-direction: column;
-    align-items: stretch;
+@media (max-width: 640px) {
+  .player-card .player-transport {
+    justify-content: center;
+    gap: 0.65rem;
   }
 
-  .transport-volume {
-    justify-content: space-between;
+  .transport-buttons {
+    flex: 1 1 100%;
+    justify-content: center;
   }
 
-  .transport-volume-slider {
-    width: 100%;
+  .transport-options {
+    flex: 1 1 100%;
+    justify-content: center;
+    margin-left: 0;
   }
 }
 

--- a/lib/webui/static/js/dashboard.js
+++ b/lib/webui/static/js/dashboard.js
@@ -1268,12 +1268,8 @@ function loadTransportPreferences() {
     if (!parsed || typeof parsed !== "object") {
       return;
     }
-    if (Number.isFinite(parsed.volume)) {
-      transportPreferences.volume = clampVolume(parsed.volume);
-    }
-    if (typeof parsed.muted === "boolean") {
-      transportPreferences.muted = parsed.muted;
-    }
+    transportPreferences.volume = 1;
+    transportPreferences.muted = false;
     if (Number.isFinite(parsed.playbackRate)) {
       transportPreferences.playbackRate = clampPlaybackRateValue(parsed.playbackRate);
     }
@@ -1288,8 +1284,8 @@ function persistTransportPreferences() {
   }
   try {
     const payload = {
-      volume: clampVolume(dom.player ? dom.player.volume : transportPreferences.volume),
-      muted: dom.player ? Boolean(dom.player.muted) : transportPreferences.muted,
+      volume: 1,
+      muted: false,
       playbackRate: clampPlaybackRateValue(
         dom.player ? dom.player.playbackRate : transportPreferences.playbackRate,
       ),
@@ -1304,13 +1300,12 @@ function applyTransportPreferences() {
   if (!dom.player) {
     return;
   }
-  const volume = clampVolume(transportPreferences.volume);
-  dom.player.volume = volume;
-  dom.player.muted = Boolean(transportPreferences.muted);
+  transportPreferences.volume = 1;
+  transportPreferences.muted = false;
+  dom.player.volume = 1;
+  dom.player.muted = false;
   dom.player.playbackRate = clampPlaybackRateValue(transportPreferences.playbackRate);
-  if (!dom.player.muted && volume > 0) {
-    transportState.lastUserVolume = volume;
-  }
+  transportState.lastUserVolume = 1;
 }
 
 function ensureTransportRateOption(rate) {

--- a/lib/webui/templates/dashboard.html
+++ b/lib/webui/templates/dashboard.html
@@ -385,73 +385,47 @@
           </div>
           <audio id="preview-player" preload="none" aria-hidden="true"></audio>
           <div class="player-transport" id="player-transport" hidden data-active="false">
-            <div class="transport-row transport-primary">
-              <div class="transport-buttons" role="group" aria-label="Playback controls">
-                <button id="transport-restart" class="transport-button" type="button">
-                  <span aria-hidden="true">⏮</span>
-                  <span class="sr-only">Restart</span>
-                </button>
-                <button id="transport-rewind" class="transport-button" type="button">
-                  <span aria-hidden="true">⏪</span>
-                  <span class="sr-only">Rewind 10 seconds</span>
-                </button>
-                <button
-                  id="transport-play"
-                  class="transport-button transport-button-primary"
-                  type="button"
-                  aria-pressed="false"
-                >
-                  <span class="transport-button-icon" aria-hidden="true">▶</span>
-                  <span class="transport-button-text">Play</span>
-                </button>
-                <button id="transport-forward" class="transport-button" type="button">
-                  <span aria-hidden="true">⏩</span>
-                  <span class="sr-only">Forward 30 seconds</span>
-                </button>
-                <button id="transport-end" class="transport-button" type="button">
-                  <span aria-hidden="true">⏭</span>
-                  <span class="sr-only">Skip to end</span>
-                </button>
-              </div>
-              <div class="transport-time" role="group" aria-label="Playback position">
-                <span id="transport-current" class="transport-time-label">0:00</span>
-                <input
-                  id="transport-scrubber"
-                  class="transport-scrubber"
-                  type="range"
-                  min="0"
-                  max="1000"
-                  step="1"
-                  value="0"
-                  aria-label="Playback position"
-                />
-                <span id="transport-duration" class="transport-time-label">0:00</span>
-              </div>
+            <div class="transport-buttons" role="group" aria-label="Playback controls">
+              <button id="transport-restart" class="transport-button" type="button" aria-label="Restart">
+                <span class="transport-button-icon" aria-hidden="true">⏮</span>
+                <span class="transport-button-text sr-only">Restart</span>
+              </button>
+              <button
+                id="transport-rewind"
+                class="transport-button"
+                type="button"
+                aria-label="Rewind 10 seconds"
+              >
+                <span class="transport-button-icon" aria-hidden="true">⏪</span>
+                <span class="transport-button-text sr-only">Rewind 10 seconds</span>
+              </button>
+              <button
+                id="transport-play"
+                class="transport-button transport-button-primary"
+                type="button"
+                aria-pressed="false"
+                aria-label="Play"
+              >
+                <span class="transport-button-icon" aria-hidden="true">▶</span>
+                <span class="transport-button-text sr-only">Play</span>
+              </button>
+              <button
+                id="transport-forward"
+                class="transport-button"
+                type="button"
+                aria-label="Forward 30 seconds"
+              >
+                <span class="transport-button-icon" aria-hidden="true">⏩</span>
+                <span class="transport-button-text sr-only">Forward 30 seconds</span>
+              </button>
+              <button id="transport-end" class="transport-button" type="button" aria-label="Skip to end">
+                <span class="transport-button-icon" aria-hidden="true">⏭</span>
+                <span class="transport-button-text sr-only">Skip to end</span>
+              </button>
             </div>
-            <div class="transport-row transport-secondary">
-              <div class="transport-volume" role="group" aria-label="Volume">
-                <button
-                  id="transport-mute"
-                  class="transport-button"
-                  type="button"
-                  aria-pressed="false"
-                >
-                  <span class="transport-button-icon" aria-hidden="true">🔊</span>
-                  <span class="transport-button-text">Mute</span>
-                </button>
-                <input
-                  id="transport-volume"
-                  class="transport-volume-slider"
-                  type="range"
-                  min="0"
-                  max="100"
-                  step="1"
-                  value="100"
-                  aria-label="Volume"
-                />
-              </div>
+            <div class="transport-options">
               <label class="transport-speed" for="transport-speed-select">
-                <span>Speed</span>
+                <span class="transport-speed-label">Speed</span>
                 <select id="transport-speed-select">
                   <option value="0.25">0.25×</option>
                   <option value="0.5">0.5×</option>


### PR DESCRIPTION
**What / Why**
- Rework the preview transport to use a compact, traditional DAW-inspired control bar per design feedback.
- Remove the legacy volume slider and timeline scrubber because playback volume stays at 100% and the timeline lives elsewhere.

**How (high-level)**
- Updated the transport markup to icon-only buttons paired with a condensed options block for the speed selector.
- Refreshed the CSS with a single-row flex layout, darker chrome, and responsive rules that drop into two neat rows on small screens.
- Locked persisted volume preferences to 100% and unmuted in the dashboard script so the player always starts at full level without the old slider.

**Risk / Rollback**
- Low risk: changes are isolated to the preview transport UI. Roll back by reverting this commit if regressions appear.

**Links**
- Jira: https://mfisbv.atlassian.net/browse/TR-80
- Task run: (link unavailable in sandbox)
- Preview: (local static preview only)


------
https://chatgpt.com/codex/tasks/task_e_68e3c903990483279b36cbac382383bd