### PR TITLE
TR-81: Highlight motion-triggered recordings in dashboard

### DIFF
--- a/lib/webui/static/css/dashboard.css
+++ b/lib/webui/static/css/dashboard.css
@@ -594,6 +594,29 @@ body[data-theme="light"] .app-menu-toggle {
   transition: background 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
 }
 
+.indicator-tag {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.15rem 0.55rem;
+  border-radius: 999px;
+  background: rgba(251, 146, 60, 0.18);
+  color: var(--warning);
+  font-size: 0.7rem;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.indicator-tag[hidden] {
+  display: none;
+}
+
+.indicator-tag.motion-tag {
+  background: rgba(251, 146, 60, 0.24);
+  color: var(--warning);
+}
+
 .recording-indicator[data-state="active"] {
   color: #fca5a5;
 }
@@ -2808,6 +2831,11 @@ body[data-scroll-locked="true"] {
   color: var(--danger);
 }
 
+.meta-pill.motion-pill {
+  background: rgba(251, 146, 60, 0.18);
+  color: var(--warning);
+}
+
 .record-mobile-subtext {
   color: var(--text-muted);
   font-size: 0.75rem;
@@ -2834,6 +2862,11 @@ body[data-scroll-locked="true"] {
 .badge.badge-recording {
   background: var(--danger-bg);
   color: var(--danger);
+}
+
+.badge.badge-motion {
+  background: rgba(251, 146, 60, 0.18);
+  color: var(--warning);
 }
 
 .record-in-progress {

--- a/lib/webui/static/js/dashboard.js
+++ b/lib/webui/static/js/dashboard.js
@@ -336,6 +336,7 @@ const dom = {
   connectionStatus: document.getElementById("connection-status"),
   recordingIndicator: document.getElementById("recording-indicator"),
   recordingIndicatorText: document.getElementById("recording-indicator-text"),
+  recordingIndicatorMotion: document.getElementById("recording-indicator-motion"),
   recordingMeta: document.getElementById("recording-meta"),
   recordingMetaText: document.getElementById("recording-meta-text"),
   rmsIndicator: document.getElementById("rms-indicator"),
@@ -2002,6 +2003,7 @@ const connectionState = {
 const captureIndicatorState = {
   state: "unknown",
   message: "",
+  motion: false,
 };
 
 const rmsIndicatorState = {
@@ -2504,22 +2506,30 @@ function updateOfflineState(offline) {
   setConnectionStatus(offline ? "Offline: unable to reach recorder" : "");
 }
 
-function applyRecordingIndicator(state, message) {
+function applyRecordingIndicator(state, message, { motion = false } = {}) {
   if (!dom.recordingIndicator || !dom.recordingIndicatorText) {
     return;
   }
-  if (captureIndicatorState.state === state && captureIndicatorState.message === message) {
+  if (
+    captureIndicatorState.state === state &&
+    captureIndicatorState.message === message &&
+    captureIndicatorState.motion === motion
+  ) {
     return;
   }
   captureIndicatorState.state = state;
   captureIndicatorState.message = message;
+  captureIndicatorState.motion = motion;
   dom.recordingIndicator.dataset.state = state;
   dom.recordingIndicatorText.textContent = message;
   dom.recordingIndicator.setAttribute("aria-hidden", "false");
+  if (dom.recordingIndicatorMotion) {
+    dom.recordingIndicatorMotion.hidden = !motion;
+  }
 }
 
 function setRecordingIndicatorUnknown(message = "Status unavailable") {
-  applyRecordingIndicator("unknown", message);
+  applyRecordingIndicator("unknown", message, { motion: false });
   hideRmsIndicator();
   hideRecordingMeta();
   hideEncodingStatus();
@@ -2540,6 +2550,7 @@ function setRecordingIndicatorStatus(rawStatus) {
     capturing = true;
   }
   const manualRecording = parseBoolean(rawStatus.manual_recording);
+  const motionTriggered = capturing && !manualRecording && isMotionTriggeredEvent(event);
   const rawStopReason =
     typeof rawStatus.last_stop_reason === "string"
       ? rawStatus.last_stop_reason.trim()
@@ -2617,7 +2628,7 @@ function setRecordingIndicatorStatus(rawStatus) {
     }
   }
 
-  applyRecordingIndicator(state, message);
+  applyRecordingIndicator(state, message, { motion: motionTriggered });
 }
 
 function setSplitEventDisabled(disabled, reason = "") {
@@ -4331,9 +4342,15 @@ function computeRecordsFingerprint(records) {
     const motionRelease = Number.isFinite(record.motion_release_offset_seconds)
       ? record.motion_release_offset_seconds
       : "";
+    const motionStarted = Number.isFinite(record.motion_started_epoch)
+      ? record.motion_started_epoch
+      : "";
+    const motionReleased = Number.isFinite(record.motion_released_epoch)
+      ? record.motion_released_epoch
+      : "";
     const waveform = typeof record.waveform_path === "string" ? record.waveform_path : "";
     parts.push(
-      `${path}|${modified}|${size}|${duration}|${trigger}|${release}|${motionTrigger}|${motionRelease}|${waveform}`
+      `${path}|${modified}|${size}|${duration}|${trigger}|${release}|${motionTrigger}|${motionRelease}|${motionStarted}|${motionReleased}|${waveform}`
     );
   }
   return parts.join("\n");
@@ -4353,8 +4370,32 @@ function computePartialFingerprint(record) {
   const name = typeof record.name === "string" ? record.name : "";
   const extension = typeof record.extension === "string" ? record.extension : "";
   const inProgress = record && record.inProgress === true ? "1" : "0";
+  const motionTrigger = Number.isFinite(record.motion_trigger_offset_seconds)
+    ? record.motion_trigger_offset_seconds
+    : "";
+  const motionRelease = Number.isFinite(record.motion_release_offset_seconds)
+    ? record.motion_release_offset_seconds
+    : "";
+  const motionStarted = Number.isFinite(record.motion_started_epoch)
+    ? record.motion_started_epoch
+    : "";
+  const motionReleased = Number.isFinite(record.motion_released_epoch)
+    ? record.motion_released_epoch
+    : "";
 
-  return [path, size, duration, modified, name, extension, inProgress].join("|");
+  return [
+    path,
+    size,
+    duration,
+    modified,
+    name,
+    extension,
+    inProgress,
+    motionTrigger,
+    motionRelease,
+    motionStarted,
+    motionReleased,
+  ].join("|");
 }
 
 function updateSortIndicators() {
@@ -4586,6 +4627,9 @@ function updatePlayerMeta(record) {
     details.push(formatBytes(record.size_bytes));
     if (Number.isFinite(record.duration_seconds) && record.duration_seconds > 0) {
       details.push(formatDuration(record.duration_seconds));
+    }
+    if (isMotionTriggeredEvent(record)) {
+      details.push("Motion event");
     }
     metaTarget.textContent = `Now playing: ${details.join(" • ")}`;
   }
@@ -5020,9 +5064,13 @@ function renderRecords() {
     const row = document.createElement("tr");
     row.dataset.path = record.path;
     const isPartial = Boolean(record.isPartial);
+    const isMotion = isMotionTriggeredEvent(record);
     if (isPartial) {
       row.dataset.recordingState = "in-progress";
       row.classList.add("record-in-progress");
+    }
+    if (isMotion) {
+      row.dataset.motion = "true";
     }
 
     const checkboxCell = document.createElement("td");
@@ -5081,6 +5129,12 @@ function renderRecords() {
       badge.textContent = "Recording";
       nameTitle.append(" ", badge);
     }
+    if (isMotion) {
+      const motionBadge = document.createElement("span");
+      motionBadge.className = "badge badge-motion";
+      motionBadge.textContent = "Motion";
+      nameTitle.append(" ", motionBadge);
+    }
     nameCell.append(nameTitle);
 
     const mobileMeta = document.createElement("div");
@@ -5090,6 +5144,12 @@ function renderRecords() {
       livePill.className = "meta-pill live-pill";
       livePill.textContent = "Recording…";
       mobileMeta.append(livePill);
+    }
+    if (isMotion) {
+      const motionPill = document.createElement("span");
+      motionPill.className = "meta-pill motion-pill";
+      motionPill.textContent = "Motion event";
+      mobileMeta.append(motionPill);
     }
     if (durationText && durationText !== "--") {
       const durationPill = document.createElement("span");
@@ -7758,6 +7818,44 @@ function parseBoolean(value) {
     return ["1", "true", "yes", "on"].includes(normalized);
   }
   return Boolean(value);
+}
+
+function isMotionTriggeredEvent(source) {
+  if (!source || typeof source !== "object") {
+    return false;
+  }
+
+  const motionTrigger = toFiniteOrNull(source.motion_trigger_offset_seconds);
+  if (Number.isFinite(motionTrigger)) {
+    return true;
+  }
+
+  const motionReleaseOffset = toFiniteOrNull(source.motion_release_offset_seconds);
+  if (Number.isFinite(motionReleaseOffset)) {
+    return true;
+  }
+
+  const motionStarted = toFiniteOrNull(source.motion_started_epoch);
+  if (Number.isFinite(motionStarted)) {
+    return true;
+  }
+
+  const motionReleased = toFiniteOrNull(source.motion_released_epoch);
+  if (Number.isFinite(motionReleased)) {
+    return true;
+  }
+
+  const motionActive = parseBoolean(source.motion_active);
+  if (motionActive === true) {
+    return true;
+  }
+
+  const motionSequence = toFiniteOrNull(source.motion_sequence);
+  if (Number.isFinite(motionSequence) && motionSequence > 0 && motionActive !== false) {
+    return true;
+  }
+
+  return false;
 }
 
 function parseListInput(value) {

--- a/lib/webui/templates/dashboard.html
+++ b/lib/webui/templates/dashboard.html
@@ -268,6 +268,13 @@
               >
                 <span class="indicator-dot" aria-hidden="true"></span>
                 <span
+                  id="recording-indicator-motion"
+                  class="indicator-tag motion-tag"
+                  hidden
+                >
+                  Motion
+                </span>
+                <span
                   id="rms-indicator"
                   class="rms-indicator"
                   aria-hidden="true"


### PR DESCRIPTION
## What / Why
* Surface when an active recording was triggered by motion so operators can quickly distinguish it from manual recordings.
* Flag past recordings that were motion-triggered within the recent recordings list for faster triage.

## How (high-level)
* Detect motion metadata in the capture status payload and toggle a new motion badge inside the header recording indicator.
* Persist motion fields on in-progress records, expand fingerprinting, and decorate table rows/mobile pills with new motion badges.
* Add styling for the new indicator tag, table badge, and mobile pill variants.

## Risk / Rollback
* Low risk – UI-only changes. Roll back by reverting this patch.

## Human Testing Criteria
* Trigger an external motion event and confirm the header recording indicator shows a "Motion" badge while the event is active.
* Verify motion-triggered recordings in the Recent recordings table display both desktop and mobile motion badges.
* Confirm non-motion recordings continue to render without the new indicator.

## Links
* [Jira TR-81](https://mfisbv.atlassian.net/browse/TR-81)
* [Task run](https://platform.openai.com/apps/codex/tasks)


------
https://chatgpt.com/codex/tasks/task_e_68e4cf1bbb3c8327a225ed37d627539e