### PR TITLE
TR-128: Downgrade selector transport guard logging severity

### DIFF
--- a/lib/web_streamer.py
+++ b/lib/web_streamer.py
@@ -233,8 +233,8 @@ def _install_selector_transport_guard(log: logging.Logger) -> None:
                 "Selector transport missing %s during connection_lost; continuing cleanup defensively."
                 % missing
             )
-            asyncio_log.error(message, stack_info=True)
-            log.error(message)
+            asyncio_log.warning(message)
+            log.warning(message)
             if protocol_connected and protocol is not None:
                 try:
                     protocol.connection_lost(exc)

--- a/tests/test_25_web_streamer.py
+++ b/tests/test_25_web_streamer.py
@@ -147,7 +147,7 @@ def test_selector_transport_guard_handles_missing_protocol(caplog):
             _server=dummy_server,
         )
 
-        with caplog.at_level(logging.ERROR, logger="asyncio"):
+        with caplog.at_level(logging.WARNING, logger="asyncio"):
             selector_events._SelectorTransport._call_connection_lost(transport, None)
 
         assert dummy_sock.closed is True
@@ -157,7 +157,11 @@ def test_selector_transport_guard_handles_missing_protocol(caplog):
         assert transport._protocol is None
         assert transport._loop is None
         assert transport._protocol_connected is False
-        assert "Selector transport missing protocol" in caplog.text
+        assert any(
+            record.levelno == logging.WARNING
+            and "Selector transport missing protocol" in record.getMessage()
+            for record in caplog.records
+        )
     finally:
         loop.close()
 


### PR DESCRIPTION
**What / Why**
* Reduce the severity of the selector transport guard log when asyncio reports a missing protocol/socket so routine cleanup no longer surfaces as an error.
* Keep automated tests aligned with the new logging level so the guard behavior remains covered.

**How (high-level)**
* Change the guard to emit warnings instead of errors when falling back to defensive cleanup, leaving the rest of the recovery path intact.
* Update the selector transport unit test to expect warning-level output and assert against captured warning records.

**Risk / Rollback**
* Low risk: only affects log severity during defensive cleanup; functionality remains the same. Revert this commit to restore the prior error-level logging.

**Links**
* Jira: https://mfisbv.atlassian.net/browse/TR-128

------
https://chatgpt.com/codex/tasks/task_e_68e3cb7332c08327a43a277d8cebd110