### PR TITLE
TR-106: Pause refresh while interacting with controls

### DIFF
--- a/lib/webui/static/js/dashboard.js
+++ b/lib/webui/static/js/dashboard.js
@@ -1120,6 +1120,23 @@ let autoRefreshSuspended = false;
 let fetchInFlight = false;
 let fetchQueued = false;
 let recordingsRefreshDeferred = false;
+const hoveredInteractiveElements = new Set();
+
+const INTERACTIVE_ROLE_NAMES = new Set([
+  "button",
+  "checkbox",
+  "combobox",
+  "menuitem",
+  "menuitemcheckbox",
+  "menuitemradio",
+  "option",
+  "radio",
+  "slider",
+  "spinbutton",
+  "switch",
+  "tab",
+  "textbox",
+]);
 
 function isInteractiveFormField(element) {
   if (!(element instanceof HTMLElement)) {
@@ -1131,7 +1148,7 @@ function isInteractiveFormField(element) {
   }
 
   const role = element.getAttribute("role");
-  if (role === "textbox" || role === "combobox" || role === "spinbutton") {
+  if (role && INTERACTIVE_ROLE_NAMES.has(role)) {
     return true;
   }
 
@@ -1142,10 +1159,13 @@ function isInteractiveFormField(element) {
   if (tagName === "TEXTAREA" || tagName === "SELECT") {
     return true;
   }
+  if (tagName === "BUTTON") {
+    return true;
+  }
 
   if (tagName === "INPUT") {
     const type = (element.getAttribute("type") || "text").toLowerCase();
-    if (type === "button" || type === "submit" || type === "reset") {
+    if (type === "hidden") {
       return false;
     }
     return true;
@@ -2531,7 +2551,7 @@ function suspendAutoRefresh() {
 }
 
 function resumeAutoRefresh() {
-  if (state.recycleBin.open) {
+  if (state.recycleBin.open || hoveredInteractiveElements.size > 0) {
     return;
   }
   if (!autoRefreshSuspended) {
@@ -14279,6 +14299,41 @@ function attachEventListeners() {
       });
     };
 
+    const handlePointerOver = (event) => {
+      const interactive = findInteractiveElement(event.target, event);
+      if (!interactive) {
+        return;
+      }
+      hoveredInteractiveElements.add(interactive);
+      suspendAutoRefresh();
+    };
+
+    const handlePointerOut = (event) => {
+      const interactive = findInteractiveElement(event.target, event);
+      if (!interactive) {
+        return;
+      }
+      const relatedTarget = event.relatedTarget instanceof Element ? event.relatedTarget : null;
+      const nextInteractive = relatedTarget ? findInteractiveElement(relatedTarget) : null;
+      if (nextInteractive === interactive) {
+        return;
+      }
+      hoveredInteractiveElements.delete(interactive);
+      if (nextInteractive) {
+        return;
+      }
+      if (hoveredInteractiveElements.size > 0) {
+        return;
+      }
+      window.requestAnimationFrame(() => {
+        const active =
+          document.activeElement instanceof HTMLElement ? document.activeElement : null;
+        if (!findInteractiveElement(active) && hoveredInteractiveElements.size === 0) {
+          resumeAutoRefresh();
+        }
+      });
+    };
+
     document.addEventListener("focusin", handleGlobalFocusIn);
     document.addEventListener("focusout", handleGlobalFocusOut);
     document.addEventListener("pointerdown", (event) => {
@@ -14286,6 +14341,8 @@ function attachEventListeners() {
         suspendAutoRefresh();
       }
     });
+    document.addEventListener("pointerover", handlePointerOver, true);
+    document.addEventListener("pointerout", handlePointerOut, true);
   }
 
   const audioSection = recorderDom.sections ? recorderDom.sections.audio : null;


### PR DESCRIPTION
**What / Why**
* Pause dashboard background refresh when the pointer hovers over interactive controls so periodic updates do not disrupt user interactions.

**How (high-level)**
* Broaden interactive element detection to cover buttons and ARIA role-based controls.
* Track hovered interactive elements and suspend refresh on pointer over/out, resuming only after focus and hover leave all controls.

**Risk / Rollback**
* Medium – affects global auto-refresh timing; rollback by reverting this PR if hover-based suspension causes stale data.

**Human Testing Criteria**
* Automated: `export DEV=0; pytest -q`
* Automated: `export DEV=1; pytest -q`
* Hover over dashboard buttons, sliders, or checkboxes and confirm auto-refresh pauses until the pointer leaves the control.
* Click a control and move the pointer away; verify refresh resumes once interaction ends.

**Links**
* Jira: https://mfisbv.atlassian.net/browse/TR-106
* Task Run: (link unavailable)
* Preview: N/A

------
https://chatgpt.com/codex/tasks/task_e_68e65370c8d08327ba82990d4a66914d