### PR TITLE
TR-101: Show clipper saving feedback

### DIFF
--- a/lib/webui/static/css/dashboard.css
+++ b/lib/webui/static/css/dashboard.css
@@ -1410,6 +1410,21 @@ button.small {
   min-height: 1rem;
   font-size: 0.85rem;
   color: var(--text-muted);
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+}
+
+.clipper-status[data-state="pending"]::before {
+  content: "";
+  display: inline-block;
+  width: 0.75rem;
+  height: 0.75rem;
+  border-radius: 50%;
+  border: 2px solid currentColor;
+  border-top-color: transparent;
+  border-right-color: transparent;
+  animation: clipper-status-spin 0.85s linear infinite;
 }
 
 .clipper-container[data-enabled="false"] .clipper-status {
@@ -1422,6 +1437,23 @@ button.small {
 
 .clipper-status[data-state="success"] {
   color: rgba(52, 211, 153, 0.9);
+}
+
+.clipper-container[data-busy="true"] {
+  cursor: progress;
+}
+
+.clipper-container[data-busy="true"] button {
+  cursor: progress;
+}
+
+@keyframes clipper-status-spin {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
 }
 
 .clipper-summary {

--- a/lib/webui/static/js/dashboard.js
+++ b/lib/webui/static/js/dashboard.js
@@ -6529,8 +6529,23 @@ function updateClipperUI({ updateInputs = true, updateName = true } = {}) {
   const valid = clipLength >= MIN_CLIP_DURATION_SECONDS && clipLength <= duration;
   updateClipperLengthElement(valid, clipLength);
 
+  if (dom.clipperContainer) {
+    dom.clipperContainer.dataset.busy = clipperState.busy ? "true" : "false";
+  }
+  if (dom.clipperForm) {
+    dom.clipperForm.setAttribute("aria-busy", clipperState.busy ? "true" : "false");
+  }
   if (dom.clipperSubmit) {
+    if (!dom.clipperSubmit.dataset.defaultLabel) {
+      dom.clipperSubmit.dataset.defaultLabel = dom.clipperSubmit.textContent
+        ? dom.clipperSubmit.textContent.trim()
+        : "Save clip";
+    }
     dom.clipperSubmit.disabled = clipperState.busy || !valid;
+    dom.clipperSubmit.setAttribute("aria-busy", clipperState.busy ? "true" : "false");
+    dom.clipperSubmit.textContent = clipperState.busy
+      ? "Saving clip…"
+      : dom.clipperSubmit.dataset.defaultLabel;
   }
   if (dom.clipperReset) {
     dom.clipperReset.disabled = clipperState.busy;


### PR DESCRIPTION
**What / Why**
* Surface a clear visual/ARIA indication that clip saving is in progress so users understand long operations are still running.

**How (high-level)**
* Flag the clip editor container/form/submit button as busy and swap the save label while a clip POST is pending.
* Add CSS for a pending spinner, inline status layout tweaks, and busy cursors so the saving state is obvious.

**Risk / Rollback**
* Low risk: changes are limited to clipper UI states. Roll back by reverting this PR if any regressions appear.

**Human Testing Criteria**
* Select a recording and enable the clip editor.
* Choose a clip range and press **Save clip**.
* Verify the save button label changes to “Saving clip…”, the form controls disable, and a spinner/status appear until the operation completes.

**Links**
* Jira: https://mfisbv.atlassian.net/browse/TR-101


------
https://chatgpt.com/codex/tasks/task_e_68e6540636a4832789dcff95f0516690