### PR TITLE
TR-103: Skip dashboard selection tests when Node.js is unavailable

### DIFF
--- a/tests/test_37_web_dashboard.py
+++ b/tests/test_37_web_dashboard.py
@@ -92,6 +92,9 @@ def _create_silent_wav(path: Path, duration: float = 2.0) -> None:
 
 def _run_dashboard_selection_script(script: str) -> dict:
     root = Path(__file__).resolve().parents[1]
+    node_path = shutil.which("node")
+    if node_path is None:
+        pytest.skip("Node.js binary is required for dashboard selection script tests")
     indented_script = textwrap.indent(script, "        ")
     template = """
         const path = require("path");
@@ -117,7 +120,7 @@ def _run_dashboard_selection_script(script: str) -> dict:
     """
     node_code = textwrap.dedent(template).format(script=indented_script)
     completed = subprocess.run(
-        ["node", "-e", node_code],
+        [node_path, "-e", node_code],
         capture_output=True,
         text=True,
         check=True,


### PR DESCRIPTION
**What / Why**
- Prevent dashboard selection unit tests from failing when the Node.js runtime is not installed in CI.

**How (high-level)**
- Detect the Node.js binary in the dashboard selection helper and skip the associated tests when it is unavailable.

**Risk / Rollback**
- Low risk; change only affects test helper behavior and gracefully skips tests instead of executing them without Node.js.
- Rollback by reverting this commit.

**Human Testing Criteria**
- `export DEV=0`
- `pytest -q`

**Links**
- Jira: https://mfisbv.atlassian.net/browse/TR-103
- Task Run: (current Codex run)
- Preview URL: N/A

------
https://chatgpt.com/codex/tasks/task_e_68e624fa56f08327909ee5ce8490b66f