### PR TITLE
TR-84: Suppress asyncio None-callback errors for cancelled handles

### DIFF
--- a/lib/web_streamer.py
+++ b/lib/web_streamer.py
@@ -152,6 +152,8 @@ def _install_handle_run_guard() -> None:
     @functools.wraps(handle_run)
     def safe_run(self: asyncio.Handle) -> None:  # type: ignore[name-defined]
         if self._callback is None:
+            if getattr(self, "_cancelled", False):
+                return
             asyncio_log.error(
                 "Discarded asyncio handle with None callback; args=%r", self._args, stack_info=True
             )

--- a/tests/test_25_web_streamer.py
+++ b/tests/test_25_web_streamer.py
@@ -115,6 +115,23 @@ def test_handle_run_guard_discards_none_callbacks(caplog):
         loop.close()
 
 
+def test_handle_run_guard_ignores_cancelled_handles(caplog):
+    loop = asyncio.new_event_loop()
+    try:
+        logger = logging.getLogger("web_streamer")
+        web_streamer._install_loop_callback_guard(loop, logger)
+
+        handle = loop.call_soon(lambda: None)
+        handle.cancel()
+
+        with caplog.at_level(logging.ERROR, logger="asyncio"):
+            handle._run()
+
+        assert "Discarded asyncio handle with None callback" not in caplog.text
+    finally:
+        loop.close()
+
+
 def test_selector_transport_guard_handles_missing_protocol(caplog):
     loop = asyncio.new_event_loop()
     try:


### PR DESCRIPTION
**What / Why**
- Prevent spurious `asyncio` error logs when cancelled handles execute the guard hook.
- Guard the behaviour with a regression test to avoid future regressions.

**How (high-level)**
- Skip logging and execution when `asyncio.Handle._run` receives a cancelled handle.
- Extend `tests/test_25_web_streamer.py` with coverage that asserts cancelled handles stay silent.

**Risk / Rollback**
- Low risk: the guard only skips callbacks that asyncio already marks as cancelled; revert this commit to roll back.

**Links**
- [TR-84](https://mfisbv.atlassian.net/browse/TR-84)
- Task run: current Codex session
- Preview: N/A

------
https://chatgpt.com/codex/tasks/task_e_68e4b325558c8327bac8c5e27e7fad11

[TR-84]: https://mfisbv.atlassian.net/browse/TR-84?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ