### PR TITLE
TR-113: Harden clip row preview placement

### DIFF
--- a/lib/webui/static/js/dashboard.js
+++ b/lib/webui/static/js/dashboard.js
@@ -5148,7 +5148,13 @@ function placePlayerCard(record, sourceRow = null) {
     return;
   }
   const isRecycle = isRecycleBinRecord(record);
-  const targetRow = sourceRow ?? (isRecycle ? getRecycleBinRow(record.recycleBinId) : findRowForRecord(record));
+  let targetRow =
+    sourceRow ?? (isRecycle ? getRecycleBinRow(record.recycleBinId) : findRowForRecord(record));
+  if (targetRow && !targetRow.parentElement) {
+    targetRow = isRecycle
+      ? getRecycleBinRow(record.recycleBinId)
+      : findRowForRecord(record);
+  }
   if (!targetRow || !targetRow.parentElement) {
     detachPlayerCard();
     return;


### PR DESCRIPTION
**What / Why**
* Prevent event list clip rows from requiring multiple clicks to expand by stabilizing the preview placement when the table rerenders mid-interaction.

**How (high-level)**
* Re-resolve the target table row before placing the preview card whenever the row provided by the click handler has already been detached during a refresh.

**Risk / Rollback**
* Low – scoped to clip preview placement in the event list.
* Rollback by reverting this commit.

**Human Testing Criteria**
* Open the dashboard event list.
* Trigger an auto-refresh (e.g., wait for recordings to reload) and click a clip row once.
* Confirm the clip detail expands after a single click even if the list refreshes at the same time.

**Links**
* [Jira TR-113](https://mfisbv.atlassian.net/browse/TR-113)


------
https://chatgpt.com/codex/tasks/task_e_68e67001d3d88327a040921200dd368c