### PR TITLE
TR-85: Soften asyncio guard logging

### DIFF
--- a/tests/test_25_web_streamer.py
+++ b/tests/test_25_web_streamer.py
@@ -85,7 +85,7 @@ def test_loop_callback_guard_replaces_none_callbacks(caplog):
     loop = asyncio.new_event_loop()
     try:
         logger = logging.getLogger("web_streamer")
-        with caplog.at_level(logging.ERROR, logger="web_streamer"):
+        with caplog.at_level(logging.WARNING, logger="web_streamer"):
             web_streamer._install_loop_callback_guard(loop, logger)
             loop.call_soon(None)
 
@@ -101,13 +101,14 @@ def test_handle_run_guard_discards_none_callbacks(caplog):
     loop = asyncio.new_event_loop()
     try:
         logger = logging.getLogger("web_streamer")
+        web_streamer._reset_asyncio_guard_counters_for_tests()
         web_streamer._install_loop_callback_guard(loop, logger)
 
         handle = loop.call_soon(lambda: None)
         handle._callback = None
         handle._args = ("sentinel",)
 
-        with caplog.at_level(logging.ERROR, logger="asyncio"):
+        with caplog.at_level(logging.WARNING, logger="asyncio"):
             handle._run()
 
         assert "Discarded asyncio handle with None callback" in caplog.text
@@ -119,12 +120,13 @@ def test_handle_run_guard_ignores_cancelled_handles(caplog):
     loop = asyncio.new_event_loop()
     try:
         logger = logging.getLogger("web_streamer")
+        web_streamer._reset_asyncio_guard_counters_for_tests()
         web_streamer._install_loop_callback_guard(loop, logger)
 
         handle = loop.call_soon(lambda: None)
         handle.cancel()
 
-        with caplog.at_level(logging.ERROR, logger="asyncio"):
+        with caplog.at_level(logging.WARNING, logger="asyncio"):
             handle._run()
 
         assert "Discarded asyncio handle with None callback" not in caplog.text


### PR DESCRIPTION
## What / Why
- stop backend logs from filling with asyncio `None` callback errors by downgrading guard severity
- keep diagnostics available through warning-once + debug follow-ups while avoiding false-positive errors
- provide a reset helper so pytest can assert first-occurrence logging behaviour

## How (high-level)
- add a module-level flag to throttle asyncio guard logging after the first occurrence
- downgrade the guard log levels to warning/debug and expose a reset helper for tests
- adjust guard unit tests to use the new helper and updated log levels

## Risk / Rollback
- **Risk:** Minimal; changes only affect internal logging and associated unit tests.
- **Rollback:** Revert this PR to restore previous logging behaviour.

## Human Testing Criteria
- `export DEV=1 && pytest -q`

## Links
- [Jira TR-85](https://mfisbv.atlassian.net/browse/TR-85)
- Codex task run: (link unavailable from environment)


------
https://chatgpt.com/codex/tasks/task_e_68e4c1632780832793b056459fdbcaf5