### PR TITLE
TR-70: Restore usable mobile actions

### DIFF
--- a/lib/webui/static/css/dashboard.css
+++ b/lib/webui/static/css/dashboard.css
@@ -2772,6 +2772,83 @@ body[data-scroll-locked="true"] {
   flex-wrap: wrap;
 }
 
+.cell-actions {
+  position: relative;
+}
+
+.mobile-actions {
+  display: none;
+}
+
+.mobile-actions-toggle {
+  width: 100%;
+  justify-content: center;
+  padding: 0.45rem 0.75rem;
+}
+
+.mobile-actions-menu {
+  position: absolute;
+  right: 0;
+  top: calc(100% + 0.4rem);
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  padding: 0.35rem;
+  background: var(--surface);
+  border: 1px solid var(--table-row-border);
+  border-radius: 0.75rem;
+  box-shadow: 0 22px 44px -24px rgba(15, 23, 42, 0.35);
+  min-width: 11rem;
+  z-index: 40;
+}
+
+.mobile-actions-menu[hidden] {
+  display: none;
+}
+
+.mobile-actions-item {
+  border: 0;
+  background: transparent;
+  border-radius: 0.6rem;
+  padding: 0.55rem 0.75rem;
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: var(--text);
+  text-align: left;
+  cursor: pointer;
+}
+
+.mobile-actions-item:hover,
+.mobile-actions-item:focus {
+  outline: none;
+  background: var(--surface-soft);
+}
+
+.mobile-actions-item.danger {
+  color: var(--danger);
+}
+
+.mobile-actions-item.danger:hover,
+.mobile-actions-item.danger:focus {
+  background: var(--danger-bg);
+}
+
+.mobile-actions-menu-open {
+  animation: mobile-menu-fade 160ms ease-out;
+}
+
+@keyframes mobile-menu-fade {
+  from {
+    opacity: 0;
+    transform: translateY(-4px);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
 .action-buttons button,
 .action-buttons a {
   border-radius: 999px;
@@ -3245,17 +3322,26 @@ body[data-theme="light"] .record-in-progress {
     display: flex;
   }
 
-  .action-buttons {
-    display: grid;
-    grid-template-columns: repeat(2, minmax(0, 1fr));
-    gap: 0.5rem;
+  .action-buttons--interactive {
+    display: none;
+  }
+
+  .mobile-actions {
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
     width: 100%;
   }
 
-  .action-buttons button,
-  .action-buttons a {
-    justify-content: center;
-    width: 100%;
+  .mobile-actions-toggle {
+    display: inline-flex;
+  }
+
+  .mobile-actions-menu {
+    left: 0;
+    right: 0;
+    margin-inline: auto;
+    width: min(14rem, 100%);
   }
 
   #recordings-table tbody tr:hover {

--- a/lib/webui/static/js/dashboard.js
+++ b/lib/webui/static/js/dashboard.js
@@ -5035,10 +5035,196 @@ function setNowPlaying(record, options = {}) {
   updateTransportAvailability();
 }
 
+let activeMobileActionMenu = null;
+let mobileActionMenuSequence = 0;
+
+function closeMobileActionMenu(options = {}) {
+  const { returnFocus = false } = options;
+  if (!activeMobileActionMenu) {
+    return;
+  }
+  const { menu, toggle } = activeMobileActionMenu;
+  if (menu && menu.isConnected) {
+    menu.hidden = true;
+    menu.classList.remove("mobile-actions-menu-open");
+  }
+  if (toggle && toggle.isConnected) {
+    toggle.setAttribute("aria-expanded", "false");
+    if (returnFocus && typeof toggle.focus === "function") {
+      toggle.focus({ preventScroll: true });
+    }
+  }
+  activeMobileActionMenu = null;
+}
+
+if (typeof document !== "undefined") {
+  document.addEventListener("pointerdown", (event) => {
+    if (!activeMobileActionMenu) {
+      return;
+    }
+    const { menu, toggle } = activeMobileActionMenu;
+    const target = event.target;
+    if (!(target instanceof Node)) {
+      return;
+    }
+    if (menu && menu.contains(target)) {
+      return;
+    }
+    if (toggle && toggle.contains(target)) {
+      return;
+    }
+    closeMobileActionMenu();
+  });
+
+  document.addEventListener("keydown", (event) => {
+    if (!activeMobileActionMenu) {
+      return;
+    }
+    if (event.key === "Escape") {
+      closeMobileActionMenu({ returnFocus: true });
+    }
+  });
+}
+
+function createMobileActionMenu(record, handlers) {
+  if (!record || typeof record.path !== "string" || !record.path) {
+    return null;
+  }
+  if (!handlers || typeof handlers !== "object") {
+    return null;
+  }
+  const { onPlay, onDownload, onRename, onDelete } = handlers;
+  const container = document.createElement("div");
+  container.className = "mobile-actions";
+
+  const instanceId = ++mobileActionMenuSequence;
+  const toggleId = `mobile-actions-toggle-${instanceId}`;
+  const menuId = `mobile-actions-${instanceId}`;
+
+  const toggle = document.createElement("button");
+  toggle.type = "button";
+  toggle.className = "ghost-button small mobile-actions-toggle";
+  toggle.id = toggleId;
+  toggle.textContent = "Actions";
+  toggle.setAttribute("aria-controls", menuId);
+  toggle.setAttribute("aria-haspopup", "true");
+  toggle.setAttribute("aria-expanded", "false");
+
+  const menu = document.createElement("div");
+  menu.id = menuId;
+  menu.className = "mobile-actions-menu";
+  menu.hidden = true;
+  menu.setAttribute("role", "menu");
+  menu.setAttribute("aria-labelledby", toggleId);
+
+  const items = [];
+
+  if (typeof onPlay === "function") {
+    const playButton = document.createElement("button");
+    playButton.type = "button";
+    playButton.className = "mobile-actions-item";
+    playButton.textContent = "Play";
+    playButton.setAttribute("role", "menuitem");
+    playButton.dataset.menuItem = "true";
+    playButton.addEventListener("click", (event) => {
+      event.stopPropagation();
+      closeMobileActionMenu();
+      onPlay();
+    });
+    items.push(playButton);
+  }
+
+  if (typeof onDownload === "function") {
+    const downloadButton = document.createElement("button");
+    downloadButton.type = "button";
+    downloadButton.className = "mobile-actions-item";
+    downloadButton.textContent = "Download";
+    downloadButton.setAttribute("role", "menuitem");
+    downloadButton.dataset.menuItem = "true";
+    downloadButton.addEventListener("click", (event) => {
+      event.stopPropagation();
+      closeMobileActionMenu();
+      onDownload();
+    });
+    items.push(downloadButton);
+  }
+
+  if (typeof onRename === "function") {
+    const renameButton = document.createElement("button");
+    renameButton.type = "button";
+    renameButton.className = "mobile-actions-item";
+    renameButton.textContent = "Rename";
+    renameButton.setAttribute("role", "menuitem");
+    renameButton.dataset.menuItem = "true";
+    renameButton.addEventListener("click", (event) => {
+      event.stopPropagation();
+      closeMobileActionMenu();
+      onRename();
+    });
+    items.push(renameButton);
+  }
+
+  if (typeof onDelete === "function") {
+    const deleteButton = document.createElement("button");
+    deleteButton.type = "button";
+    deleteButton.className = "mobile-actions-item danger";
+    deleteButton.textContent = "Delete";
+    deleteButton.setAttribute("role", "menuitem");
+    deleteButton.dataset.menuItem = "true";
+    deleteButton.addEventListener("click", async (event) => {
+      event.stopPropagation();
+      closeMobileActionMenu();
+      await onDelete();
+    });
+    items.push(deleteButton);
+  }
+
+  for (const item of items) {
+    menu.append(item);
+  }
+
+  if (items.length === 0) {
+    return null;
+  }
+
+  toggle.addEventListener("click", (event) => {
+    event.stopPropagation();
+    const isOpen = !menu.hidden;
+    if (isOpen) {
+      closeMobileActionMenu({ returnFocus: true });
+      return;
+    }
+    if (activeMobileActionMenu && activeMobileActionMenu.menu !== menu) {
+      closeMobileActionMenu();
+    }
+    menu.hidden = false;
+    menu.classList.add("mobile-actions-menu-open");
+    toggle.setAttribute("aria-expanded", "true");
+    activeMobileActionMenu = { menu, toggle };
+    const focusTarget = menu.querySelector("[data-menu-item]");
+    if (focusTarget instanceof HTMLElement) {
+      focusTarget.focus({ preventScroll: true });
+    }
+  });
+
+  menu.addEventListener("keydown", (event) => {
+    if (event.key === "Escape") {
+      event.stopPropagation();
+      event.preventDefault();
+      closeMobileActionMenu({ returnFocus: true });
+    }
+  });
+
+  container.append(toggle, menu);
+  return container;
+}
+
 function renderRecords() {
   if (!dom.tableBody) {
     return;
   }
+
+  closeMobileActionMenu();
 
   const shouldPreservePreview =
     previewIsActive() &&
@@ -5220,6 +5406,7 @@ function renderRecords() {
     actionsCell.className = "actions cell-actions";
     const actionWrapper = document.createElement("div");
     actionWrapper.className = "action-buttons";
+    let mobileActions = null;
 
     if (isPartial) {
       const statusLabel = document.createElement("span");
@@ -5242,6 +5429,7 @@ function renderRecords() {
       renameButton.classList.add("small");
       renameButton.addEventListener("click", (event) => {
         event.stopPropagation();
+        closeMobileActionMenu();
         openRenameDialog(record);
       });
 
@@ -5249,13 +5437,39 @@ function renderRecords() {
       deleteButton.type = "button";
       deleteButton.textContent = "Delete";
       deleteButton.classList.add("danger-button");
-      deleteButton.addEventListener("click", async () => {
+      deleteButton.addEventListener("click", async (event) => {
+        event.stopPropagation();
+        closeMobileActionMenu();
         await requestRecordDeletion(record);
       });
 
+      actionWrapper.classList.add("action-buttons--interactive");
       actionWrapper.append(downloadLink, renameButton, deleteButton);
+
+      mobileActions = createMobileActionMenu(record, {
+        onPlay() {
+          setNowPlaying(record, {
+            autoplay: true,
+            resetToStart: true,
+            sourceRow: row,
+          });
+        },
+        onDownload() {
+          downloadLink.click();
+        },
+        onRename() {
+          openRenameDialog(record);
+        },
+        async onDelete() {
+          await requestRecordDeletion(record);
+        },
+      });
     }
+
     actionsCell.append(actionWrapper);
+    if (mobileActions) {
+      actionsCell.append(mobileActions);
+    }
     row.append(actionsCell);
 
     row.addEventListener("click", (event) => {
@@ -5266,6 +5480,7 @@ function renderRecords() {
           target.closest("a") ||
           target.closest("input") ||
           target.closest(".action-buttons") ||
+          target.closest(".mobile-actions") ||
           target.closest(".player-card")
         ) {
           return;
@@ -5281,7 +5496,8 @@ function renderRecords() {
           target.closest("button") ||
           target.closest("a") ||
           target.closest("input") ||
-          target.closest(".player-card")
+          target.closest(".player-card") ||
+          target.closest(".mobile-actions")
         ) {
           return;
         }


### PR DESCRIPTION
**What / Why**
- remove the long-press quick action experiment and return to the reliable desktop/tablet layout
- introduce a compact mobile actions menu so play/download/rename/delete remain reachable on narrow screens

**How (high-level)**
- rebuild the recordings row actions to keep the existing buttons for desktop while wiring a scripted menu for mobile that drives the same handlers
- layer new CSS to hide the desktop button group on ≤640px viewports and present the anchored action menu with polished styling

**Risk / Rollback**
- scoped to the dashboard frontend; revert this commit to undo

**Human Testing Criteria**
- On a ≤640px viewport open the menu on any recording and use play/download/rename/delete
- Confirm desktop/tablet layouts still expose inline buttons and selection controls without the hidden toggle

**Links**
- [Jira TR-70](https://mfisbv.atlassian.net/browse/TR-70)
- [Task run](https://platform.openai.com/)

------
https://chatgpt.com/codex/tasks/task_e_68e4e717106c83279494c715f621bf15