### PR TITLE
TR-95: Increase waveform zoom range to 10x

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ Uploads run immediately after the encoder finishes so recordings land in the arc
 - Recording browser with search, day filtering, pagination, and a recycle bin for safe deletion and restoration.
 - Recycle bin view provides inline audio preview before you restore or permanently clear recordings.
 - Audio preview player with waveform visualization, trigger/release markers, and timeline scrubbing.
-- Adjustable waveform amplitude zoom control for inspecting quiet or loud passages.
+- Adjustable waveform amplitude zoom control (0.25×–10×) for inspecting quiet or loud passages.
 - Config viewer that renders the merged runtime configuration (post-environment overrides).
 - Recorder configuration modal supports saving individual sections or using the **Save all changes** button to persist every dirty section in one go.
 - Persistent SD card health banner fed by the monitor service when kernel/syslog errors appear.

--- a/lib/webui/static/js/dashboard.js
+++ b/lib/webui/static/js/dashboard.js
@@ -1193,7 +1193,7 @@ const renameDialogState = {
 
 const WAVEFORM_ZOOM_DEFAULT = 1;
 const WAVEFORM_ZOOM_MIN = 0.25;
-const WAVEFORM_ZOOM_MAX = 4;
+const WAVEFORM_ZOOM_MAX = 10;
 
 const waveformState = {
   peaks: null,

--- a/lib/webui/templates/dashboard.html
+++ b/lib/webui/templates/dashboard.html
@@ -464,7 +464,7 @@
                     id="waveform-zoom"
                     type="range"
                     min="0.25"
-                    max="4"
+                    max="10"
                     step="0.25"
                     value="1"
                   />


### PR DESCRIPTION
**What / Why**
* Raise the dashboard waveform amplitude zoom ceiling to 10× so quiet captures are easier to inspect.

**How (high-level)**
* Increased the waveform slider maximum in the dashboard template and matching JavaScript constant so normalization honors the higher cap.
* Updated README documentation to note the expanded 0.25×–10× range.

**Risk / Rollback**
* Low – UI-only adjustment; revert the template/JS change to restore the previous 4× ceiling.

**Human Testing Criteria**
* `export DEV=0`
* `pytest -q`

**Links**
* [Jira TR-95](https://mfisbv.atlassian.net/browse/TR-95)
* Task Run: (internal)


------
https://chatgpt.com/codex/tasks/task_e_68e6163e86088327ab30ba366fd12f4c