### PR TITLE
TR-98: Align clip row layout

### DIFF
--- a/lib/webui/static/css/dashboard.css
+++ b/lib/webui/static/css/dashboard.css
@@ -2711,6 +2711,11 @@ body[data-scroll-locked="true"] {
   font-size: 0.95rem;
 }
 
+#recordings-table tbody td {
+  vertical-align: top;
+  padding-top: 1.25rem;
+}
+
 #recordings-table th {
   font-weight: 600;
   color: var(--text-muted);
@@ -2793,7 +2798,12 @@ body[data-scroll-locked="true"] {
 }
 
 .checkbox-cell {
-  width: 48px;
+  width: 64px;
+}
+
+#recordings-table tbody tr .checkbox-cell input[type="checkbox"] {
+  width: 2rem;
+  height: 2rem;
 }
 
 #recordings-table td.numeric {


### PR DESCRIPTION
**What / Why**
* Align recording titles with their selection checkboxes for clearer scanning.
* Increase the checkbox hit area for easier interaction on desktop and tablet.

**How (high-level)**
* Top-align recording table cells and add extra top padding to the desktop layout.
* Expand the checkbox column width and explicitly size the checkbox control to 2rem.

**Risk / Rollback**
* Low risk: CSS-only tweaks scoped to the recordings table. Roll back by reverting this patch if spacing issues appear.

**Human Testing Criteria**
* Open the recordings list and confirm clip names line up horizontally with the checkboxes.
* Verify the action buttons still render beneath the title with consistent spacing.
* Check that the enlarged checkbox remains clickable and toggles selection as expected.

**Links**
* Jira: https://mfisbv.atlassian.net/browse/TR-98
* Task Run: (current)


------
https://chatgpt.com/codex/tasks/task_e_68e5ff478b348327bb58eecf0c9ebeef