### PR TITLE
TR-102: Fix shift-click range checkbox state

### DIFF
--- a/lib/webui/static/js/dashboard.js
+++ b/lib/webui/static/js/dashboard.js
@@ -5260,6 +5260,7 @@ function renderRecords() {
         const shouldSelect = !wasSelected;
         const changed = applySelectionRange(anchorPath, record.path, shouldSelect);
         state.selectionAnchor = record.path;
+        checkbox.checked = state.selections.has(record.path);
         if (changed) {
           updateSelectionUI();
           applyNowPlayingHighlight();
@@ -12777,6 +12778,7 @@ function renderRecycleBinItems() {
         const shouldSelect = !checkbox.checked;
         const changed = applyRecycleBinRangeSelection(state.recycleBin.anchorId, item.id, shouldSelect);
         state.recycleBin.anchorId = item.id;
+        checkbox.checked = state.recycleBin.selected.has(item.id);
         if (changed) {
           if (
             !shouldSelect &&


### PR DESCRIPTION
**What / Why**
* Ensure the shift-clicked checkbox mirrors the applied range selection so the UI matches the actual selection state.
* Apply the same visual feedback fix to recycle bin range selections for consistent behavior.

**How (high-level)**
* After applying the range selection, immediately sync the clicked checkbox with the updated selection set in both the recordings table and recycle bin list.

**Risk / Rollback**
* Low. The change only updates client-side checkbox state. Roll back by reverting this PR if any regressions appear.

**Human Testing Criteria**
* Open the recordings list, select one item, then shift-click a second item and confirm both endpoints are visibly checked.
* Repeat the shift-click flow inside the recycle bin table to confirm the final item shows as selected.

**Links**
* Jira: https://mfisbv.atlassian.net/browse/TR-102
* Task Run: N/A (local execution)
* Preview URL: N/A


------
https://chatgpt.com/codex/tasks/task_e_68e61cf209b48327a7eebf198c5089d0