### PR TITLE
TR-94: Improve shift-click selection

### DIFF
--- a/lib/webui/static/css/dashboard.css
+++ b/lib/webui/static/css/dashboard.css
@@ -1049,6 +1049,13 @@ button.small {
   justify-content: flex-end;
 }
 
+.table-actions-hint {
+  margin: 0.25rem 0 0;
+  text-align: right;
+  color: var(--text-muted);
+  font-size: 0.8125rem;
+}
+
 .filters-header {
   display: flex;
   align-items: center;
@@ -3115,6 +3122,10 @@ body[data-theme="light"] .record-in-progress {
   .table-actions {
     width: 100%;
     justify-content: flex-start;
+  }
+
+  .table-actions-hint {
+    text-align: left;
   }
 }
 

--- a/lib/webui/static/js/dashboard.js
+++ b/lib/webui/static/js/dashboard.js
@@ -272,6 +272,7 @@ const state = {
   availableDays: [],
   selections: new Set(),
   selectionAnchor: "",
+  selectionFocus: "",
   current: null,
   partialRecord: null,
   captureStatus: null,
@@ -287,6 +288,10 @@ const state = {
     anchorId: "",
   },
 };
+
+if (typeof window !== "undefined") {
+  window.TRICORDER_DASHBOARD_STATE = state;
+}
 
 const storedCollection = loadStoredCollection();
 if (storedCollection === "saved" || storedCollection === "recent") {
@@ -4334,6 +4339,86 @@ function getSelectableRecords() {
   return getVisibleRecords().filter((record) => record && !record.isPartial);
 }
 
+function findNearestSelectionAnchor(records, targetIndex) {
+  let previous = { path: "", distance: Number.POSITIVE_INFINITY };
+  for (let index = targetIndex - 1; index >= 0; index -= 1) {
+    const candidate = records[index];
+    if (!candidate || typeof candidate.path !== "string" || !candidate.path) {
+      continue;
+    }
+    if (state.selections.has(candidate.path)) {
+      previous = { path: candidate.path, distance: targetIndex - index };
+      break;
+    }
+  }
+
+  let next = { path: "", distance: Number.POSITIVE_INFINITY };
+  for (let index = targetIndex + 1; index < records.length; index += 1) {
+    const candidate = records[index];
+    if (!candidate || typeof candidate.path !== "string" || !candidate.path) {
+      continue;
+    }
+    if (state.selections.has(candidate.path)) {
+      next = { path: candidate.path, distance: index - targetIndex };
+      break;
+    }
+  }
+
+  if (previous.path && next.path) {
+    return previous.distance <= next.distance ? previous.path : next.path;
+  }
+  if (previous.path) {
+    return previous.path;
+  }
+  if (next.path) {
+    return next.path;
+  }
+  return "";
+}
+
+function resolveSelectionAnchor(targetPath) {
+  if (typeof targetPath !== "string" || !targetPath) {
+    return "";
+  }
+
+  const records = getSelectableRecords();
+  if (!records.length) {
+    return "";
+  }
+
+  const targetIndex = records.findIndex((record) => record && record.path === targetPath);
+  if (targetIndex === -1) {
+    return "";
+  }
+
+  const anchorCandidate = state.selectionAnchor;
+  if (
+    typeof anchorCandidate === "string" &&
+    anchorCandidate &&
+    anchorCandidate !== targetPath &&
+    records.some((record) => record && record.path === anchorCandidate)
+  ) {
+    return anchorCandidate;
+  }
+
+  const focusCandidate = state.selectionFocus;
+  if (
+    typeof focusCandidate === "string" &&
+    focusCandidate &&
+    focusCandidate !== targetPath &&
+    records.some((record) => record && record.path === focusCandidate)
+  ) {
+    return focusCandidate;
+  }
+
+  const nearest = findNearestSelectionAnchor(records, targetIndex);
+  if (nearest && nearest !== targetPath) {
+    return nearest;
+  }
+
+  return "";
+}
+
 function applySelectionRange(anchorPath, targetPath, shouldSelect) {
   if (typeof anchorPath !== "string" || !anchorPath) {
     return false;
@@ -4540,8 +4625,27 @@ function updateSelectionUI(records = null) {
       (record) => record && record.path === state.selectionAnchor,
     );
     if (!anchorExists) {
-      state.selectionAnchor = "";
+      const focusPath = state.selectionFocus;
+      const focusExists = selectable.some(
+        (record) => record && record.path === focusPath,
+      );
+      if (focusExists && focusPath) {
+        state.selectionAnchor = focusPath;
+      } else {
+        const fallback = selectable.find((record) => state.selections.has(record.path));
+        if (fallback && typeof fallback.path === "string") {
+          state.selectionAnchor = fallback.path;
+          state.selectionFocus = fallback.path;
+        } else {
+          state.selectionAnchor = "";
+          if (state.selections.size === 0) {
+            state.selectionFocus = "";
+          }
+        }
+      }
     }
+  } else if (state.selections.size === 0) {
+    state.selectionFocus = "";
   }
 }
 
@@ -5144,11 +5248,17 @@ function renderRecords() {
       if (!(event instanceof MouseEvent)) {
         return;
       }
-      if (event.shiftKey && typeof state.selectionAnchor === "string" && state.selectionAnchor) {
+      state.selectionFocus = record.path;
+      if (event.shiftKey) {
+        const anchorPath = resolveSelectionAnchor(record.path);
+        if (!anchorPath) {
+          state.selectionAnchor = record.path;
+          return;
+        }
         event.preventDefault();
-        const currentlySelected = state.selections.has(record.path);
-        const shouldSelect = !currentlySelected;
-        const changed = applySelectionRange(state.selectionAnchor, record.path, shouldSelect);
+        const wasSelected = state.selections.has(record.path);
+        const shouldSelect = !wasSelected;
+        const changed = applySelectionRange(anchorPath, record.path, shouldSelect);
         state.selectionAnchor = record.path;
         if (changed) {
           updateSelectionUI();
@@ -5159,6 +5269,7 @@ function renderRecords() {
       state.selectionAnchor = record.path;
     });
     checkbox.addEventListener("change", (event) => {
+      state.selectionFocus = record.path;
       if (event.target.checked) {
         state.selections.add(record.path);
       } else {
@@ -7763,6 +7874,7 @@ function setCollection(nextCollection, options = {}) {
   state.offset = 0;
   state.selections.clear();
   state.selectionAnchor = "";
+  state.selectionFocus = "";
   updateSelectionUI();
   setNowPlaying(null, { autoplay: false, resetToStart: true });
   updateCollectionUI();
@@ -13222,6 +13334,9 @@ async function deleteRecordings(paths) {
       state.selections.delete(path);
       if (state.selectionAnchor === path) {
         state.selectionAnchor = "";
+        if (state.selectionFocus === path) {
+          state.selectionFocus = "";
+        }
       }
       if (state.current && state.current.path === path) {
         setNowPlaying(null);
@@ -13315,6 +13430,9 @@ async function renameRecording(path, newName, options = {}) {
   }
   if (state.selectionAnchor === oldPath) {
     state.selectionAnchor = newPath;
+    state.selectionFocus = newPath;
+  } else if (state.selectionFocus === oldPath) {
+    state.selectionFocus = newPath;
   }
   if (state.current && state.current.path === oldPath) {
     pendingSelectionPath = newPath;
@@ -14232,6 +14350,7 @@ function attachEventListeners() {
     applyFiltersFromInputs();
     state.selections.clear();
     state.selectionAnchor = "";
+    state.selectionFocus = "";
     fetchRecordings({ silent: false });
     updateSelectionUI();
     resumeAutoRefresh();
@@ -14248,6 +14367,7 @@ function attachEventListeners() {
     clearFilters();
     state.selections.clear();
     state.selectionAnchor = "";
+    state.selectionFocus = "";
     fetchRecordings({ silent: false });
     updateSelectionUI();
     resumeAutoRefresh();
@@ -14533,12 +14653,14 @@ function attachEventListeners() {
       }
       if (records.length > 0) {
         state.selectionAnchor = records[records.length - 1].path;
+        state.selectionFocus = records[records.length - 1].path;
       }
     } else {
       for (const record of records) {
         state.selections.delete(record.path);
       }
       state.selectionAnchor = "";
+      state.selectionFocus = "";
     }
     renderRecords();
   });
@@ -14550,6 +14672,7 @@ function attachEventListeners() {
     }
     if (records.length > 0) {
       state.selectionAnchor = records[records.length - 1].path;
+      state.selectionFocus = records[records.length - 1].path;
     }
     renderRecords();
   });
@@ -14557,6 +14680,7 @@ function attachEventListeners() {
   dom.clearSelection.addEventListener("click", () => {
     state.selections.clear();
     state.selectionAnchor = "";
+    state.selectionFocus = "";
     renderRecords();
   });
 

--- a/lib/webui/templates/dashboard.html
+++ b/lib/webui/templates/dashboard.html
@@ -749,6 +749,9 @@
                   Move to recycle bin
                 </button>
               </div>
+              <p class="table-actions-hint" id="selection-shortcut-hint">
+                Tip: Hold Shift while clicking checkboxes to select a range.
+              </p>
             </div>
             <div class="table-responsive">
               <table id="recordings-table">

--- a/tests/helpers/dashboard_node_env.js
+++ b/tests/helpers/dashboard_node_env.js
@@ -1,0 +1,144 @@
+const fs = require("fs");
+const path = require("path");
+const vm = require("vm");
+
+function createWindowStub() {
+  const document = {
+    readyState: "loading",
+    addEventListener: () => {},
+    removeEventListener: () => {},
+    getElementById: () => null,
+    querySelector: () => null,
+    querySelectorAll: () => [],
+    createElement: () => ({
+      style: {},
+      classList: { add() {}, remove() {}, toggle() {} },
+      append() {},
+      appendChild() {},
+      setAttribute() {},
+      removeAttribute() {},
+      addEventListener() {},
+      removeEventListener() {},
+      querySelector() { return null; },
+      querySelectorAll() { return []; },
+      getBoundingClientRect() {
+        return { top: 0, left: 0, width: 0, height: 0 };
+      },
+    }),
+    body: {
+      dataset: {},
+      classList: { add() {}, remove() {}, toggle() {}, contains() { return false; } },
+      appendChild() {},
+      removeEventListener() {},
+    },
+  };
+
+  const storageStub = {
+    getItem: () => null,
+    setItem: () => {},
+    removeItem: () => {},
+  };
+
+  const noop = () => {};
+
+  const windowStub = {
+    document,
+    addEventListener: noop,
+    removeEventListener: noop,
+    localStorage: storageStub,
+    sessionStorage: { ...storageStub },
+    matchMedia: () => ({ matches: false, addEventListener: noop, removeEventListener: noop }),
+    setTimeout,
+    clearTimeout,
+    setInterval,
+    clearInterval,
+    navigator: {
+      languages: ["en-US"],
+      language: "en-US",
+      sendBeacon: noop,
+      clipboard: { writeText: async () => {} },
+    },
+    fetch: async () => ({ ok: true, status: 200, json: async () => ({}) }),
+    Intl,
+    performance: { now: () => 0 },
+    AudioContext: function AudioContext() {},
+    HTMLAudioElement: function HTMLAudioElement() {},
+    Blob: function Blob() {},
+    URL: { createObjectURL: () => "", revokeObjectURL: () => {} },
+    alert: noop,
+    confirm: () => false,
+    prompt: () => null,
+    CustomEvent: function CustomEvent(type, params = {}) {
+      this.type = type;
+      this.detail = params.detail ?? null;
+    },
+    history: { replaceState: noop },
+    location: { href: "", replace: noop, assign: noop, reload: noop },
+    devicePixelRatio: 1,
+    screen: { width: 1024, height: 768 },
+    crypto: { getRandomValues: (array) => array.fill(0) },
+  };
+
+  windowStub.window = windowStub;
+  windowStub.document = document;
+  return windowStub;
+}
+
+function createSandbox() {
+  const windowStub = createWindowStub();
+  const sandbox = {
+    console,
+    module: { exports: {} },
+    exports: {},
+    window: windowStub,
+    document: windowStub.document,
+    navigator: windowStub.navigator,
+    localStorage: windowStub.localStorage,
+    sessionStorage: windowStub.sessionStorage,
+    fetch: windowStub.fetch,
+    performance: windowStub.performance,
+    Intl,
+    Audio: function Audio() {},
+    URL: windowStub.URL,
+    Headers: function Headers() {},
+    Request: function Request() {},
+    Response: function Response() {},
+    AbortController: function AbortController() {
+      this.signal = {};
+      this.abort = () => {};
+    },
+    FormData: function FormData() {},
+    FileReader: function FileReader() {
+      this.readAsDataURL = () => {};
+    },
+    btoa: () => "",
+    atob: () => "",
+    CustomEvent: windowStub.CustomEvent,
+    Event: function Event(type) {
+      this.type = type;
+    },
+    Node: function Node() {},
+    Element: function Element() {},
+    HTMLElement: function HTMLElement() {},
+    HTMLInputElement: function HTMLInputElement() {},
+    TextEncoder,
+    TextDecoder,
+    setTimeout,
+    clearTimeout,
+    setInterval,
+    clearInterval,
+  };
+
+  vm.createContext(sandbox);
+  return { sandbox, windowStub };
+}
+
+function loadDashboard() {
+  const { sandbox } = createSandbox();
+  const dashboardPath = path.join(__dirname, "..", "..", "lib", "webui", "static", "js", "dashboard.js");
+  const code = fs.readFileSync(dashboardPath, "utf8");
+  vm.runInContext(code, sandbox, { filename: "dashboard.js" });
+  return sandbox;
+}
+
+module.exports = { loadDashboard };

--- a/tests/test_37_web_dashboard.py
+++ b/tests/test_37_web_dashboard.py
@@ -2,6 +2,8 @@ import asyncio
 import os
 
 import json
+import subprocess
+import textwrap
 import time
 from datetime import datetime, timezone
 import io
@@ -86,6 +88,43 @@ def _create_silent_wav(path: Path, duration: float = 2.0) -> None:
         handle.setsampwidth(2)
         handle.setframerate(48000)
         handle.writeframes(b"\x00\x00" * frame_count)
+
+
+def _run_dashboard_selection_script(script: str) -> dict:
+    root = Path(__file__).resolve().parents[1]
+    indented_script = textwrap.indent(script, "        ")
+    template = """
+        const path = require("path");
+        const {{ loadDashboard }} = require(path.join(process.cwd(), "tests", "helpers", "dashboard_node_env.js"));
+        const sandbox = loadDashboard();
+        const state = sandbox.window.TRICORDER_DASHBOARD_STATE;
+        if (!state) {{
+          throw new Error("Dashboard state is unavailable for tests");
+        }}
+        state.records = [];
+        state.partialRecord = null;
+        state.recordsFingerprint = "";
+        state.selectionAnchor = "";
+        state.selectionFocus = "";
+        state.selections = new Set();
+        state.sort = {{ key: "name", direction: "asc" }};
+        state.total = 0;
+        state.filteredSize = 0;
+        const result = (() => {{
+{script}
+        }})();
+        console.log(JSON.stringify(result));
+    """
+    node_code = textwrap.dedent(template).format(script=indented_script)
+    completed = subprocess.run(
+        ["node", "-e", node_code],
+        capture_output=True,
+        text=True,
+        check=True,
+        cwd=root,
+    )
+    output = completed.stdout.strip()
+    return json.loads(output or "null")
 
 
 def test_recordings_listing_filters(dashboard_env, monkeypatch):
@@ -2368,6 +2407,77 @@ def test_recordings_bulk_download_includes_sidecars(dashboard_env):
             await server.close()
 
     asyncio.run(runner())
+
+
+def test_shift_click_selects_range_between_non_adjacent_records():
+    script = textwrap.dedent(
+        """
+        const records = [
+          { path: "20240101/alpha.opus", name: "Alpha", day: "20240101", modified: 1, duration_seconds: 10, size_bytes: 100 },
+          { path: "20240101/bravo.opus", name: "Bravo", day: "20240101", modified: 2, duration_seconds: 11, size_bytes: 110 },
+          { path: "20240101/charlie.opus", name: "Charlie", day: "20240101", modified: 3, duration_seconds: 12, size_bytes: 120 },
+          { path: "20240101/delta.opus", name: "Delta", day: "20240101", modified: 4, duration_seconds: 13, size_bytes: 130 },
+          { path: "20240101/echo.opus", name: "Echo", day: "20240101", modified: 5, duration_seconds: 14, size_bytes: 140 },
+        ];
+        state.records = records;
+        state.total = records.length;
+        state.filteredSize = records.length;
+        const target = "20240101/charlie.opus";
+        state.selections = new Set(["20240101/alpha.opus", "20240101/echo.opus"]);
+        state.selectionAnchor = "";
+        state.selectionFocus = "";
+        const anchor = sandbox.resolveSelectionAnchor(target);
+        const changed = sandbox.applySelectionRange(anchor, target, true);
+        return {
+          anchor,
+          changed,
+          selections: Array.from(state.selections.values()).sort(),
+        };
+        """
+    )
+    result = _run_dashboard_selection_script(script)
+    assert result["anchor"] == "20240101/alpha.opus"
+    assert result["changed"] is True
+    assert "20240101/bravo.opus" in result["selections"]
+    assert "20240101/charlie.opus" in result["selections"]
+    assert "20240101/delta.opus" not in result["selections"]
+    assert "20240101/echo.opus" in result["selections"]
+
+
+def test_shift_click_uses_existing_anchor_when_available():
+    script = textwrap.dedent(
+        """
+        const records = [
+          { path: "20240101/alpha.opus", name: "Alpha", day: "20240101", modified: 1, duration_seconds: 10, size_bytes: 100 },
+          { path: "20240101/bravo.opus", name: "Bravo", day: "20240101", modified: 2, duration_seconds: 11, size_bytes: 110 },
+          { path: "20240101/charlie.opus", name: "Charlie", day: "20240101", modified: 3, duration_seconds: 12, size_bytes: 120 },
+          { path: "20240101/delta.opus", name: "Delta", day: "20240101", modified: 4, duration_seconds: 13, size_bytes: 130 },
+          { path: "20240101/echo.opus", name: "Echo", day: "20240101", modified: 5, duration_seconds: 14, size_bytes: 140 },
+        ];
+        state.records = records;
+        state.total = records.length;
+        state.filteredSize = records.length;
+        const target = "20240101/echo.opus";
+        state.selections = new Set(["20240101/bravo.opus"]);
+        state.selectionAnchor = "20240101/bravo.opus";
+        state.selectionFocus = "20240101/bravo.opus";
+        const anchor = sandbox.resolveSelectionAnchor(target);
+        const changed = sandbox.applySelectionRange(anchor, target, true);
+        return {
+          anchor,
+          changed,
+          selections: Array.from(state.selections.values()).sort(),
+        };
+        """
+    )
+    result = _run_dashboard_selection_script(script)
+    assert result["anchor"] == "20240101/bravo.opus"
+    assert result["changed"] is True
+    assert result["selections"].count("20240101/bravo.opus") == 1
+    assert "20240101/charlie.opus" in result["selections"]
+    assert "20240101/delta.opus" in result["selections"]
+    assert "20240101/echo.opus" in result["selections"]
+    assert "20240101/alpha.opus" not in result["selections"]
 
 
 def test_sd_card_recovery_static_doc_served(dashboard_env):


### PR DESCRIPTION
## What / Why
* Fix shift-click range selection on the recordings table so non-adjacent selections correctly include intermediate items.
* Surface the shortcut with a dashboard hint to make the interaction discoverable.

## How (high-level)
* Added selection focus tracking and anchor resolution helpers so shift-click finds the right range even after list refreshes.
* Updated checkbox/toggle handlers to preserve focus and anchor state while honoring shift-click requests.
* Introduced a lightweight Node-based test harness for dashboard.js and new pytest coverage for the range-selection scenarios.
* Added a tooltip-style hint next to the selection controls.

## Risk / Rollback
* **Risk:** Low; changes are limited to dashboard selection logic and related UI text. Automated tests exercise the new behavior.
* **Rollback:** Revert commit 3eba3b4221c130d4c30ff2007817d49fdd0894ad.

## Human Testing Criteria
* Load the dashboard, select a recording, then Shift+click another non-adjacent recording and confirm everything between them is selected.
* Verify the selection hint appears near the selection controls on desktop and mobile breakpoints.

## Links
* Jira: https://mfisbv.atlassian.net/browse/TR-94
* Commit: 3eba3b4221c130d4c30ff2007817d49fdd0894ad

------
https://chatgpt.com/codex/tasks/task_e_68e61222560083278b876df7cde7862b