### PR TITLE
TR-109: Report total storage across collections

### DIFF
--- a/tests/test_25_web_streamer.py
+++ b/tests/test_25_web_streamer.py
@@ -390,7 +390,8 @@ async def test_recordings_saved_collection_lists_saved_entries(
     assert payload["collection"] == "saved"
     assert payload["available_days"] == [saved_day_dir.name]
     assert payload["available_extensions"] == ["opus"]
-    assert payload["recordings_total_bytes"] == audio_path.stat().st_size
+    expected_storage = audio_path.stat().st_size + waveform_path.stat().st_size
+    assert payload["recordings_total_bytes"] == expected_storage
 
     items = payload.get("items", [])
     assert len(items) == 1
@@ -405,6 +406,7 @@ async def test_recordings_saved_collection_lists_saved_entries(
     recent_payload = await recent_response.json()
     assert recent_payload.get("collection") == "recent"
     assert recent_payload.get("items") == []
+    assert recent_payload.get("recordings_total_bytes") == expected_storage
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## What / Why
* Ensure the dashboard storage widget always reports the full on-disk footprint instead of per-tab subsets.

## How (high-level)
* Added a shared directory-walking helper that totals every file under the recordings root while skipping the recycle bin subtree when needed.
* Reused the helper for recycle bin accounting and updated the API to always report totals from the full recordings tree.
* Adjusted the saved-recordings test to expect consistent totals across views.

## Risk / Rollback
* **Risk:** Low – touches storage bookkeeping only. Errors would surface as incorrect dashboard stats.
* **Rollback:** Revert this PR.

## Human Testing Criteria
* `export DEV=1 && pytest -q`

## Links
* Jira: https://mfisbv.atlassian.net/browse/TR-109


------
https://chatgpt.com/codex/tasks/task_e_68e65bddfbc4832797d7e3c71071faff