### PR TITLE
TR-105: Add recorder uptime widget to dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,7 @@ Uploads run immediately after the encoder finishes so recordings land in the arc
 `lib/web_streamer.py` + `lib/webui` expose a dashboard at `/` with the following capabilities:
 
 - Live recorder status and listener counts with encoder start/stop controls.
+- Recorder uptime tile showing how long `voice-recorder.service` has been active since the last start.
 - Manual **Split Event** control to finalize the current recording and immediately begin a new segment without interrupting encoding.
 - Manual **Record** toggle to force continuous recording and skip offline filter passes when you need uninterrupted capture.
 - Recording browser with search, day filtering, pagination, and a recycle bin for safe deletion and restoration.

--- a/lib/webui/static/css/dashboard.css
+++ b/lib/webui/static/css/dashboard.css
@@ -778,6 +778,17 @@ body[data-theme="light"] .app-menu-toggle {
   margin-top: 0.35rem;
 }
 
+.stat-uptime .value {
+  font-variant-numeric: tabular-nums;
+}
+
+.stat-uptime .hint {
+  display: block;
+  font-size: 0.8rem;
+  color: var(--text-muted);
+  margin-top: 0.35rem;
+}
+
 .main-grid {
   display: flex;
   flex-direction: column;

--- a/lib/webui/static/js/dashboard.js
+++ b/lib/webui/static/js/dashboard.js
@@ -334,6 +334,8 @@ const dom = {
   storageUsageText: document.getElementById("storage-usage-text"),
   storageHint: document.getElementById("storage-hint"),
   storageProgress: document.getElementById("storage-progress-bar"),
+  recorderUptimeValue: document.getElementById("recorder-uptime-value"),
+  recorderUptimeHint: document.getElementById("recorder-uptime-hint"),
   lastUpdated: document.getElementById("last-updated"),
   tableBody: document.querySelector("#recordings-table tbody"),
   toggleAll: document.getElementById("toggle-all"),
@@ -966,6 +968,133 @@ function renderResourceStats() {
       dom.memoryDetail.textContent = "--";
     }
   }
+}
+
+function formatRecorderUptimeValue(seconds) {
+  const total = Math.max(0, Math.floor(seconds));
+  if (total < 60) {
+    return `${total}s`;
+  }
+  if (total < 3600) {
+    const minutes = Math.floor(total / 60);
+    const secs = total % 60;
+    return secs > 0 ? `${minutes}m ${secs}s` : `${minutes}m`;
+  }
+  if (total < 86400) {
+    const hours = Math.floor(total / 3600);
+    const minutes = Math.floor((total % 3600) / 60);
+    return minutes > 0 ? `${hours}h ${minutes}m` : `${hours}h`;
+  }
+  const days = Math.floor(total / 86400);
+  const hours = Math.floor((total % 86400) / 3600);
+  return hours > 0 ? `${days}d ${hours}h` : `${days}d`;
+}
+
+function formatRecorderUptimeHint(startEpoch) {
+  if (!Number.isFinite(startEpoch)) {
+    return "";
+  }
+  try {
+    return `since ${dateFormatter.format(new Date(startEpoch * 1000))}`;
+  } catch (error) {
+    console.warn("Unable to format recorder uptime start", error);
+  }
+  return "";
+}
+
+function stopRecorderUptimeTimer() {
+  if (recorderUptimeState.timerId && typeof window !== "undefined") {
+    window.clearInterval(recorderUptimeState.timerId);
+    recorderUptimeState.timerId = null;
+  }
+}
+
+function ensureRecorderUptimeTimer() {
+  if (recorderUptimeState.timerId || typeof window === "undefined") {
+    return;
+  }
+  recorderUptimeState.timerId = window.setInterval(() => {
+    if (!recorderUptimeState.active) {
+      stopRecorderUptimeTimer();
+      return;
+    }
+    renderRecorderUptime();
+  }, 1000);
+}
+
+function renderRecorderUptime() {
+  if (!dom.recorderUptimeValue) {
+    return;
+  }
+  let valueText = recorderUptimeState.statusText || "--";
+  let hintText = recorderUptimeState.hint || "";
+  if (recorderUptimeState.active && Number.isFinite(recorderUptimeState.startEpoch)) {
+    const now = Date.now() / 1000;
+    const uptimeSeconds = Math.max(0, now - recorderUptimeState.startEpoch);
+    valueText = formatRecorderUptimeValue(uptimeSeconds);
+    hintText = formatRecorderUptimeHint(recorderUptimeState.startEpoch);
+  }
+  dom.recorderUptimeValue.textContent = valueText;
+  if (dom.recorderUptimeHint) {
+    if (hintText) {
+      dom.recorderUptimeHint.textContent = hintText;
+      dom.recorderUptimeHint.hidden = false;
+    } else {
+      dom.recorderUptimeHint.textContent = "";
+      dom.recorderUptimeHint.hidden = true;
+    }
+  }
+}
+
+function setRecorderUptimeStatus(statusText, options = {}) {
+  const { available = false, hint = "" } = options;
+  recorderUptimeState.active = false;
+  recorderUptimeState.available = Boolean(available);
+  recorderUptimeState.startEpoch = null;
+  recorderUptimeState.statusText = statusText || "--";
+  recorderUptimeState.hint = hint || "";
+  stopRecorderUptimeTimer();
+  renderRecorderUptime();
+}
+
+function setRecorderUptimeActive(startEpoch) {
+  if (!Number.isFinite(startEpoch) || startEpoch <= 0) {
+    setRecorderUptimeStatus("Running", { available: true });
+    return;
+  }
+  recorderUptimeState.available = true;
+  recorderUptimeState.active = true;
+  recorderUptimeState.startEpoch = startEpoch;
+  recorderUptimeState.statusText = "";
+  recorderUptimeState.hint = "";
+  renderRecorderUptime();
+  ensureRecorderUptimeTimer();
+}
+
+function updateRecorderUptimeFromServices() {
+  const voiceService = servicesState.items.find(
+    (item) => item.unit === VOICE_RECORDER_SERVICE_UNIT,
+  );
+  if (!voiceService) {
+    setRecorderUptimeStatus("Unavailable");
+    return;
+  }
+  if (voiceService.available === false) {
+    const hint = voiceService.error || voiceService.status_text || "";
+    setRecorderUptimeStatus("Unavailable", { hint });
+    return;
+  }
+  if (!voiceService.is_active) {
+    const hint = voiceService.status_text || "";
+    setRecorderUptimeStatus("Stopped", { available: true, hint });
+    return;
+  }
+  if (Number.isFinite(voiceService.activeEnterEpoch)) {
+    setRecorderUptimeActive(voiceService.activeEnterEpoch);
+    return;
+  }
+  const hint = voiceService.status_text || "";
+  setRecorderUptimeStatus("Running", { available: true, hint });
 }
 
 function applyHealthPayload(payload) {
@@ -1930,6 +2059,15 @@ const servicesState = {
   timerId: null,
   error: null,
   refreshAfterActionId: null,
+};
+
+const recorderUptimeState = {
+  active: false,
+  available: false,
+  startEpoch: null,
+  statusText: "Loading…",
+  hint: "",
+  timerId: null,
 };
 
 const webServerState = {
@@ -11140,6 +11278,11 @@ function normalizeServiceEntry(entry) {
         : "",
     error: typeof entry.error === "string" ? entry.error : "",
     related_units: relatedUnits,
+    activeEnterEpoch: toFiniteOrNull(entry.active_enter_epoch),
+    activeEnterTimestamp:
+      typeof entry.active_enter_timestamp === "string"
+        ? entry.active_enter_timestamp
+        : "",
   };
 }
 
@@ -13137,6 +13280,7 @@ async function fetchServices(options = {}) {
       .map((entry) => normalizeServiceEntry(entry))
       .filter((entry) => entry !== null);
     servicesState.items = normalized;
+    updateRecorderUptimeFromServices();
     const updatedAt = Number(payload.updated_at);
     if (Number.isFinite(updatedAt) && updatedAt > 0) {
       servicesState.lastUpdated = new Date(updatedAt * 1000);
@@ -13152,6 +13296,10 @@ async function fetchServices(options = {}) {
       servicesState.error = "Recorder unreachable. Unable to load services.";
     } else {
       servicesState.error = normalizeErrorMessage(error, "Unable to load services.");
+    }
+    if (!recorderUptimeState.active && recorderUptimeState.startEpoch === null) {
+      const hint = servicesState.error || "";
+      setRecorderUptimeStatus("Offline", { hint });
     }
     renderServices();
   } finally {
@@ -15328,6 +15476,7 @@ function initialize() {
   updateArchivalConfigPath(archivalState.configPath);
   attachEventListeners();
   updateTransportAvailability();
+  renderRecorderUptime();
   fetchRecordings({ silent: false });
   fetchConfig({ silent: false });
   fetchWebServerSettings({ silent: true });

--- a/lib/webui/templates/dashboard.html
+++ b/lib/webui/templates/dashboard.html
@@ -350,6 +350,11 @@
           </div>
           <span class="hint" id="storage-hint">--</span>
         </div>
+        <div class="stat stat-uptime">
+          <span class="label">Recorder uptime</span>
+          <span class="value" id="recorder-uptime-value">--</span>
+          <span class="hint" id="recorder-uptime-hint" hidden>--</span>
+        </div>
         <div class="stat stat-last-updated">
           <span class="label">Last updated</span>
           <span class="value" id="last-updated">--</span>

--- a/tests/test_25_web_streamer.py
+++ b/tests/test_25_web_streamer.py
@@ -829,6 +829,7 @@ def test_parse_show_output_handles_blank_fields():
             "CanReload=no",
             "CanRestart=yes",
             "TriggeredBy=",
+            "ActiveEnterTimestamp=",
         ]
     )
 

--- a/tests/test_37_web_dashboard.py
+++ b/tests/test_37_web_dashboard.py
@@ -1973,6 +1973,7 @@ def test_services_listing_reports_status(monkeypatch, dashboard_env):
                 "no",
                 "yes",
                 "",
+                "Tue 2024-05-14 12:34:56 UTC",
             ),
             "web-streamer.service": (
                 "loaded",
@@ -1985,6 +1986,7 @@ def test_services_listing_reports_status(monkeypatch, dashboard_env):
                 "no",
                 "yes",
                 "",
+                "Tue 2024-05-14 11:22:33 UTC",
             ),
         }
 
@@ -2003,6 +2005,7 @@ def test_services_listing_reports_status(monkeypatch, dashboard_env):
                         "no",
                         "no",
                         "no",
+                        "",
                         "",
                     ),
                 )
@@ -2027,6 +2030,9 @@ def test_services_listing_reports_status(monkeypatch, dashboard_env):
             recorder = next((item for item in services if item["unit"] == "voice-recorder.service"), None)
             assert recorder is not None
             assert recorder["status_text"].startswith("Active")
+            expected_epoch = datetime(2024, 5, 14, 12, 34, 56, tzinfo=timezone.utc).timestamp()
+            assert recorder.get("active_enter_epoch") == pytest.approx(expected_epoch)
+            assert recorder.get("active_enter_timestamp", "").startswith("2024-05-14T12:34:56")
         finally:
             await client.close()
             await server.close()
@@ -2048,6 +2054,7 @@ def test_service_action_auto_restart(monkeypatch, dashboard_env):
                 "no",
                 "yes",
                 "",
+                "Tue 2024-05-14 11:22:33 UTC",
             )
         }
 
@@ -2066,6 +2073,7 @@ def test_service_action_auto_restart(monkeypatch, dashboard_env):
                         "yes",
                         "no",
                         "yes",
+                        "",
                         "",
                     ),
                 )
@@ -2125,6 +2133,7 @@ def test_service_action_recorder_restart_keeps_dashboard(monkeypatch, dashboard_
                 "no",
                 "yes",
                 "",
+                "Tue 2024-05-14 12:34:56 UTC",
             ),
             "web-streamer.service": (
                 "loaded",
@@ -2137,6 +2146,7 @@ def test_service_action_recorder_restart_keeps_dashboard(monkeypatch, dashboard_
                 "no",
                 "yes",
                 "",
+                "Tue 2024-05-14 11:22:33 UTC",
             ),
         }
 
@@ -2159,6 +2169,7 @@ def test_service_action_recorder_restart_keeps_dashboard(monkeypatch, dashboard_
                         "yes",
                         "no",
                         "yes",
+                        "",
                         "",
                     )
                 payload = "\n".join(


### PR DESCRIPTION
**What / Why**
* Add a dashboard tile that surfaces how long `voice-recorder.service` has been running so operators can see recent restarts at a glance.
* Expose the recorder service start time through `/api/services` and document the new UI affordance.

**How (high-level)**
* Extend the systemd status parser to capture `ActiveEnterTimestamp` and return both epoch and ISO forms to the client.
* Add client-side state and timers that render the uptime value, show fallback messaging, and style the new status bar tile.
* Update tests covering service status payloads and the dashboard to reflect the additional data.

**Risk / Rollback**
* Moderate — touches the service inspection API and dashboard JS/CSS. Roll back by reverting this change if the tile misbehaves.

**Human Testing Criteria**
* Start the web UI locally: `python -m lib.web_streamer --host 0.0.0.0 --port 8080`.
* Open `http://localhost:8080` and verify the “Recorder uptime” tile appears and counts up while the service is active.
* Stop or restart the recorder service and confirm the tile reflects the stopped/unavailable state.

**Links**
* Jira: https://mfisbv.atlassian.net/browse/TR-105
* Task Run: (this run)
* Preview: n/a

------
https://chatgpt.com/codex/tasks/task_e_68e653eacb6c83279bb6c0778f3bb392