### PR TITLE
TR-99: Clarify asyncio guard logging

### DIFF
--- a/lib/web_streamer.py
+++ b/lib/web_streamer.py
@@ -160,10 +160,16 @@ def _install_handle_run_guard() -> None:
                 return
             if not _NONE_HANDLE_LOG_REPORTED:
                 asyncio_log.warning(
-                    "Discarded asyncio handle with None callback; args=%r",
+                    "Discarded asyncio handle with None callback; args=%r. "
+                    "Guard replaced it with a no-op callback.",
                     self._args,
-                    stack_info=True,
                 )
+                if asyncio_log.isEnabledFor(logging.DEBUG):
+                    asyncio_log.debug(
+                        "Discarded asyncio handle with None callback; args=%r",
+                        self._args,
+                        stack_info=True,
+                    )
                 _NONE_HANDLE_LOG_REPORTED = True
             else:
                 asyncio_log.debug(


### PR DESCRIPTION
## What / Why
- Reword the asyncio guard warning so operators understand the None-callback replacement is expected.
- Limit the stack trace emission to DEBUG logging to avoid confusing warning output that looks like a crash.

## How (high-level)
- Updated the `_install_handle_run_guard` warning path to clarify the mitigation and gate stack trace emission behind a DEBUG log check.

## Risk / Rollback
- **Risk:** Low; only touches log messaging in the asyncio guard path.
- **Rollback:** Revert this commit to restore the prior warning behavior.

## Human Testing Criteria
- `export DEV=0; pytest -q`

## Links
- Jira: https://mfisbv.atlassian.net/browse/TR-99
- Codex task run: current session (no public URL)


------
https://chatgpt.com/codex/tasks/task_e_68e60ffb77dc83279c8176df50d8e8bb