### PR TITLE
TR-116: Align hover affordance for recordings tabs

### DIFF
--- a/lib/webui/static/css/dashboard.css
+++ b/lib/webui/static/css/dashboard.css
@@ -1038,7 +1038,19 @@ button.small {
   font-size: 0.85rem;
   background: var(--surface-muted);
   color: var(--text-muted);
-  transition: border-color 0.2s ease, background 0.2s ease, color 0.2s ease;
+  transition: border-color 0.2s ease, background 0.2s ease, color 0.2s ease,
+    transform 0.15s ease;
+}
+
+.recordings-tab:hover {
+  transform: translateY(-1px);
+  border-color: var(--ghost-border-hover);
+  color: var(--text);
+}
+
+.recordings-tab.active:hover,
+.recordings-tab[data-active="true"]:hover {
+  border-color: rgba(56, 189, 248, 0.75);
 }
 
 .recordings-tab.active,


### PR DESCRIPTION
**What / Why**
- Ensure the Recent and Saved recordings tabs provide the same hover feedback as the other toolbar actions.
- Improve consistency in user feedback by reusing the ghost button hover affordance.

**How (high-level)**
- Add a hover state to `.recordings-tab` that raises the button and adjusts the border/text color, including the active variant.

**Risk / Rollback**
- Risk: Low – CSS-only change scoped to recordings tab buttons.
- Rollback: Revert this commit.

**Human Testing Criteria**
- [ ] Open the recordings dashboard.
- [ ] Hover the "Recent" tab and observe the raised hover state similar to the toolbar buttons.
- [ ] Hover the "Saved" tab and confirm the hover effect also appears while it remains styled as active.

**Links**
- [TR-116](https://mfisbv.atlassian.net/browse/TR-116)

------
https://chatgpt.com/codex/tasks/task_e_68e66df11c6883278327ddc42069b999

[TR-116]: https://mfisbv.atlassian.net/browse/TR-116?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ