### PR TITLE
TR-82: Add motion start/end markers to waveform timeline

### DIFF
--- a/lib/web_streamer.py
+++ b/lib/web_streamer.py
@@ -2044,6 +2044,11 @@ def _scan_recordings_worker(
 ) -> tuple[list[dict[str, object]], list[str], list[str], int]:
     log = logging.getLogger("web_streamer")
 
+    def _float_or_none(value: object) -> float | None:
+        if isinstance(value, (int, float)) and math.isfinite(float(value)):
+            return float(value)
+        return None
+
     def _iter_candidate_files() -> Iterable[Path]:
         def _on_error(error: OSError) -> None:
             location = getattr(error, "filename", None) or recordings_root
@@ -2161,6 +2166,25 @@ def _scan_recordings_worker(
         else:
             duration = _probe_duration(path, stat)
 
+        trigger_offset = _float_or_none(
+            waveform_meta.get("trigger_offset_seconds") if waveform_meta else None
+        )
+        release_offset = _float_or_none(
+            waveform_meta.get("release_offset_seconds") if waveform_meta else None
+        )
+        motion_trigger_offset = _float_or_none(
+            waveform_meta.get("motion_trigger_offset_seconds") if waveform_meta else None
+        )
+        motion_release_offset = _float_or_none(
+            waveform_meta.get("motion_release_offset_seconds") if waveform_meta else None
+        )
+        motion_started_epoch = _float_or_none(
+            waveform_meta.get("motion_started_epoch") if waveform_meta else None
+        )
+        motion_released_epoch = _float_or_none(
+            waveform_meta.get("motion_released_epoch") if waveform_meta else None
+        )
+
         rel_posix = rel.as_posix()
         day = rel.parts[0] if len(rel.parts) > 1 else ""
 
@@ -2195,6 +2219,12 @@ def _scan_recordings_worker(
                 "transcript_event_type": transcript_event_type,
                 "transcript_updated": transcript_updated,
                 "transcript_updated_iso": transcript_updated_iso,
+                "trigger_offset_seconds": trigger_offset,
+                "release_offset_seconds": release_offset,
+                "motion_trigger_offset_seconds": motion_trigger_offset,
+                "motion_release_offset_seconds": motion_release_offset,
+                "motion_started_epoch": motion_started_epoch,
+                "motion_released_epoch": motion_released_epoch,
             }
         )
 
@@ -3965,6 +3995,36 @@ def build_app(lets_encrypt_manager: LetsEncryptManager | None = None) -> web.App
                 "duration_seconds": (
                     float(entry.get("duration"))
                     if isinstance(entry.get("duration"), (int, float))
+                    else None
+                ),
+                "trigger_offset_seconds": (
+                    float(entry.get("trigger_offset_seconds"))
+                    if isinstance(entry.get("trigger_offset_seconds"), (int, float))
+                    else None
+                ),
+                "release_offset_seconds": (
+                    float(entry.get("release_offset_seconds"))
+                    if isinstance(entry.get("release_offset_seconds"), (int, float))
+                    else None
+                ),
+                "motion_trigger_offset_seconds": (
+                    float(entry.get("motion_trigger_offset_seconds"))
+                    if isinstance(entry.get("motion_trigger_offset_seconds"), (int, float))
+                    else None
+                ),
+                "motion_release_offset_seconds": (
+                    float(entry.get("motion_release_offset_seconds"))
+                    if isinstance(entry.get("motion_release_offset_seconds"), (int, float))
+                    else None
+                ),
+                "motion_started_epoch": (
+                    float(entry.get("motion_started_epoch"))
+                    if isinstance(entry.get("motion_started_epoch"), (int, float))
+                    else None
+                ),
+                "motion_released_epoch": (
+                    float(entry.get("motion_released_epoch"))
+                    if isinstance(entry.get("motion_released_epoch"), (int, float))
                     else None
                 ),
                 "waveform_path": (

--- a/lib/webui/static/css/dashboard.css
+++ b/lib/webui/static/css/dashboard.css
@@ -1700,6 +1700,16 @@ button.small {
   box-shadow: 0 0 10px rgba(34, 197, 94, 0.25);
 }
 
+.waveform-marker.marker-motion-start {
+  background: rgba(59, 130, 246, 0.65);
+  box-shadow: 0 0 10px rgba(59, 130, 246, 0.25);
+}
+
+.waveform-marker.marker-motion-release {
+  background: rgba(147, 51, 234, 0.65);
+  box-shadow: 0 0 10px rgba(147, 51, 234, 0.25);
+}
+
 .waveform-marker.marker-release {
   background: rgba(251, 191, 36, 0.65);
   box-shadow: 0 0 10px rgba(251, 191, 36, 0.25);

--- a/lib/webui/static/js/dashboard.js
+++ b/lib/webui/static/js/dashboard.js
@@ -466,6 +466,8 @@ const dom = {
   waveformClock: document.getElementById("waveform-clock"),
   waveformCursor: document.getElementById("waveform-cursor"),
   waveformTriggerMarker: document.getElementById("waveform-trigger-marker"),
+  waveformMotionStartMarker: document.getElementById("waveform-motion-start-marker"),
+  waveformMotionEndMarker: document.getElementById("waveform-motion-end-marker"),
   waveformReleaseMarker: document.getElementById("waveform-release-marker"),
   waveformEmpty: document.getElementById("waveform-empty"),
   waveformStatus: document.getElementById("waveform-status"),
@@ -1179,6 +1181,8 @@ const waveformState = {
   lastFraction: 0,
   triggerSeconds: null,
   releaseSeconds: null,
+  motionTriggerSeconds: null,
+  motionReleaseSeconds: null,
   peakScale: 32767,
   startEpoch: null,
   rmsValues: null,
@@ -4235,6 +4239,10 @@ function deriveInProgressRecord(captureStatus) {
     transcript_updated_iso: "",
     trigger_offset_seconds: null,
     release_offset_seconds: null,
+    motion_trigger_offset_seconds: toFiniteOrNull(event.motion_trigger_offset_seconds),
+    motion_release_offset_seconds: toFiniteOrNull(event.motion_release_offset_seconds),
+    motion_started_epoch: toFiniteOrNull(event.motion_started_epoch),
+    motion_released_epoch: toFiniteOrNull(event.motion_released_epoch),
     isPartial: true,
     inProgress: true,
   };
@@ -4312,8 +4320,16 @@ function computeRecordsFingerprint(records) {
     const release = Number.isFinite(record.release_offset_seconds)
       ? record.release_offset_seconds
       : "";
+    const motionTrigger = Number.isFinite(record.motion_trigger_offset_seconds)
+      ? record.motion_trigger_offset_seconds
+      : "";
+    const motionRelease = Number.isFinite(record.motion_release_offset_seconds)
+      ? record.motion_release_offset_seconds
+      : "";
     const waveform = typeof record.waveform_path === "string" ? record.waveform_path : "";
-    parts.push(`${path}|${modified}|${size}|${duration}|${trigger}|${release}|${waveform}`);
+    parts.push(
+      `${path}|${modified}|${size}|${duration}|${trigger}|${release}|${motionTrigger}|${motionRelease}|${waveform}`
+    );
   }
   return parts.join("\n");
 }
@@ -4963,6 +4979,8 @@ function setNowPlaying(record, options = {}) {
   }
 
   setWaveformMarker(dom.waveformTriggerMarker, null, null);
+  setWaveformMarker(dom.waveformMotionStartMarker, null, null);
+  setWaveformMarker(dom.waveformMotionEndMarker, null, null);
   setWaveformMarker(dom.waveformReleaseMarker, null, null);
   loadWaveform(record);
   updateTransportAvailability();
@@ -5450,7 +5468,11 @@ function updateWaveformMarkers() {
   if (!state.current || duration <= 0) {
     waveformState.triggerSeconds = null;
     waveformState.releaseSeconds = null;
+    waveformState.motionTriggerSeconds = null;
+    waveformState.motionReleaseSeconds = null;
     setWaveformMarker(dom.waveformTriggerMarker, null, null);
+    setWaveformMarker(dom.waveformMotionStartMarker, null, null);
+    setWaveformMarker(dom.waveformMotionEndMarker, null, null);
     setWaveformMarker(dom.waveformReleaseMarker, null, null);
     return;
   }
@@ -5492,9 +5514,50 @@ function updateWaveformMarkers() {
     releaseSeconds = null;
   }
 
+  let motionTriggerSeconds = toFiniteOrNull(state.current.motion_trigger_offset_seconds);
+  if (Number.isFinite(motionTriggerSeconds)) {
+    motionTriggerSeconds = clamp(motionTriggerSeconds, 0, duration);
+    if (motionTriggerSeconds <= minGap || motionTriggerSeconds >= duration - minGap) {
+      motionTriggerSeconds = null;
+    }
+  } else {
+    motionTriggerSeconds = null;
+  }
+
+  let motionReleaseSeconds = toFiniteOrNull(state.current.motion_release_offset_seconds);
+  if (Number.isFinite(motionReleaseSeconds)) {
+    motionReleaseSeconds = clamp(motionReleaseSeconds, 0, duration);
+    if (motionReleaseSeconds <= minGap || motionReleaseSeconds >= duration - minGap) {
+      motionReleaseSeconds = null;
+    }
+  } else {
+    motionReleaseSeconds = null;
+  }
+
+  if (
+    motionReleaseSeconds !== null &&
+    motionTriggerSeconds !== null &&
+    motionReleaseSeconds - motionTriggerSeconds <= minGap
+  ) {
+    motionReleaseSeconds = motionTriggerSeconds;
+  }
+
+  if (
+    motionReleaseSeconds !== null &&
+    motionTriggerSeconds === null &&
+    triggerSeconds !== null &&
+    Math.abs(motionReleaseSeconds - triggerSeconds) <= minGap
+  ) {
+    motionReleaseSeconds = triggerSeconds;
+  }
+
   waveformState.triggerSeconds = triggerSeconds;
   waveformState.releaseSeconds = releaseSeconds;
+  waveformState.motionTriggerSeconds = motionTriggerSeconds;
+  waveformState.motionReleaseSeconds = motionReleaseSeconds;
   setWaveformMarker(dom.waveformTriggerMarker, triggerSeconds, duration);
+  setWaveformMarker(dom.waveformMotionStartMarker, motionTriggerSeconds, duration);
+  setWaveformMarker(dom.waveformMotionEndMarker, motionReleaseSeconds, duration);
   setWaveformMarker(dom.waveformReleaseMarker, releaseSeconds, duration);
 }
 
@@ -5594,6 +5657,8 @@ function resetWaveform() {
   waveformState.lastFraction = 0;
   waveformState.triggerSeconds = null;
   waveformState.releaseSeconds = null;
+  waveformState.motionTriggerSeconds = null;
+  waveformState.motionReleaseSeconds = null;
   waveformState.peakScale = 32767;
   waveformState.startEpoch = null;
   waveformState.rmsValues = null;
@@ -5609,6 +5674,8 @@ function resetWaveform() {
     dom.waveformCursor.style.left = "0%";
   }
   setWaveformMarker(dom.waveformTriggerMarker, null, null);
+  setWaveformMarker(dom.waveformMotionStartMarker, null, null);
+  setWaveformMarker(dom.waveformMotionEndMarker, null, null);
   setWaveformMarker(dom.waveformReleaseMarker, null, null);
   hideWaveformRms();
   if (dom.waveformEmpty) {
@@ -6567,9 +6634,13 @@ async function loadWaveform(record) {
   setCursorFraction(0);
   waveformState.triggerSeconds = null;
   waveformState.releaseSeconds = null;
+  waveformState.motionTriggerSeconds = null;
+  waveformState.motionReleaseSeconds = null;
   waveformState.startEpoch = null;
   waveformState.rmsValues = null;
   setWaveformMarker(dom.waveformTriggerMarker, null, null);
+  setWaveformMarker(dom.waveformMotionStartMarker, null, null);
+  setWaveformMarker(dom.waveformMotionEndMarker, null, null);
   setWaveformMarker(dom.waveformReleaseMarker, null, null);
   hideWaveformRms();
 
@@ -6641,6 +6712,14 @@ async function loadWaveform(record) {
     waveformState.duration = effectiveDuration;
     waveformState.rmsValues = normalizedRms;
     record.duration_seconds = effectiveDuration;
+    record.motion_trigger_offset_seconds = toFiniteOrNull(
+      payload.motion_trigger_offset_seconds
+    );
+    record.motion_release_offset_seconds = toFiniteOrNull(
+      payload.motion_release_offset_seconds
+    );
+    record.motion_started_epoch = toFiniteOrNull(payload.motion_started_epoch);
+    record.motion_released_epoch = toFiniteOrNull(payload.motion_released_epoch);
 
     let startEpoch = toFiniteOrNull(payload.start_epoch);
     if (startEpoch === null) {
@@ -7413,6 +7492,14 @@ async function fetchRecordings(options = {}) {
         started_at: startedAt,
         trigger_offset_seconds: toFiniteOrNull(item.trigger_offset_seconds),
         release_offset_seconds: toFiniteOrNull(item.release_offset_seconds),
+        motion_trigger_offset_seconds: toFiniteOrNull(
+          item.motion_trigger_offset_seconds
+        ),
+        motion_release_offset_seconds: toFiniteOrNull(
+          item.motion_release_offset_seconds
+        ),
+        motion_started_epoch: toFiniteOrNull(item.motion_started_epoch),
+        motion_released_epoch: toFiniteOrNull(item.motion_released_epoch),
         waveform_path:
           typeof item.waveform_path === "string" && item.waveform_path
             ? String(item.waveform_path)

--- a/lib/webui/templates/dashboard.html
+++ b/lib/webui/templates/dashboard.html
@@ -490,6 +490,22 @@
                 <span>Trigger</span>
               </div>
               <div
+                id="waveform-motion-start-marker"
+                class="waveform-marker marker-motion-start"
+                aria-hidden="true"
+                data-active="false"
+              >
+                <span>Motion Start</span>
+              </div>
+              <div
+                id="waveform-motion-end-marker"
+                class="waveform-marker marker-motion-release"
+                aria-hidden="true"
+                data-active="false"
+              >
+                <span>Motion End</span>
+              </div>
+              <div
                 id="waveform-release-marker"
                 class="waveform-marker marker-release"
                 aria-hidden="true"


### PR DESCRIPTION
## What / Why
- add motion trigger/release metadata to recorded events so the UI can distinguish motion-driven captures
- render dedicated motion start/end markers on the dashboard waveform to improve debugging of multi-sensor triggers

## How (high-level)
- track motion watcher state in the segmenter, persisting motion epochs/offsets into waveform metadata and live status payloads
- surface motion offsets through the web streamer APIs and partial recording state consumed by the dashboard
- enhance dashboard templates, styling, and JS logic to place motion markers with distinct colors and reset behavior, plus extend tests for the new data

## Risk / Rollback
- Low: changes are additive to motion metadata and UI markers; rollback by reverting this PR if issues appear.

## Links
- [Jira: TR-82](https://mfisbv.atlassian.net/browse/TR-82)

------
https://chatgpt.com/codex/tasks/task_e_68e4152f65848327ad6958b48df0e472