### PR TITLE
TR-107: Align motion indicator with live flag

### DIFF
--- a/lib/webui/static/js/dashboard.js
+++ b/lib/webui/static/js/dashboard.js
@@ -2646,6 +2646,15 @@ function setRecordingIndicatorStatus(rawStatus) {
   }
   const manualRecording = parseBoolean(rawStatus.manual_recording);
   const motionTriggered = capturing && !manualRecording && isMotionTriggeredEvent(event);
+  let liveMotion = null;
+  if (
+    rawStatus &&
+    typeof rawStatus === "object" &&
+    Object.prototype.hasOwnProperty.call(rawStatus, "motion_active")
+  ) {
+    liveMotion = parseBoolean(rawStatus.motion_active);
+  }
+  const indicatorMotion = liveMotion === null ? motionTriggered : liveMotion;
   const rawStopReason =
     typeof rawStatus.last_stop_reason === "string"
       ? rawStatus.last_stop_reason.trim()
@@ -2723,7 +2732,7 @@ function setRecordingIndicatorStatus(rawStatus) {
     }
   }
 
-  applyRecordingIndicator(state, message, { motion: motionTriggered });
+  applyRecordingIndicator(state, message, { motion: indicatorMotion });
 }
 
 function setSplitEventDisabled(disabled, reason = "") {

--- a/tests/helpers/dashboard_node_env.js
+++ b/tests/helpers/dashboard_node_env.js
@@ -2,34 +2,115 @@ const fs = require("fs");
 const path = require("path");
 const vm = require("vm");
 
+function createMockElement() {
+  const element = {
+    dataset: {},
+    hidden: false,
+    textContent: "",
+    value: "",
+    style: {},
+    classList: {
+      add() {},
+      remove() {},
+      toggle() {},
+      contains() {
+        return false;
+      },
+    },
+    children: [],
+    append(...nodes) {
+      for (const node of nodes) {
+        if (node !== undefined && node !== null) {
+          element.children.push(node);
+        }
+      }
+    },
+    appendChild(node) {
+      if (node !== undefined && node !== null) {
+        element.children.push(node);
+      }
+      return node;
+    },
+    removeChild(node) {
+      const index = element.children.indexOf(node);
+      if (index !== -1) {
+        element.children.splice(index, 1);
+      }
+      return node;
+    },
+    get childElementCount() {
+      return element.children.length;
+    },
+    setAttribute() {},
+    removeAttribute() {},
+    addEventListener() {},
+    removeEventListener() {},
+    querySelector() {
+      return null;
+    },
+    querySelectorAll() {
+      return [];
+    },
+    getBoundingClientRect() {
+      return { top: 0, left: 0, width: 0, height: 0 };
+    },
+  };
+  return element;
+}
+
 function createWindowStub() {
+  const elementStore = new Map();
+
+  const ensureElement = (id, props) => {
+    if (typeof id !== "string" || !id) {
+      return null;
+    }
+    const element = createMockElement();
+    if (props && typeof props === "object" && !Array.isArray(props)) {
+      Object.assign(element, props);
+    }
+    elementStore.set(id, element);
+    return element;
+  };
+
+  const overrides = globalThis.__DASHBOARD_ELEMENT_OVERRIDES;
+  if (overrides && typeof overrides === "object" && !Array.isArray(overrides)) {
+    for (const [id, props] of Object.entries(overrides)) {
+      if (!props) {
+        continue;
+      }
+      if (elementStore.has(id)) {
+        continue;
+      }
+      if (props === true) {
+        ensureElement(id);
+      } else {
+        ensureElement(id, props);
+      }
+    }
+  }
+
   const document = {
     readyState: "loading",
     addEventListener: () => {},
     removeEventListener: () => {},
-    getElementById: () => null,
+    getElementById: (id) => (elementStore.has(id) ? elementStore.get(id) : null),
     querySelector: () => null,
     querySelectorAll: () => [],
-    createElement: () => ({
-      style: {},
-      classList: { add() {}, remove() {}, toggle() {} },
-      append() {},
-      appendChild() {},
-      setAttribute() {},
-      removeAttribute() {},
-      addEventListener() {},
-      removeEventListener() {},
-      querySelector() { return null; },
-      querySelectorAll() { return []; },
-      getBoundingClientRect() {
-        return { top: 0, left: 0, width: 0, height: 0 };
-      },
-    }),
-    body: {
-      dataset: {},
-      classList: { add() {}, remove() {}, toggle() {}, contains() { return false; } },
-      appendChild() {},
-      removeEventListener() {},
+    createElement: () => createMockElement(),
+    body: (() => {
+      const bodyElement = createMockElement();
+      bodyElement.classList.contains = () => false;
+      return bodyElement;
+    })(),
+    __setMockElement(id, props) {
+      return ensureElement(id, props === true ? undefined : props);
+    },
+    __getMockElement(id) {
+      if (typeof id !== "string" || !id) {
+        return null;
+      }
+      return elementStore.get(id) || null;
     },
   };
 
@@ -138,6 +219,9 @@ function loadDashboard() {
   const dashboardPath = path.join(__dirname, "..", "..", "lib", "webui", "static", "js", "dashboard.js");
   const code = fs.readFileSync(dashboardPath, "utf8");
   vm.runInContext(code, sandbox, { filename: "dashboard.js" });
+  if (globalThis.__DASHBOARD_ELEMENT_OVERRIDES) {
+    delete globalThis.__DASHBOARD_ELEMENT_OVERRIDES;
+  }
   return sandbox;
 }
 

--- a/tests/test_37_web_dashboard.py
+++ b/tests/test_37_web_dashboard.py
@@ -90,16 +90,24 @@ def _create_silent_wav(path: Path, duration: float = 2.0) -> None:
         handle.writeframes(b"\x00\x00" * frame_count)
 
 
-def _run_dashboard_selection_script(script: str) -> dict:
+def _run_dashboard_selection_script(
+    script: str, *, elements: dict[str, object] | None = None
+) -> dict:
     root = Path(__file__).resolve().parents[1]
     node_path = shutil.which("node")
     if node_path is None:
         pytest.skip("Node.js binary is required for dashboard selection script tests")
     indented_script = textwrap.indent(script, "        ")
+    overrides = json.dumps(elements or {})
     template = """
         const path = require("path");
         const {{ loadDashboard }} = require(path.join(process.cwd(), "tests", "helpers", "dashboard_node_env.js"));
+        const overrides = {overrides};
+        if (overrides && Object.keys(overrides).length > 0) {{
+          global.__DASHBOARD_ELEMENT_OVERRIDES = overrides;
+        }}
         const sandbox = loadDashboard();
+        delete global.__DASHBOARD_ELEMENT_OVERRIDES;
         const state = sandbox.window.TRICORDER_DASHBOARD_STATE;
         if (!state) {{
           throw new Error("Dashboard state is unavailable for tests");
@@ -118,7 +126,9 @@ def _run_dashboard_selection_script(script: str) -> dict:
         }})();
         console.log(JSON.stringify(result));
     """
-    node_code = textwrap.dedent(template).format(script=indented_script)
+    node_code = textwrap.dedent(template).format(
+        script=indented_script, overrides=overrides
+    )
     completed = subprocess.run(
         [node_path, "-e", node_code],
         capture_output=True,
@@ -2480,6 +2490,79 @@ def test_recordings_bulk_download_includes_sidecars(dashboard_env):
             await server.close()
 
     asyncio.run(runner())
+
+
+def test_recording_indicator_motion_badge_tracks_live_flag():
+    script = textwrap.dedent(
+        """
+        const indicator = sandbox.window.document.__getMockElement("recording-indicator");
+        const motionBadge = sandbox.window.document.__getMockElement("recording-indicator-motion");
+        motionBadge.hidden = true;
+        sandbox.setRecordingIndicatorStatus({
+          capturing: true,
+          motion_active: true,
+          event: { motion_trigger_offset_seconds: 0.25 }
+        });
+        const shownDuringMotion = motionBadge.hidden === false;
+        sandbox.setRecordingIndicatorStatus({
+          capturing: true,
+          motion_active: false,
+          event: {
+            motion_trigger_offset_seconds: 0.25,
+            motion_release_offset_seconds: 0.75
+          }
+        });
+        const hiddenAfterRelease = motionBadge.hidden === true;
+        sandbox.setRecordingIndicatorStatus({
+          capturing: true,
+          motion_active: true,
+          event: {
+            motion_trigger_offset_seconds: 0.25,
+            motion_release_offset_seconds: 0.75
+          }
+        });
+        const shownAfterReturn = motionBadge.hidden === false;
+        return {
+          shownDuringMotion,
+          hiddenAfterRelease,
+          shownAfterReturn,
+          state: indicator.dataset.state,
+        };
+        """
+    )
+    result = _run_dashboard_selection_script(
+        script,
+        elements={
+            "recording-indicator": True,
+            "recording-indicator-text": True,
+            "recording-indicator-motion": True,
+        },
+    )
+    assert result["shownDuringMotion"] is True
+    assert result["hiddenAfterRelease"] is True
+    assert result["shownAfterReturn"] is True
+    assert result["state"] == "active"
+
+
+def test_motion_trigger_detection_persists_for_recordings():
+    script = textwrap.dedent(
+        """
+        const releaseOnly = sandbox.isMotionTriggeredEvent({
+          motion_release_offset_seconds: 1.25,
+          motion_active: false
+        });
+        const startedEpoch = sandbox.isMotionTriggeredEvent({
+          motion_started_epoch: 1700000000,
+          motion_active: false
+        });
+        const none = sandbox.isMotionTriggeredEvent({ motion_active: false });
+        return { releaseOnly, startedEpoch, none };
+        """
+    )
+    result = _run_dashboard_selection_script(script)
+    assert result["releaseOnly"] is True
+    assert result["startedEpoch"] is True
+    assert result["none"] is False
 
 
 def test_shift_click_selects_range_between_non_adjacent_records():


### PR DESCRIPTION
## What / Why
- Ensure the live recording indicator only shows the motion badge while motion is actively detected.
- Preserve motion labeling on completed recordings so users can still identify clips with motion segments.
- Add automated coverage for motion flag transitions to avoid regressions.

## How (high-level)
- Drive the indicator badge from the `motion_active` flag when present, falling back to legacy motion metadata when absent.
- Expand the Node dashboard harness with configurable DOM stubs so tests can observe indicator state.
- Add dashboard tests that verify live badge toggling and that motion metadata continues to mark recordings.

## Risk / Rollback
- Low; changes are limited to dashboard UI bindings and supporting tests. Roll back by reverting the feature branch.

## Human Testing Criteria
- Load the dashboard while a recording is active and toggle motion via the `/api/integrations?motion=true|false` endpoint; confirm the live indicator hides the badge immediately when motion stops and reappears when motion resumes.
- Verify an existing recording with motion metadata still shows the "Motion" badge in the recordings table.

## Links
- Jira: https://mfisbv.atlassian.net/browse/TR-107
- Task run: (internal)
- Preview URL: n/a

------
https://chatgpt.com/codex/tasks/task_e_68e65879b9d48327a0d2dac68a8a00d7