### PR TITLE
TR-70: Improve mobile dashboard usability

### DIFF
--- a/lib/webui/static/css/dashboard.css
+++ b/lib/webui/static/css/dashboard.css
@@ -1014,6 +1014,17 @@ button.small {
   justify-content: flex-end;
 }
 
+#toggle-hidden[data-active="true"] {
+  background: rgba(56, 189, 248, 0.18);
+  border-color: rgba(56, 189, 248, 0.6);
+  color: var(--primary, #0891b2);
+}
+
+#toggle-hidden[data-active="true"]:hover {
+  background: rgba(56, 189, 248, 0.26);
+  border-color: rgba(56, 189, 248, 0.85);
+}
+
 .filters-header {
   display: flex;
   align-items: center;
@@ -2772,6 +2783,10 @@ body[data-scroll-locked="true"] {
   flex-wrap: wrap;
 }
 
+.mobile-quick-actions {
+  display: none;
+}
+
 .action-buttons button,
 .action-buttons a {
   border-radius: 999px;
@@ -2867,6 +2882,26 @@ body[data-scroll-locked="true"] {
 .badge.badge-motion {
   background: rgba(251, 146, 60, 0.18);
   color: var(--warning);
+}
+
+.badge.badge-hidden {
+  background: rgba(148, 163, 184, 0.24);
+  color: rgba(71, 85, 105, 0.95);
+}
+
+body[data-theme="dark"] .badge.badge-hidden {
+  background: rgba(71, 85, 105, 0.32);
+  color: rgba(226, 232, 240, 0.92);
+}
+
+tr[data-hidden="true"] {
+  opacity: 0.78;
+}
+
+tr[data-hidden="true"] .record-title {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
 }
 
 .record-in-progress {
@@ -3190,8 +3225,8 @@ body[data-theme="light"] .record-in-progress {
   #recordings-table tbody tr {
     display: grid;
     grid-template-columns: auto 1fr;
-    gap: 0.5rem 0.75rem;
-    padding: 0.9rem 1rem;
+    gap: 0.45rem 0.65rem;
+    padding: 0.75rem 0.9rem;
     border: 1px solid var(--table-row-border);
     border-radius: 1rem;
     background: var(--surface-soft);
@@ -3243,19 +3278,80 @@ body[data-theme="light"] .record-in-progress {
   .record-mobile-meta,
   .record-mobile-subtext {
     display: flex;
+    gap: 0.35rem;
   }
 
   .action-buttons {
-    display: grid;
-    grid-template-columns: repeat(2, minmax(0, 1fr));
+    display: flex;
+    flex-wrap: nowrap;
     gap: 0.5rem;
     width: 100%;
+    overflow-x: auto;
+    padding-bottom: 0.15rem;
+    -webkit-overflow-scrolling: touch;
+    scrollbar-width: thin;
+  }
+
+  .action-buttons::-webkit-scrollbar {
+    height: 0.35rem;
   }
 
   .action-buttons button,
   .action-buttons a {
+    flex: 0 0 auto;
+    min-width: clamp(6.5rem, 32vw, 10rem);
+    min-height: 2.75rem;
     justify-content: center;
-    width: 100%;
+  }
+
+  .mobile-quick-actions {
+    display: grid;
+    grid-template-columns: repeat(3, minmax(0, 1fr));
+    gap: 0.5rem;
+    margin-top: 0.4rem;
+    max-height: 0;
+    opacity: 0;
+    pointer-events: none;
+    transform: translateY(0.4rem);
+    transition: opacity 0.18s ease, transform 0.18s ease, max-height 0.18s ease;
+  }
+
+  .mobile-quick-actions[data-visible="true"] {
+    max-height: 12rem;
+    opacity: 1;
+    pointer-events: auto;
+    transform: translateY(0);
+  }
+
+  .mobile-quick-action {
+    border-radius: 0.85rem;
+    border: 1px solid var(--ghost-border);
+    background: var(--surface-muted);
+    color: var(--text);
+    font-size: 0.9rem;
+    font-weight: 600;
+    padding: 0.65rem 0.5rem;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.35rem;
+    min-height: 2.85rem;
+  }
+
+  .mobile-quick-action:active {
+    transform: scale(0.98);
+  }
+
+  .mobile-quick-action[data-variant="primary"] {
+    background: rgba(56, 189, 248, 0.18);
+    border-color: rgba(56, 189, 248, 0.6);
+    color: var(--primary, #0891b2);
+  }
+
+  .mobile-quick-action[data-variant="danger"] {
+    background: var(--danger-bg);
+    border-color: rgba(248, 113, 113, 0.7);
+    color: var(--danger);
   }
 
   #recordings-table tbody tr:hover {

--- a/lib/webui/static/js/dashboard.js
+++ b/lib/webui/static/js/dashboard.js
@@ -128,6 +128,7 @@ const THEME_STORAGE_KEY = "tricorder.dashboard.theme";
 const RECYCLE_BIN_STATE_STORAGE_KEY = "tricorder.dashboard.recycleBin";
 const WAVEFORM_STORAGE_KEY = "tricorder.dashboard.waveform";
 const TRANSPORT_STORAGE_KEY = "tricorder.dashboard.transport";
+const HIDDEN_RECORDS_STORAGE_KEY = "tricorder.dashboard.hiddenRecords";
 const TRANSPORT_SCRUB_MAX = 1000;
 const TRANSPORT_SKIP_BACK_SECONDS = 10;
 const TRANSPORT_SKIP_FORWARD_SECONDS = 30;
@@ -260,6 +261,7 @@ const state = {
     day: "",
     limit: DEFAULT_LIMIT,
     timeRange: "",
+    showHidden: false,
   },
   records: [],
   recordsFingerprint: "",
@@ -284,6 +286,7 @@ const state = {
     loading: false,
     anchorId: "",
   },
+  hiddenRecords: new Set(),
 };
 
 const persistedRecycleBinState = loadPersistedRecycleBinState();
@@ -299,6 +302,11 @@ if (persistedRecycleBinState) {
   if (typeof persistedRecycleBinState.anchorId === "string" && persistedRecycleBinState.anchorId) {
     state.recycleBin.anchorId = persistedRecycleBinState.anchorId;
   }
+}
+
+const persistedHiddenRecords = readStoredHiddenRecords();
+if (persistedHiddenRecords.length > 0) {
+  state.hiddenRecords = new Set(persistedHiddenRecords);
 }
 
 const healthState = {
@@ -324,6 +332,7 @@ const dom = {
   toggleAll: document.getElementById("toggle-all"),
   selectAll: document.getElementById("select-all"),
   clearSelection: document.getElementById("clear-selection"),
+  toggleHidden: document.getElementById("toggle-hidden"),
   downloadSelected: document.getElementById("download-selected"),
   renameSelected: document.getElementById("rename-selected"),
   deleteSelected: document.getElementById("delete-selected"),
@@ -1819,6 +1828,11 @@ const playerPlacement = {
 
 const playerCardHome = dom.playerCard ? dom.playerCard.parentElement : null;
 const playerCardHomeAnchor = dom.playerCard ? dom.playerCard.nextElementSibling : null;
+const mobileQuickActionState = {
+  currentRow: null,
+  currentContainer: null,
+  hideTimer: null,
+};
 const mobileLayoutQuery =
   typeof window.matchMedia === "function" ? window.matchMedia("(max-width: 640px)") : null;
 const filtersLayoutQuery =
@@ -2119,6 +2133,7 @@ function persistFilters() {
       day: state.filters.day,
       limit: state.filters.limit,
       timeRange: state.filters.timeRange,
+      showHidden: state.filters.showHidden,
     };
     window.localStorage.setItem(FILTER_STORAGE_KEY, JSON.stringify(payload));
   } catch (error) {
@@ -2138,6 +2153,51 @@ function clearStoredFilters() {
     window.localStorage.removeItem(FILTER_STORAGE_KEY);
   } catch (error) {
     /* ignore removal errors */
+  }
+}
+
+function readStoredHiddenRecords() {
+  try {
+    if (typeof window === "undefined" || !window.localStorage) {
+      return [];
+    }
+  } catch (error) {
+    return [];
+  }
+  try {
+    const raw = window.localStorage.getItem(HIDDEN_RECORDS_STORAGE_KEY);
+    if (!raw) {
+      return [];
+    }
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) {
+      return [];
+    }
+    return parsed.filter((value) => typeof value === "string" && value.trim() !== "");
+  } catch (error) {
+    return [];
+  }
+}
+
+function persistHiddenRecords() {
+  try {
+    if (typeof window === "undefined" || !window.localStorage) {
+      return;
+    }
+  } catch (error) {
+    return;
+  }
+  try {
+    const payload = Array.from(state.hiddenRecords.values()).filter(
+      (value) => typeof value === "string" && value
+    );
+    if (payload.length === 0) {
+      window.localStorage.removeItem(HIDDEN_RECORDS_STORAGE_KEY);
+      return;
+    }
+    window.localStorage.setItem(HIDDEN_RECORDS_STORAGE_KEY, JSON.stringify(payload));
+  } catch (error) {
+    /* ignore persistence errors */
   }
 }
 
@@ -2253,6 +2313,7 @@ function restoreFiltersFromStorage() {
     day: state.filters.day,
     limit: state.filters.limit,
     timeRange: state.filters.timeRange,
+    showHidden: state.filters.showHidden,
   };
   if (typeof stored.search === "string") {
     next.search = stored.search;
@@ -2265,6 +2326,9 @@ function restoreFiltersFromStorage() {
   }
   if (typeof stored.timeRange === "string" && VALID_TIME_RANGES.has(stored.timeRange)) {
     next.timeRange = stored.timeRange;
+  }
+  if (typeof stored.showHidden === "boolean") {
+    next.showHidden = stored.showHidden;
   }
   state.filters = next;
 }
@@ -4265,10 +4329,22 @@ function deriveInProgressRecord(captureStatus) {
 }
 
 function getVisibleRecords() {
-  const sorted = [...state.records].sort(compareRecords);
+  const showHidden = state.filters.showHidden === true;
+  const filtered = state.records.filter((entry) => {
+    if (!entry || typeof entry.path !== "string" || !entry.path) {
+      return false;
+    }
+    if (showHidden) {
+      return true;
+    }
+    return !state.hiddenRecords.has(entry.path);
+  });
+  const sorted = filtered.sort(compareRecords);
   if (state.partialRecord) {
-    const filtered = sorted.filter((entry) => entry.path !== state.partialRecord.path);
-    return [state.partialRecord, ...filtered];
+    const withoutDuplicate = sorted.filter(
+      (entry) => entry && entry.path !== state.partialRecord.path
+    );
+    return [state.partialRecord, ...withoutDuplicate];
   }
   return sorted;
 }
@@ -4663,6 +4739,264 @@ function layoutIsMobile() {
   return window.innerWidth <= 640;
 }
 
+function isInteractiveRowTarget(target) {
+  if (!(target instanceof Element)) {
+    return false;
+  }
+  return Boolean(
+    target.closest("button") ||
+      target.closest("a") ||
+      target.closest("input") ||
+      target.closest(".action-buttons") ||
+      target.closest(".mobile-quick-actions") ||
+      target.closest(".player-card")
+  );
+}
+
+function isRecordHidden(record) {
+  return Boolean(
+    record && typeof record.path === "string" && record.path && state.hiddenRecords.has(record.path)
+  );
+}
+
+function updateHiddenToggleUI() {
+  if (!dom.toggleHidden) {
+    return;
+  }
+  const hiddenCount = state.hiddenRecords.size;
+  const showHidden = state.filters.showHidden === true;
+  const shouldShow = hiddenCount > 0 || showHidden;
+  dom.toggleHidden.hidden = !shouldShow;
+  dom.toggleHidden.dataset.active = showHidden ? "true" : "false";
+  const label = showHidden
+    ? "Hide hidden"
+    : hiddenCount > 0
+      ? `Show hidden (${hiddenCount})`
+      : "Show hidden";
+  dom.toggleHidden.textContent = label;
+}
+
+function hideRecord(record) {
+  if (!record || typeof record.path !== "string" || !record.path) {
+    return;
+  }
+  if (state.hiddenRecords.has(record.path)) {
+    return;
+  }
+  state.hiddenRecords.add(record.path);
+  state.selections.delete(record.path);
+  if (state.current && state.current.path === record.path && !state.filters.showHidden) {
+    setNowPlaying(null);
+  }
+  persistHiddenRecords();
+  updateHiddenToggleUI();
+  renderRecords();
+  updateSelectionUI();
+}
+
+function unhideRecord(record) {
+  if (!record || typeof record.path !== "string" || !record.path) {
+    return;
+  }
+  if (!state.hiddenRecords.delete(record.path)) {
+    return;
+  }
+  persistHiddenRecords();
+  updateHiddenToggleUI();
+  renderRecords();
+  updateSelectionUI();
+}
+
+function showRowMobileActions(row, container) {
+  if (!(container instanceof HTMLElement)) {
+    return;
+  }
+  if (mobileQuickActionState.hideTimer) {
+    window.clearTimeout(mobileQuickActionState.hideTimer);
+    mobileQuickActionState.hideTimer = null;
+  }
+  if (
+    mobileQuickActionState.currentContainer &&
+    mobileQuickActionState.currentContainer !== container
+  ) {
+    hideRowMobileActions(
+      mobileQuickActionState.currentRow,
+      mobileQuickActionState.currentContainer,
+      true,
+    );
+  }
+  container.hidden = false;
+  const activate = () => {
+    container.dataset.visible = "true";
+  };
+  if (typeof window !== "undefined" && typeof window.requestAnimationFrame === "function") {
+    window.requestAnimationFrame(activate);
+  } else {
+    setTimeout(activate, 16);
+  }
+  mobileQuickActionState.currentRow = row || null;
+  mobileQuickActionState.currentContainer = container;
+}
+
+function hideRowMobileActions(row, container, immediate = false) {
+  if (!(container instanceof HTMLElement)) {
+    return;
+  }
+  if (mobileQuickActionState.hideTimer) {
+    window.clearTimeout(mobileQuickActionState.hideTimer);
+    mobileQuickActionState.hideTimer = null;
+  }
+  const finalize = () => {
+    container.hidden = true;
+    if (mobileQuickActionState.currentContainer === container) {
+      mobileQuickActionState.currentContainer = null;
+      mobileQuickActionState.currentRow = null;
+    }
+  };
+  container.dataset.visible = "false";
+  if (immediate) {
+    finalize();
+    return;
+  }
+  mobileQuickActionState.hideTimer = window.setTimeout(finalize, 180);
+}
+
+function closeActiveMobileActions(immediate = true) {
+  if (!mobileQuickActionState.currentContainer) {
+    return;
+  }
+  hideRowMobileActions(
+    mobileQuickActionState.currentRow,
+    mobileQuickActionState.currentContainer,
+    immediate,
+  );
+}
+
+function attachMobileRowInteractions(row, record, options = {}) {
+  if (!row || !record || typeof row.addEventListener !== "function") {
+    return;
+  }
+  const { mobileActions = null, markSkipNextClick = null, isPartial = false } = options;
+  if (isPartial || !(mobileActions instanceof HTMLElement)) {
+    return;
+  }
+
+  let active = false;
+  let startX = 0;
+  let startY = 0;
+  let startTime = 0;
+  let swipeHandled = false;
+  let longPressHandled = false;
+  let longPressTimer = null;
+
+  const cancelLongPress = () => {
+    if (longPressTimer !== null) {
+      window.clearTimeout(longPressTimer);
+      longPressTimer = null;
+    }
+  };
+
+  const markSkip = () => {
+    if (typeof markSkipNextClick === "function") {
+      markSkipNextClick();
+    }
+  };
+
+  row.addEventListener(
+    "touchstart",
+    (event) => {
+      if (!layoutIsMobile()) {
+        return;
+      }
+      if (!event.touches || event.touches.length !== 1) {
+        cancelLongPress();
+        active = false;
+        return;
+      }
+      const target = event.target;
+      if (isInteractiveRowTarget(target)) {
+        return;
+      }
+      active = true;
+      swipeHandled = false;
+      longPressHandled = false;
+      const touch = event.touches[0];
+      startX = touch.clientX;
+      startY = touch.clientY;
+      startTime = nowMilliseconds();
+      cancelLongPress();
+      longPressTimer = window.setTimeout(() => {
+        longPressHandled = true;
+        markSkip();
+        showRowMobileActions(row, mobileActions);
+      }, 450);
+    },
+    { passive: true },
+  );
+
+  row.addEventListener(
+    "touchmove",
+    (event) => {
+      if (!active || !layoutIsMobile() || !event.touches || event.touches.length !== 1) {
+        return;
+      }
+      const touch = event.touches[0];
+      const dx = touch.clientX - startX;
+      const dy = touch.clientY - startY;
+      if (Math.abs(dx) > 6 || Math.abs(dy) > 6) {
+        cancelLongPress();
+      }
+      if (swipeHandled) {
+        return;
+      }
+      if (Math.abs(dx) > 45 && Math.abs(dx) > Math.abs(dy) * 1.4) {
+        swipeHandled = true;
+        cancelLongPress();
+        if (dx < 0) {
+          if (event.cancelable) {
+            event.preventDefault();
+          }
+          markSkip();
+          showRowMobileActions(row, mobileActions);
+        } else {
+          if (event.cancelable) {
+            event.preventDefault();
+          }
+          markSkip();
+          hideRowMobileActions(row, mobileActions, true);
+          setNowPlaying(record, { autoplay: true, resetToStart: true, sourceRow: row });
+        }
+      }
+    },
+    { passive: false },
+  );
+
+  const endTouch = (event) => {
+    if (!active || !layoutIsMobile()) {
+      cancelLongPress();
+      active = false;
+      return;
+    }
+    active = false;
+    cancelLongPress();
+    if (swipeHandled || longPressHandled) {
+      return;
+    }
+    const touch = event.changedTouches && event.changedTouches[0];
+    const dx = touch ? touch.clientX - startX : 0;
+    const dy = touch ? touch.clientY - startY : 0;
+    const duration = nowMilliseconds() - startTime;
+    if (Math.abs(dx) < 8 && Math.abs(dy) < 8 && duration < 300) {
+      markSkip();
+      hideRowMobileActions(row, mobileActions, true);
+      setNowPlaying(record, { autoplay: true, resetToStart: true, sourceRow: row });
+    }
+  };
+
+  row.addEventListener("touchend", endTouch);
+  row.addEventListener("touchcancel", endTouch);
+}
+
 function getTableColumnCount() {
   const headerRow = document.querySelector("#recordings-table thead tr");
   if (headerRow && headerRow.children.length > 0) {
@@ -5040,6 +5374,8 @@ function renderRecords() {
     return;
   }
 
+  closeActiveMobileActions(true);
+
   const shouldPreservePreview =
     previewIsActive() &&
     dom.playerCard &&
@@ -5053,7 +5389,11 @@ function renderRecords() {
   const records = getVisibleRecords();
 
   if (!records.length) {
-    renderEmptyState("No recordings match the selected filters.");
+    const message =
+      state.hiddenRecords.size > 0 && !state.filters.showHidden
+        ? 'All recordings are hidden. Tap "Show hidden" to review them.'
+        : "No recordings match the selected filters.";
+    renderEmptyState(message);
     updateSelectionUI(records);
     applyNowPlayingHighlight();
     syncPlayerPlacement();
@@ -5065,6 +5405,17 @@ function renderRecords() {
     row.dataset.path = record.path;
     const isPartial = Boolean(record.isPartial);
     const isMotion = isMotionTriggeredEvent(record);
+    const hiddenRecord = isRecordHidden(record);
+    if (hiddenRecord) {
+      row.dataset.hidden = "true";
+    }
+    let suppressNextClick = false;
+    const markSkipNextClick = () => {
+      suppressNextClick = true;
+      window.setTimeout(() => {
+        suppressNextClick = false;
+      }, 0);
+    };
     if (isPartial) {
       row.dataset.recordingState = "in-progress";
       row.classList.add("record-in-progress");
@@ -5134,6 +5485,12 @@ function renderRecords() {
       motionBadge.className = "badge badge-motion";
       motionBadge.textContent = "Motion";
       nameTitle.append(" ", motionBadge);
+    }
+    if (hiddenRecord) {
+      const hiddenBadge = document.createElement("span");
+      hiddenBadge.className = "badge badge-hidden";
+      hiddenBadge.textContent = "Hidden";
+      nameTitle.append(" ", hiddenBadge);
     }
     nameCell.append(nameTitle);
 
@@ -5220,6 +5577,7 @@ function renderRecords() {
     actionsCell.className = "actions cell-actions";
     const actionWrapper = document.createElement("div");
     actionWrapper.className = "action-buttons";
+    let mobileActions = null;
 
     if (isPartial) {
       const statusLabel = document.createElement("span");
@@ -5254,39 +5612,91 @@ function renderRecords() {
       });
 
       actionWrapper.append(downloadLink, renameButton, deleteButton);
+
+      mobileActions = document.createElement("div");
+      mobileActions.className = "mobile-quick-actions";
+      mobileActions.hidden = true;
+      mobileActions.dataset.visible = "false";
+
+      const quickPlay = document.createElement("button");
+      quickPlay.type = "button";
+      quickPlay.className = "mobile-quick-action";
+      quickPlay.dataset.variant = "primary";
+      quickPlay.textContent = "Play";
+      quickPlay.addEventListener("click", (event) => {
+        event.stopPropagation();
+        markSkipNextClick();
+        hideRowMobileActions(row, mobileActions, true);
+        setNowPlaying(record, { autoplay: true, resetToStart: true, sourceRow: row });
+      });
+
+      const quickHide = document.createElement("button");
+      quickHide.type = "button";
+      quickHide.className = "mobile-quick-action";
+      quickHide.textContent = hiddenRecord ? "Unhide" : "Hide";
+      quickHide.addEventListener("click", (event) => {
+        event.stopPropagation();
+        markSkipNextClick();
+        hideRowMobileActions(row, mobileActions, true);
+        if (hiddenRecord) {
+          unhideRecord(record);
+        } else {
+          hideRecord(record);
+        }
+      });
+
+      const quickDelete = document.createElement("button");
+      quickDelete.type = "button";
+      quickDelete.className = "mobile-quick-action";
+      quickDelete.dataset.variant = "danger";
+      quickDelete.textContent = "Delete";
+      quickDelete.addEventListener("click", async (event) => {
+        event.stopPropagation();
+        markSkipNextClick();
+        hideRowMobileActions(row, mobileActions, true);
+        await requestRecordDeletion(record);
+      });
+
+      mobileActions.append(quickPlay, quickHide, quickDelete);
     }
     actionsCell.append(actionWrapper);
+    if (mobileActions) {
+      actionsCell.append(mobileActions);
+    }
     row.append(actionsCell);
 
     row.addEventListener("click", (event) => {
-      const target = event.target;
-      if (target instanceof Element) {
-        if (
-          target.closest("button") ||
-          target.closest("a") ||
-          target.closest("input") ||
-          target.closest(".action-buttons") ||
-          target.closest(".player-card")
-        ) {
-          return;
-        }
+      if (suppressNextClick) {
+        suppressNextClick = false;
+        return;
       }
-      setNowPlaying(record, { autoplay: false, resetToStart: true, sourceRow: row });
+      const target = event.target;
+      if (isInteractiveRowTarget(target)) {
+        return;
+      }
+      const shouldAutoplay = layoutIsMobile();
+      setNowPlaying(record, {
+        autoplay: shouldAutoplay,
+        resetToStart: true,
+        sourceRow: row,
+      });
     });
 
     row.addEventListener("dblclick", (event) => {
+      if (suppressNextClick) {
+        suppressNextClick = false;
+      }
       const target = event.target;
-      if (target instanceof Element) {
-        if (
-          target.closest("button") ||
-          target.closest("a") ||
-          target.closest("input") ||
-          target.closest(".player-card")
-        ) {
-          return;
-        }
+      if (isInteractiveRowTarget(target)) {
+        return;
       }
       setNowPlaying(record, { autoplay: true, resetToStart: true, sourceRow: row });
+    });
+
+    attachMobileRowInteractions(row, record, {
+      mobileActions,
+      markSkipNextClick,
+      isPartial,
     });
 
     dom.tableBody.append(row);
@@ -14244,6 +14654,15 @@ function attachEventListeners() {
     renderRecords();
   });
 
+  if (dom.toggleHidden) {
+    dom.toggleHidden.addEventListener("click", () => {
+      state.filters.showHidden = !state.filters.showHidden;
+      updateHiddenToggleUI();
+      persistFilters();
+      renderRecords();
+    });
+  }
+
   if (dom.recycleBinOpen) {
     dom.recycleBinOpen.addEventListener("click", () => {
       openRecycleBinModal({ focus: true });
@@ -14817,6 +15236,7 @@ function attachEventListeners() {
 
   if (mobileLayoutQuery) {
     const handleLayoutChange = () => {
+      closeActiveMobileActions(true);
       syncPlayerPlacement();
     };
     if (typeof mobileLayoutQuery.addEventListener === "function") {
@@ -14830,6 +15250,7 @@ function attachEventListeners() {
 function initialize() {
   initializeTheme();
   restoreFiltersFromStorage();
+  updateHiddenToggleUI();
   restoreSortFromStorage();
   restoreFilterPanelPreference();
   setupResponsiveFilters();

--- a/lib/webui/templates/dashboard.html
+++ b/lib/webui/templates/dashboard.html
@@ -714,6 +714,15 @@
               <div class="table-actions">
                 <button id="select-all" class="ghost-button small" type="button">Select all</button>
                 <button id="clear-selection" class="ghost-button small" type="button">Clear</button>
+                <button
+                  id="toggle-hidden"
+                  class="ghost-button small"
+                  type="button"
+                  data-active="false"
+                  hidden
+                >
+                  Show hidden
+                </button>
                 <button id="download-selected" class="ghost-button small" type="button" disabled>
                   Download selected
                 </button>


### PR DESCRIPTION
**What / Why**
- add a mobile-friendly quick action tray so play, hide, and delete are reachable without scrolling
- allow operators to hide recordings locally while keeping a toggle to surface them when needed

**How (high-level)**
- persist a hidden-record set, expose a "Show hidden" control, and gate visibility in the render pipeline
- introduce mobile gesture handlers and an overlaid quick-action grid with refreshed responsive styling
- tighten compact layout spacing for cards so more items fit on small screens

**Risk / Rollback**
- scoped to dashboard frontend; revert this commit to undo
- if touch gestures misbehave, actions remain accessible via existing desktop buttons

**Human Testing Criteria**
- On a ≤640px viewport, swipe or long-press a recording to open quick actions, then play, hide/unhide, and delete
- Toggle "Show hidden" to confirm hidden recordings return to the list
- Verify desktop layout and selection flows still behave as before

**Links**
- [Jira TR-70](https://mfisbv.atlassian.net/browse/TR-70)
- Task run: (see Codex task log)


------
https://chatgpt.com/codex/tasks/task_e_68e4e717106c83279494c715f621bf15